### PR TITLE
update build status link for windows meterpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #### Build Status
 
- * `master` Windows x86 and x64: ![Windows Meterpreter Build Status][build_icon_windows]
+ * `master` Windows x86 and x64: [![Windows Build Status](https://ci.metasploit.com/buildStatus/icon?job=metasploit-payloads-win)](https://ci.metasploit.com/job/metasploit-payloads-win/)
  * `master` POSIX x86: ![POSIX Meterpreter Build Status][build_icon_posix]
 
 metasploit-payloads >

--- a/c/meterpreter/README.md
+++ b/c/meterpreter/README.md
@@ -1,10 +1,5 @@
-Current `master` branch: ![Meterpreter Build Status][build_icon]
-
-meterpreter >
+Native C meterpreter >
 =============
-
-This is the new repository for the Meterpreter [source], which was originally in the
-[Metasploit Framework][framework] source.
 
 Building - Windows
 ==================


### PR DESCRIPTION
This is a test PR, but also a functional one that should update the build status link for windows meterpreter.