### PR TITLE
We need to get the channel hash by reference when modifying the 'data'.

### DIFF
--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -530,7 +530,7 @@ function get_channel_id_from_resource($resource) {
     return false;
 }
 
-function get_channel_by_id($chan_id) {
+function &get_channel_by_id($chan_id) {
     global $channels;
     my_print("Looking up channel id $chan_id");
     #dump_channels("in get_channel_by_id");
@@ -555,7 +555,7 @@ function channel_write($chan_id, $data) {
 
 # Read from the channel's stdout
 function channel_read($chan_id, $len) {
-    $c = get_channel_by_id($chan_id);
+    $c = &get_channel_by_id($chan_id);
     if ($c) {
         # First get any pending unread data from a previous read
         $ret = substr($c['data'], 0, $len);


### PR DESCRIPTION
When we read from a channel in PHP, if there is more data returned by read() than the caller asked for, the data is cached in a 'data' element in the channel hash. However, since get_channel_by_id() returns a copy, we immediately lose all of that extra data on the first read. We need to get the hash by reference in order to modify its elements.

This fixes https://github.com/rapid7/metasploit-framework/issues/6414

# Validation steps

 - [x] Start PHP meterpreter
 - [x] Download a file > 64k
 - [x] Verify that the file is the same length and content as the original.