### PR TITLE
fix activity_start

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -161,6 +161,7 @@ public class AndroidMeterpreter extends Meterpreter {
             mgr.registerCommand("send_sms", send_sms_android.class);
             mgr.registerCommand("wlan_geolocate", wlan_geolocate.class);
             mgr.registerCommand("interval_collect", interval_collect.class);
+            mgr.registerCommand("activity_start", activity_start_android.class);
             mgr.registerCommand("set_audio_mode", set_audio_mode_android.class);
         }
         return getCommandManager().getNewCommands();


### PR DESCRIPTION
When I merged https://github.com/rapid7/metasploit-payloads/pull/72 I accidentally took this line out. This line is required for the activity_start command to work.