### PR TITLE
Pymet fix search_root always being set to '.'

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1027,7 +1027,8 @@ def stdapi_fs_mkdir(request, response):
 @meterpreter.register_function
 def stdapi_fs_search(request, response):
 	search_root = packet_get_tlv(request, TLV_TYPE_SEARCH_ROOT).get('value', '.')
-	search_root = ('' or '.') # sometimes it's an empty string
+	if not search_root: # sometimes it's an empty string
+		search_root = '.'
 	search_root = unicode(search_root)
 	glob = packet_get_tlv(request, TLV_TYPE_SEARCH_GLOB)['value']
 	recurse = packet_get_tlv(request, TLV_TYPE_SEARCH_RECURSE)['value']


### PR DESCRIPTION
Python meterpreter will always set the search_root directory to the current directory instead of using the value from the packet.

    $ mkdir /tmp/test
    $ touch /tmp/test/abc.xyz

Currently:

    meterpreter > search -d /tmp/test -f *.xyz
    No files matching your search were found.

With the PR:

    meterpreter > search -d /tmp/test -f *.xyz
    Found 1 result...
        /tmp/test\abc.xyz