### PR TITLE
Use temp storage for URL parsing

### DIFF
--- a/c/meterpreter/source/common/arch/posix/base_dispatch.c
+++ b/c/meterpreter/source/common/arch/posix/base_dispatch.c
@@ -283,8 +283,6 @@ DWORD remote_request_core_transport_remove(Remote* remote, Packet* packet)
 			remote->trans_remove(remote, found);
 			dprintf("[DISPATCH] Transport removed");
 		}
-
-		SAFE_FREE(transportUrl);
 	}
 
 	packet_transmit_empty_response(remote, packet, result);

--- a/c/meterpreter/source/server/server_setup_posix.c
+++ b/c/meterpreter/source/server/server_setup_posix.c
@@ -937,6 +937,7 @@ static void transport_reset_tcp(Transport* transport, BOOL shuttingDown) {
 static BOOL configure_tcp_connection(Transport* transport) {
 	DWORD result = ERROR_SUCCESS;
 	size_t charsConverted;
+	char tempUrl[512] = {0};
 	TcpTransportContext* ctx = (TcpTransportContext*)transport->ctx;
 
 	// check if comms is already open via a staged payload
@@ -946,15 +947,20 @@ static BOOL configure_tcp_connection(Transport* transport) {
 	else {
 		dprintf("[TCP CONFIGURE] Url: %s", transport->url);
 
+		// copy the URL to the temp location and work from there
+		// so that we don't damage the original URL while breaking
+		// it up into its individual parts.
+		strncpy(tempUrl, transport->url, sizeof(tempUrl) - 1);
+
 		//transport->start_time = current_unix_timestamp();
 		transport->comms_last_packet = current_unix_timestamp();
 
-		if (strncmp(transport->url, "tcp", 3) == 0) {
-			char* pHost = strstr(transport->url, "//") + 2;
+		if (strncmp(tempUrl, "tcp", 3) == 0) {
+			char* pHost = strstr(tempUrl, "//") + 2;
 			char* pPort = strrchr(pHost, ':') + 1;
 
 			// check if we're using IPv6
-			if (transport->url[3] == '6') {
+			if (tempUrl[3] == '6') {
 				char* pScopeId = strrchr(pHost, '?') + 1;
 				*(pScopeId - 1) = '\0';
 				*(pPort - 1) = '\0';


### PR DESCRIPTION
This removes the issue where URLs were truncated during parsing on POSIX, resulting in them not working later on when transports are changed. When a URL is parsed, the `:` between the host and the port is replaced with `NULL` so that the strings are effectively split. This was being done on the URL that was stored alongside the transport, resulting in the port being truncated for future transport parsing.

This wasn't an issue in the Windows case, because this was being done on a temp buffer. This change copies the URL to a temp buffer before doing the parsing, resulting in the original URL being left alone.

Updated: `transport remove` has been fixed as well. This was due to an invalid called to `SAFE_FREE`.

Thanks to @rwhitcroft for reporting, this should fix #6 and #9.

## Sample run

See #6 to get an idea of how is was broken. With this change, it looks like this:
```
meterpreter > transport list
Session Expiry  : @ 2015-07-13 14:55:09

    Curr  URL                    Comms T/O  Retry Total  Retry Wait
    ----  ---                    ---------  -----------  ----------
    *     tcp://10.1.10.40:7000  300        3600         10

meterpreter > transport add -t reverse_tcp -l 10.1.10.40 -p 7005
[*] Adding new transport ...
[+] Successfully added reverse_tcp transport.
meterpreter > transport list
Session Expiry  : @ 2015-07-13 22:32:47

    Curr  URL                    Comms T/O  Retry Total  Retry Wait
    ----  ---                    ---------  -----------  ----------
    *     tcp://10.1.10.40:7000  300        3600         10
          tcp://10.1.10.40:7005  300        3600         10

meterpreter > transport next
[*] Changing to next transport ...

[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[+] Successfully changed to the next transport, killing current session.

[*] 10.1.10.40 - Meterpreter session 10 closed.  Reason: User exit
msf exploit(handler) > 
[*] Sending stage (1581614 bytes) to 10.1.10.40
[*] Meterpreter session 11 opened (10.1.10.40:7005 -> 10.1.10.40:34758) at 2015-07-10 14:53:03 +1000

msf exploit(handler) > sessions -i -1
[*] Starting interaction with 11...

meterpreter > transport list
Session Expiry  : @ 2015-07-11 04:55:52

    Curr  URL                    Comms T/O  Retry Total  Retry Wait
    ----  ---                    ---------  -----------  ----------
    *     tcp://10.1.10.40:7005  300        3600         10
          tcp://10.1.10.40:7000  300        3600         10

meterpreter > transport next
[*] Changing to next transport ...

[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[+] Successfully changed to the next transport, killing current session.

[*] 10.1.10.40 - Meterpreter session 11 closed.  Reason: User exit
msf exploit(handler) > 
[*] Sending stage (1581614 bytes) to 10.1.10.40
[*] Meterpreter session 12 opened (10.1.10.40:7000 -> 10.1.10.40:54594) at 2015-07-10 14:53:17 +1000

msf exploit(handler) > sessions -i -1
[*] Starting interaction with 12...

meterpreter > transport list
Session Expiry  : @ 2015-07-11 00:16:12

    Curr  URL                    Comms T/O  Retry Total  Retry Wait
    ----  ---                    ---------  -----------  ----------
    *     tcp://10.1.10.40:7000  300        3600         10
          tcp://10.1.10.40:7005  300        3600         10

meterpreter > 
```

Removal of transports:
```
meterpreter > transport add -t reverse_tcp -l 10.1.10.40 -p 5005
[*] Adding new transport ...
[+] Successfully added reverse_tcp transport.
meterpreter > transport remove -t reverse_tcp -l 10.1.10.40 -p 5005
[*] Removing transport ...
[+] Successfully removed reverse_tcp transport.
meterpreter > sysinfo
Computer     : ropchain
OS           : Linux ropchain 4.0.5-200.fc21.x86_64 #1 SMP Mon Jun 8 16:25:02 UTC 2015 (x86_64)
Architecture : x86_64
Meterpreter  : x86/linux
```

## Verification

- [ ] Get a TCP session in POSIX.
- [ ] Add a new transport.
- [ ] Switch to the new transport.
- [ ] Switch back.
- [ ] Remove the new transport.
- [ ] The session should not die.