### PR TITLE
fix #61, suppress error when Android meterpreter handler down

### DIFF
--- a/java/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -92,7 +92,7 @@ public class Payload {
                 }
                 break;
             } catch (Exception e) {
-                e.printStackTrace();
+//                e.printStackTrace();
             }
             try {
                 Thread.sleep(retry_wait);


### PR DESCRIPTION
Fix https://github.com/rapid7/metasploit-payloads/issues/61. This change hides the stack trace when the payload fails to connect to the handler.