### PR TITLE
On socket flush, stop reading on error

### DIFF
--- a/c/meterpreter/source/server/server_setup_posix.c
+++ b/c/meterpreter/source/server/server_setup_posix.c
@@ -357,7 +357,7 @@ static VOID server_socket_flush(Transport* transport)
 		dprintf("[SERVER] Flushed %d bytes from the buffer", ret);
 
 		// The socket closed while we waited
-		if (ret == 0) {
+		if (ret <= 0) {
 			break;
 		}
 		continue;
@@ -889,7 +889,7 @@ DWORD THREADCALL cleanup_socket(THREAD* thread) {
 	dprintf("[TCP] waiting for disconnect from remote");
 	// loop until FD_CLOSE comes through.
 	while ((result = recv(fd, buf, sizeof(buf), 0)) != 0) {
-		if (result < 0) {
+		if (result <= 0) {
 			dprintf("[TCP] something went wrong on read.");
 			break;
 		}

--- a/c/meterpreter/source/server/server_setup_posix.c
+++ b/c/meterpreter/source/server/server_setup_posix.c
@@ -890,7 +890,6 @@ DWORD THREADCALL cleanup_socket(THREAD* thread) {
 	// loop until FD_CLOSE comes through.
 	while ((result = recv(fd, buf, sizeof(buf), 0)) != 0) {
 		if (result <= 0) {
-			dprintf("[TCP] something went wrong on read.");
 			break;
 		}
 	}

--- a/c/meterpreter/source/server/win/server_transport_tcp.c
+++ b/c/meterpreter/source/server/win/server_transport_tcp.c
@@ -374,7 +374,7 @@ static VOID server_socket_flush(Transport* transport)
 		dprintf("[SERVER] Flushed %d bytes from the buffer", ret);
 
 		// The socket closed while we waited
-		if (ret == 0)
+		if (ret <= 0)
 		{
 			break;
 		}
@@ -846,7 +846,7 @@ DWORD THREADCALL cleanup_socket(THREAD* thread)
 	// loop until FD_CLOSE comes through.
 	while ((result = recv(fd, buf, sizeof(buf), 0)) != 0)
 	{
-		if (result < 0)
+		if (result <= 0)
 		{
 			dprintf("[TCP] something went wrong on read.");
 			break;

--- a/c/meterpreter/source/server/win/server_transport_tcp.c
+++ b/c/meterpreter/source/server/win/server_transport_tcp.c
@@ -848,7 +848,6 @@ DWORD THREADCALL cleanup_socket(THREAD* thread)
 	{
 		if (result <= 0)
 		{
-			dprintf("[TCP] something went wrong on read.");
 			break;
 		}
 	}


### PR DESCRIPTION
We are currently inconsistently handling errors in recv() when flushing data from a TCP socket. In one case, we handle the graceful close, but not the error case. In the other, we handle exactly the opposite.

Both of these loops may spin indefinitely depending on the recv return code. In one, if the TCP connection is abruptly closed in stageless meterpreter or on a transport switch, the flush function may loop. In the other, if the remote server does a socket shutdown, but not a close, we will also loop.

# Verification Steps

I'm still working on these to get exact ways to reproduce all of the hanging scenarios, but thought it made sense to get the PR up for review anyway, since its pretty clear we're not handling the -1 error cases.