### PR TITLE
Fix STUPID mistake in config string handling

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Meterpreter.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Meterpreter.java
@@ -113,11 +113,11 @@ public class Meterpreter {
     public static String readString(byte[] bytes, int offset, int size) {
         byte[] bytesRead = readBytes(bytes, offset, size);
         try {
-            return new String(bytes, "ISO-8859-1").trim();
+            return new String(bytesRead, "ISO-8859-1").trim();
         }
         catch (UnsupportedEncodingException ex) {
             // fallback to no encoding
-            return new String(bytes).trim();
+            return new String(bytesRead).trim();
         }
     }
 


### PR DESCRIPTION
So, I was clearly stupid thanks to:

1. I make a coding mistake.
1. Think I've deployed binaries to MSF when I actually haven't.
1. Test existing production binaries and not the development binaries.
1. Submit a PR with busted code.
1. .... PROFIT?!

This commit fixes the derp I pushed in #1 (way to go marking the new repo with a failed first PR.. sheesh). It actually uses the bytes that were read from the underlying configuration, rather than ignoring them. This will make things work as expected.

Please @bcook-r7 forgive me for my sins.