### PR TITLE
Add Utils.getHostname, a more robust alternative

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_config_sysinfo_android.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_config_sysinfo_android.java
@@ -1,7 +1,5 @@
 package com.metasploit.meterpreter.android;
 
-import java.net.InetAddress;
-
 import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.TLVPacket;
 import com.metasploit.meterpreter.TLVType;
@@ -17,7 +15,7 @@ public class stdapi_sys_config_sysinfo_android extends
     public int execute(Meterpreter meterpreter, TLVPacket request,
                        TLVPacket response) throws Exception {
         String androidOS = Utils.runCommand("getprop ro.build.version.release").replace("\n", "");
-        response.add(TLVType.TLV_TYPE_COMPUTER_NAME, InetAddress.getLocalHost().getHostName());
+        response.add(TLVType.TLV_TYPE_COMPUTER_NAME, Utils.getHostname());
         response.add(TLVType.TLV_TYPE_OS_NAME, "Android " + androidOS
                 + " - " + System.getProperty("os.name")
                 + " " + System.getProperty("os.version") + " (" + System.getProperty("os.arch") + ")");

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Utils.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Utils.java
@@ -4,6 +4,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 public class Utils {
 
     public static String runCommand(String command) throws IOException {
@@ -16,5 +19,23 @@ public class Utils {
             stringBuffer.append('\n');
         }
         return stringBuffer.toString();
+    }
+
+    public static String getHostname() {
+        try {
+            String result = InetAddress.getLocalHost().getHostName();
+            if (result != "")
+                return result;
+        } catch (UnknownHostException e) { }
+
+        String host = System.getenv("COMPUTERNAME");
+        if (host != null)
+            return host;
+
+        host = System.getenv("HOSTNAME");
+        if (host != null)
+            return host;
+
+        return "unknown";
     }
 }

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_machine_id.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_machine_id.java
@@ -10,8 +10,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 
 public class core_machine_id implements Command {
 
@@ -44,17 +42,13 @@ public class core_machine_id implements Command {
         return "";
     }
 
-    private String getHostname() throws UnknownHostException {
-        return InetAddress.getLocalHost().getHostName();
-    }
-
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         if (machine_id == null) {
             String serial = getHDLabel();
             if (serial == null) {
                 serial = getSerial();
             }
-            machine_id = serial + ":" + getHostname();
+            machine_id = serial + ":" + Utils.getHostname();
         }
         response.add(TLVType.TLV_TYPE_MACHINE_ID, machine_id);
         return ERROR_SUCCESS;


### PR DESCRIPTION
This fixes a stack trace triggered on ``sysinfo()`` when the configured hostname does not resolve.