### PR TITLE
fileInstalled should check for a file, not a package

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/check_root_android.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/check_root_android.java
@@ -38,10 +38,10 @@ public class check_root_android implements Command {
                 || canExecuteCommand("which su");
     }
 
-    private static boolean fileInstalled(String packageName) {
+    private static boolean fileInstalled(String fileName) {
         boolean installed;
         try {
-            File file = new File("/system/app/" + packageName);
+            File file = new File(fileName);
             installed = file.exists();
         } catch (Exception e1){
             installed = false;


### PR DESCRIPTION
The fileInstalled method was used earlier to check if a package is installed, but I botched removing the path expansion when it was converted to just check for a regular file path, as @Jack64 noticed on IRC.

# Verification steps
 - [ ] Start an android meterpreter session
 - [ ] create a file at one of the checked paths, e.g. /system/xbin/su
 - [ ] ensure that check_root returns true
 - [ ] remove the file
 - [ ] ensure that check_root returns false