### PR TITLE
Build correction for fedora on not EN system

### DIFF
--- a/c/meterpreter/source/bionic/libm/Makefile.msf
+++ b/c/meterpreter/source/bionic/libm/Makefile.msf
@@ -11,6 +11,7 @@ CFLAGS+=-D_BYTE_ORDER=_LITTLE_ENDIAN -Ihack/ -I${TARGET_FPU} -I../libc/arch-${TA
 CFLAGS+=-fPIC -DPIC
 CFLAGS+=-Wl,--hash-style=sysv
 CFLAGS+=-march=i386 -m32
+CFLAGS+=-Wl,--allow-multiple-definition
 
 libm_common_src_files= \
 	isinf.c  \

--- a/c/meterpreter/source/server/rtld/Makefile
+++ b/c/meterpreter/source/server/rtld/Makefile
@@ -48,7 +48,7 @@ msflinker.bin: msflinker elf2bin.c
 metsrv_rtld.o: $(HEADERS)
 
 rtldtest: rtldtest.c msflinker
-	$(CC) -march=i386 -m32 -o rtldtest rtldtest.c -DEP=`objdump -f msflinker | grep start | awk '{ print $$3 }'`
+	$(CC) -march=i386 -m32 -o rtldtest rtldtest.c -DEP=`LANG=en_US objdump -f msflinker | grep start | awk '{ print $$3 }'`
 
 .S.o:
 	@echo [CC] $@


### PR DESCRIPTION
Correction for build c-meterpreter on Fedora and not EN system.

For example `objdump -f msflinker | grep start` does not work on French system because:
```
objdump -f msflinker
msflinker:     format de fichier elf32-i386
architecture: i386, fanions 0x00000112:
EXEC_P, HAS_SYMS, D_PAGED
adresse de départ 0x2004ffc8`
```

include the patch found at https://github.com/rapid7/metasploit-payloads/issues/54