### PR TITLE
update minSDK version to 10, update compat check for Android 2.3.3

### DIFF
--- a/java/androidpayload/app/AndroidManifest.xml
+++ b/java/androidpayload/app/AndroidManifest.xml
@@ -3,8 +3,8 @@
     package="com.metasploit.stage"
     android:versionCode="1"
     android:versionName="1.0" >
-    
-    <uses-sdk android:minSdkVersion="3"/>
+
+    <uses-sdk android:minSdkVersion="10"/>
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/java/androidpayload/library/AndroidManifest.xml
+++ b/java/androidpayload/library/AndroidManifest.xml
@@ -4,6 +4,6 @@
       android:versionCode="1"
       android:versionName="1.0">
 
-    <uses-sdk android:minSdkVersion="3"/>
+    <uses-sdk android:minSdkVersion="10"/>
 
-</manifest> 
+</manifest>

--- a/java/version-compatibility-check/android-api10/pom.xml
+++ b/java/version-compatibility-check/android-api10/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.google.android</groupId>
 			<artifactId>android</artifactId>
-			<version>1.5_r4</version>
+			<version>2.3.3</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
This fixes a few more places where we were still either specifying Android 1.5 or API level 3 to require Android 2.3.3 and API level 10.

# Verification
- [x] Ensure that payloads still build and run
- [x] Ensure that adding a later API, e.g. adding something like this:

```
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -3,6 +3,7 @@ package com.metasploit.meterpreter;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
+import android.telephony.SmsManager;
```

builds without any missing symbols or API checks.

