### PR TITLE
Add patch points for stageless python meterpreter

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1106,6 +1106,8 @@ if not hasattr(os, 'fork') or (hasattr(os, 'fork') and os.fork() == 0):
 	if HTTP_CONNECTION_URL and has_urllib:
 		transport = HttpTransport(HTTP_CONNECTION_URL, proxy=HTTP_PROXY, user_agent=HTTP_USER_AGENT)
 	else:
+		# PATCH-SETUP-STAGELESS-TCP-SOCKET #
 		transport = TcpTransport.from_socket(s)
 	met = PythonMeterpreter(transport)
+	# PATCH-SETUP-TRANSPORTS #
 	met.run()


### PR DESCRIPTION
This PR will be leveraged by a submission I'll make to the metasploit-framework repo to support stageless TCP Python Meterpreter payloads. This change adds patch points so the new `Msf::Payload::Python::MeterpreterLoader` code knows where to patch in the TCP socket setup code and perhaps later, additional transports.

Additional details will be in the more complex PR on the metasploit-framework side of things.