### PR TITLE
Fix network interface enumeration limitation

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/net/config/interface.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/config/interface.c
@@ -9,14 +9,10 @@
 DWORD get_interfaces_windows_mib(Remote *remote, Packet *response)
 {
 	DWORD result = ERROR_SUCCESS;
-	DWORD tlv_cnt;
 
-	Tlv entries[6];
 	PMIB_IPADDRTABLE table = NULL;
 	DWORD tableSize = sizeof(MIB_IPADDRROW) * 33;
 	DWORD index;
-	DWORD mtu_bigendian;
-	DWORD interface_index_bigendian;
 	MIB_IFROW iface;
 
 	do
@@ -38,77 +34,45 @@ DWORD get_interfaces_windows_mib(Remote *remote, Packet *response)
 		// Enumerate the entries
 		for (index = 0; index < table->dwNumEntries; index++)
 		{
-			tlv_cnt = 0;
+			Packet* group = packet_create_group();
 
-			interface_index_bigendian = htonl(table->table[index].dwIndex);
-			entries[tlv_cnt].header.length = sizeof(DWORD);
-			entries[tlv_cnt].header.type = TLV_TYPE_INTERFACE_INDEX;
-			entries[tlv_cnt].buffer = (PUCHAR)&interface_index_bigendian;
-			tlv_cnt++;
-
-			entries[tlv_cnt].header.length = sizeof(DWORD);
-			entries[tlv_cnt].header.type = TLV_TYPE_IP;
-			entries[tlv_cnt].buffer = (PUCHAR)&table->table[index].dwAddr;
-			tlv_cnt++;
-
-			entries[tlv_cnt].header.length = sizeof(DWORD);
-			entries[tlv_cnt].header.type = TLV_TYPE_NETMASK;
-			entries[tlv_cnt].buffer = (PUCHAR)&table->table[index].dwMask;
-			tlv_cnt++;
+			packet_add_tlv_uint(group, TLV_TYPE_INTERFACE_INDEX, table->table[index].dwIndex);
+			packet_add_tlv_raw(group, TLV_TYPE_IP, (PUCHAR)&table->table[index].dwAddr, sizeof(DWORD));
+			packet_add_tlv_raw(group, TLV_TYPE_NETMASK, (PUCHAR)&table->table[index].dwMask, sizeof(DWORD));
 
 			iface.dwIndex = table->table[index].dwIndex;
 
 			// If interface information can get gotten, use it.
 			if (GetIfEntry(&iface) == NO_ERROR)
 			{
-				entries[tlv_cnt].header.length = iface.dwPhysAddrLen;
-				entries[tlv_cnt].header.type = TLV_TYPE_MAC_ADDR;
-				entries[tlv_cnt].buffer = (PUCHAR)iface.bPhysAddr;
-				tlv_cnt++;
-
-				mtu_bigendian = htonl(iface.dwMtu);
-				entries[tlv_cnt].header.length = sizeof(DWORD);
-				entries[tlv_cnt].header.type = TLV_TYPE_INTERFACE_MTU;
-				entries[tlv_cnt].buffer = (PUCHAR)&mtu_bigendian;
-				tlv_cnt++;
+				packet_add_tlv_raw(group, TLV_TYPE_MAC_ADDR, (PUCHAR)iface.bPhysAddr, iface.dwPhysAddrLen);
+				packet_add_tlv_uint(group, TLV_TYPE_INTERFACE_MTU, iface.dwMtu);
 
 				if (iface.bDescr)
 				{
-					entries[tlv_cnt].header.length = iface.dwDescrLen + 1;
-					entries[tlv_cnt].header.type = TLV_TYPE_MAC_NAME;
-					entries[tlv_cnt].buffer = (PUCHAR)iface.bDescr;
-					tlv_cnt++;
+					packet_add_tlv_string(group, TLV_TYPE_MAC_NAME, iface.bDescr);
 				}
 			}
 
 			// Add the interface group
-			packet_add_tlv_group(response, TLV_TYPE_NETWORK_INTERFACE,
-			entries, tlv_cnt);
+			packet_add_group(response, TLV_TYPE_NETWORK_INTERFACE, group);
 		}
 
 	} while (0);
 
 	if (table)
+	{
 		free(table);
+	}
 
 	return result;
 }
 
-
-DWORD get_interfaces_windows(Remote *remote, Packet *response) {
+DWORD get_interfaces_windows(Remote *remote, Packet *response)
+{
 	DWORD result = ERROR_SUCCESS;
-	DWORD tlv_cnt;
-	// Most of the time we'll need:
-	//   index, name (description), MAC addr, mtu, flags, IP addr, netmask, maybe scope id
-	// In some cases, the interface will have multiple addresses, so we'll realloc
-	// this when necessary, but this will cover the common case.
-	DWORD allocd_entries = 20;
-	Tlv *entries = (Tlv *)malloc(sizeof(Tlv) * 20);
 	int prefixes[30];
-	int prefixes_cnt = 0;
-
-	DWORD mtu_bigendian;
-	DWORD interface_index_bigendian;
+	int prefixCount = 0;
 
 	ULONG flags = GAA_FLAG_INCLUDE_PREFIX
 		| GAA_FLAG_SKIP_DNS_SERVER
@@ -121,7 +85,7 @@ DWORD get_interfaces_windows(Remote *remote, Packet *response) {
 	IP_ADAPTER_ADDRESSES *pAdapters = NULL;
 	IP_ADAPTER_ADDRESSES *pCurr = NULL;
 	ULONG outBufLen = 0;
-	DWORD (WINAPI *gaa)(DWORD, DWORD, void *, void *, void *);
+	DWORD(WINAPI *gaa)(DWORD, DWORD, void *, void *, void *);
 
 	// Use the newer version so we're guaranteed to have a large enough struct.
 	// Unfortunately, using these probably means it won't compile on older
@@ -140,11 +104,11 @@ DWORD get_interfaces_windows(Remote *remote, Packet *response) {
 
 	do
 	{
-		gaa = (DWORD (WINAPI *)(DWORD,DWORD,void*,void*,void*))GetProcAddress(
-				GetModuleHandle("iphlpapi"), "GetAdaptersAddresses"
-			);
-		if (!gaa) {
-			dprintf( "[INTERFACE] No 'GetAdaptersAddresses'. Falling back on get_interfaces_windows_mib" );
+		gaa = (DWORD(WINAPI *)(DWORD, DWORD, void*, void*, void*))GetProcAddress(
+			GetModuleHandle("iphlpapi"), "GetAdaptersAddresses");
+		if (!gaa)
+		{
+			dprintf("[INTERFACE] No 'GetAdaptersAddresses'. Falling back on get_interfaces_windows_mib");
 			result = get_interfaces_windows_mib(remote, response);
 			break;
 		}
@@ -161,137 +125,111 @@ DWORD get_interfaces_windows(Remote *remote, Packet *response) {
 			break;
 		}
 
-		dprintf( "[INTERFACE] pAdapters->Length = %d", pAdapters->Length );
+		dprintf("[INTERFACE] pAdapters->Length = %d", pAdapters->Length);
 		// According to http://msdn.microsoft.com/en-us/library/windows/desktop/aa366058(v=vs.85).aspx
 		// the PIP_ADAPTER_PREFIX doesn't exist prior to XP SP1. We check for this via the `Length`
 		// value, which is 72 in XP without an SP, but 144 in later versions.
-		if (pAdapters->Length <= 72) {
-			dprintf( "[INTERFACE] PIP_ADAPTER_PREFIX is missing" );
+		if (pAdapters->Length <= 72)
+		{
+			dprintf("[INTERFACE] PIP_ADAPTER_PREFIX is missing");
 			result = get_interfaces_windows_mib(remote, response);
 			break;
 		}
 
 		// we'll need to know the version later on
-		memset( &v, 0, sizeof(v) );
+		memset(&v, 0, sizeof(v));
 		v.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-		GetVersionEx( (LPOSVERSIONINFO)&v );
+		GetVersionEx((LPOSVERSIONINFO)&v);
 
 		// Enumerate the entries
-		for( pCurr = pAdapters; pCurr; pCurr = pCurr->Next )
+		for (pCurr = pAdapters; pCurr; pCurr = pCurr->Next)
 		{
 			// Save the first prefix for later in case we don't have an OnLinkPrefixLength
 			pPrefix = pCurr->FirstPrefix;
 
-			tlv_cnt = 0;
+			Packet* group = packet_create_group();
 
-			dprintf( "[INTERFACE] Adding index: %u", pCurr->IfIndex );
-			interface_index_bigendian      = htonl(pCurr->IfIndex);
-			entries[tlv_cnt].header.length = sizeof(DWORD);
-			entries[tlv_cnt].header.type   = TLV_TYPE_INTERFACE_INDEX;
-			entries[tlv_cnt].buffer        = (PUCHAR)&interface_index_bigendian;
-			tlv_cnt++;
+			dprintf("[INTERFACE] Adding index: %u", pCurr->IfIndex);
+			packet_add_tlv_uint(group, TLV_TYPE_INTERFACE_INDEX, pCurr->IfIndex);
 
-			dprintf( "[INTERFACE] Adding MAC" );
-			entries[tlv_cnt].header.length = pCurr->PhysicalAddressLength;
-			entries[tlv_cnt].header.type   = TLV_TYPE_MAC_ADDR;
-			entries[tlv_cnt].buffer        = (PUCHAR)pCurr->PhysicalAddress;
-			tlv_cnt++;
+			dprintf("[INTERFACE] Adding MAC");
+			packet_add_tlv_raw(group, TLV_TYPE_MAC_ADDR, (PUCHAR)pCurr->PhysicalAddress, pCurr->PhysicalAddressLength);
 
-			dprintf( "[INTERFACE] Adding Description" );
-			entries[tlv_cnt].header.length = (DWORD)wcslen(pCurr->Description)*2 + 1;
-			entries[tlv_cnt].header.type   = TLV_TYPE_MAC_NAME;
-			entries[tlv_cnt].buffer        = (PUCHAR)pCurr->Description;
-			tlv_cnt++;
+			dprintf("[INTERFACE] Adding Description");
+			packet_add_tlv_wstring(group, TLV_TYPE_MAC_NAME, pCurr->Description);
 
-			dprintf( "[INTERFACE] Adding MTU: %u", pCurr->Mtu );
-			mtu_bigendian                  = htonl(pCurr->Mtu);
-			entries[tlv_cnt].header.length = sizeof(DWORD);
-			entries[tlv_cnt].header.type   = TLV_TYPE_INTERFACE_MTU;
-			entries[tlv_cnt].buffer        = (PUCHAR)&mtu_bigendian;
-			tlv_cnt++;
+			dprintf("[INTERFACE] Adding MTU: %u", pCurr->Mtu);
+			packet_add_tlv_uint(group, TLV_TYPE_INTERFACE_MTU, pCurr->Mtu);
 
 			for (pAddr = (IP_ADAPTER_UNICAST_ADDRESS_LH*)pCurr->FirstUnicastAddress;
 				pAddr; pAddr = pAddr->Next)
 			{
 				sockaddr = pAddr->Address.lpSockaddr;
-				if (AF_INET != sockaddr->sa_family && AF_INET6 != sockaddr->sa_family) {
+				if (AF_INET != sockaddr->sa_family && AF_INET6 != sockaddr->sa_family)
+				{
 					// Skip interfaces that aren't IP
 					continue;
-				}
-
-				// This loop can add up to three Tlv's - one for address, one
-				// for scope_id, one for netmask.  Go ahead and allocate enough
-				// room for all of them.
-				if (allocd_entries < tlv_cnt+3) {
-					entries = (Tlv*)realloc(entries, sizeof(Tlv) * (tlv_cnt+3));
-					allocd_entries += 3;
 				}
 
 				if (v.dwMajorVersion >= 6) {
 					// Then this is Vista+ and the OnLinkPrefixLength member
 					// will be populated
-					dprintf( "[INTERFACES] >= Vista, using prefix: %x", pAddr->OnLinkPrefixLength );
-					prefixes[prefixes_cnt] = htonl(pAddr->OnLinkPrefixLength);
+					dprintf("[INTERFACES] >= Vista, using prefix: %x", pAddr->OnLinkPrefixLength);
+					prefixes[prefixCount] = htonl(pAddr->OnLinkPrefixLength);
 				}
-				else if( pPrefix ) {
-					dprintf( "[INTERFACES] < Vista, using prefix: %x", pPrefix->PrefixLength );
-					prefixes[prefixes_cnt] = htonl(pPrefix->PrefixLength);
-				} else {
-					dprintf( "[INTERFACES] < Vista, no prefix" );
-					prefixes[prefixes_cnt] = 0;
+				else if (pPrefix)
+				{
+					dprintf("[INTERFACES] < Vista, using prefix: %x", pPrefix->PrefixLength);
+					prefixes[prefixCount] = htonl(pPrefix->PrefixLength);
 				}
-
-				if (prefixes[prefixes_cnt]) {
-					dprintf( "[INTERFACE] Adding Prefix: %x", prefixes[prefixes_cnt] );
-					entries[tlv_cnt].header.length = 4;
-					entries[tlv_cnt].header.type = TLV_TYPE_IP_PREFIX;
-					entries[tlv_cnt].buffer = (PUCHAR)&prefixes[prefixes_cnt];
-					tlv_cnt++;
-					prefixes_cnt++;
+				else
+				{
+					dprintf("[INTERFACES] < Vista, no prefix");
+					prefixes[prefixCount] = 0;
 				}
 
-				if (sockaddr->sa_family == AF_INET) {
-					dprintf( "[INTERFACE] Adding IPv4 Address: %x", ((struct sockaddr_in *)sockaddr)->sin_addr );
-					entries[tlv_cnt].header.length = 4;
-					entries[tlv_cnt].header.type = TLV_TYPE_IP;
-					entries[tlv_cnt].buffer = (PUCHAR)&(((struct sockaddr_in *)sockaddr)->sin_addr);
-					tlv_cnt++;
-				} else {
-					dprintf( "[INTERFACE] Adding IPv6 Address" );
-					entries[tlv_cnt].header.length = 16;
-					entries[tlv_cnt].header.type = TLV_TYPE_IP;
-					entries[tlv_cnt].buffer = (PUCHAR)&(((struct sockaddr_in6 *)sockaddr)->sin6_addr);
-					tlv_cnt++;
+				if (prefixes[prefixCount])
+				{
+					dprintf("[INTERFACE] Adding Prefix: %x", prefixes[prefixCount]);
+					// the UINT value is already byte-swapped, so we add it as a raw instead of
+					// swizzling the bytes twice.
+					packet_add_tlv_raw(group, TLV_TYPE_IP_PREFIX, (PUCHAR)&prefixes[prefixCount], sizeof(DWORD));
+					prefixCount++;
+				}
 
-					entries[tlv_cnt].header.length = sizeof(DWORD);
-					entries[tlv_cnt].header.type = TLV_TYPE_IP6_SCOPE;
-					entries[tlv_cnt].buffer = (PUCHAR)&(((struct sockaddr_in6 *)sockaddr)->sin6_scope_id);
-					tlv_cnt++;
+				if (sockaddr->sa_family == AF_INET)
+				{
+					dprintf("[INTERFACE] Adding IPv4 Address: %x", ((struct sockaddr_in *)sockaddr)->sin_addr);
+					packet_add_tlv_raw(group, TLV_TYPE_IP, (PUCHAR)&(((struct sockaddr_in *)sockaddr)->sin_addr), 4);
+				}
+				else
+				{
+					dprintf("[INTERFACE] Adding IPv6 Address");
+					packet_add_tlv_raw(group, TLV_TYPE_IP, (PUCHAR)&(((struct sockaddr_in6 *)sockaddr)->sin6_addr), 16);
+					packet_add_tlv_raw(group, TLV_TYPE_IP6_SCOPE, (PUCHAR)&(((struct sockaddr_in6 *)sockaddr)->sin6_scope_id), sizeof(DWORD));
 				}
 
 			}
 			// Add the interface group
-			packet_add_tlv_group(response, TLV_TYPE_NETWORK_INTERFACE,
-					entries, tlv_cnt);
+			packet_add_group(response, TLV_TYPE_NETWORK_INTERFACE, group);
 		}
 	} while (0);
 
-	if (entries)
-		free(entries);
 	if (pAdapters)
+	{
 		free(pAdapters);
-
+	}
 	return result;
 }
 
 #else /* _WIN32 */
-int get_interfaces_linux(Remote *remote, Packet *response) {
+int get_interfaces_linux(Remote *remote, Packet *response)
+{
 	struct ifaces_list *ifaces = NULL;
 	int i;
 	int result;
 	uint32_t interface_index_bigendian, mtu_bigendian;
 	DWORD allocd_entries = 10;
-	Tlv *entries = (Tlv *)malloc(sizeof(Tlv) * 10);
 
 	dprintf("Grabbing interfaces");
 	result = netlink_get_interfaces(&ifaces);
@@ -299,80 +237,38 @@ int get_interfaces_linux(Remote *remote, Packet *response) {
 
 	if (!result) {
 		for (i = 0; i < ifaces->entries; i++) {
+			Packet* group = packet_create_group();
 			int tlv_cnt = 0;
 			int j = 0;
 			dprintf("Building TLV for iface %d", i);
 
-			entries[tlv_cnt].header.length = strlen(ifaces->ifaces[i].name)+1;
-			entries[tlv_cnt].header.type   = TLV_TYPE_MAC_NAME;
-			entries[tlv_cnt].buffer        = (PUCHAR)ifaces->ifaces[i].name;
-			tlv_cnt++;
-
-			entries[tlv_cnt].header.length = 6;
-			entries[tlv_cnt].header.type   = TLV_TYPE_MAC_ADDR;
-			entries[tlv_cnt].buffer        = (PUCHAR)ifaces->ifaces[i].hwaddr;
-			tlv_cnt++;
-
-			mtu_bigendian            = htonl(ifaces->ifaces[i].mtu);
-			entries[tlv_cnt].header.length = sizeof(uint32_t);
-			entries[tlv_cnt].header.type   = TLV_TYPE_INTERFACE_MTU;
-			entries[tlv_cnt].buffer        = (PUCHAR)&mtu_bigendian;
-			tlv_cnt++;
-
-			entries[tlv_cnt].header.length = strlen(ifaces->ifaces[i].flags)+1;
-			entries[tlv_cnt].header.type   = TLV_TYPE_INTERFACE_FLAGS;
-			entries[tlv_cnt].buffer        = (PUCHAR)ifaces->ifaces[i].flags;
-			tlv_cnt++;
-
-			interface_index_bigendian = htonl(ifaces->ifaces[i].index);
-			entries[tlv_cnt].header.length = sizeof(uint32_t);
-			entries[tlv_cnt].header.type   = TLV_TYPE_INTERFACE_INDEX;
-			entries[tlv_cnt].buffer        = (PUCHAR)&interface_index_bigendian;
-			tlv_cnt++;
+			packet_add_tlv_string(group, TLV_TYPE_MAC_NAME, ifaces->ifaces[i].name);
+			packet_add_tlv_raw(group, TLV_TYPE_MAC_ADDR, ifaces->ifaces[i].hwaddr, 6);
+			packet_add_tlv_uint(group, TLV_TYPE_INTERFACE_MTU, ifaces->ifaces[i].mtu);
+			packet_add_tlv_string(group, TLV_TYPE_INTERFACE_FLAGS, ifaces->ifaces[i].flags);
+			packet_add_tlv_uint(group, TLV_TYPE_INTERFACE_INDEX, ifaces->ifaces[i].index);
 
 			for (j = 0; j < ifaces->ifaces[i].addr_count; j++) {
-				if (allocd_entries < tlv_cnt+2) {
-					entries = realloc(entries, sizeof(Tlv) * (tlv_cnt+2));
-					allocd_entries += 2;
-				}
 				if (ifaces->ifaces[i].addr_list[j].family == AF_INET) {
 					dprintf("ip addr for %s", ifaces->ifaces[i].name);
-					entries[tlv_cnt].header.length = sizeof(__u32);
-					entries[tlv_cnt].header.type   = TLV_TYPE_IP;
-					entries[tlv_cnt].buffer        = (PUCHAR)&ifaces->ifaces[i].addr_list[j].ip.addr;
-					tlv_cnt++;
-
-					//dprintf("netmask for %s", ifaces->ifaces[i].name);
-					entries[tlv_cnt].header.length = sizeof(__u32);
-					entries[tlv_cnt].header.type   = TLV_TYPE_NETMASK;
-					entries[tlv_cnt].buffer        = (PUCHAR)&ifaces->ifaces[i].addr_list[j].nm.netmask;
-					tlv_cnt++;
+					packet_add_tlv_raw(group, TLV_TYPE_IP, (PUCHAR)&ifaces->ifaces[i].addr_list[j].ip.addr, sizeof(__u32));
+					packet_add_tlv_raw(group, TLV_TYPE_NETMASK, (PUCHAR)&ifaces->ifaces[i].addr_list[j].nm.netmask, sizeof(__u32));
 				} else {
 					dprintf("-- ip six addr for %s", ifaces->ifaces[i].name);
-					entries[tlv_cnt].header.length = sizeof(__u128);
-					entries[tlv_cnt].header.type   = TLV_TYPE_IP;
-					entries[tlv_cnt].buffer        = (PUCHAR)&ifaces->ifaces[i].addr_list[j].ip.addr6;
-					tlv_cnt++;
-
-					//dprintf("netmask6 for %s", ifaces->ifaces[i].name);
-					entries[tlv_cnt].header.length = sizeof(__u128);
-					entries[tlv_cnt].header.type   = TLV_TYPE_NETMASK;
-					entries[tlv_cnt].buffer        = (PUCHAR)&ifaces->ifaces[i].addr_list[j].nm.netmask6;
-					tlv_cnt++;
+					packet_add_tlv_raw(group, TLV_TYPE_IP, (PUCHAR)&ifaces->ifaces[i].addr_list[j].ip.addr6, sizeof(__u128));
+					packet_add_tlv_raw(group, TLV_TYPE_NETMASK, (PUCHAR)&ifaces->ifaces[i].addr_list[j].nm.netmask6, sizeof(__u128));
 				}
 			}
 
 			dprintf("Adding TLV to group");
-			packet_add_tlv_group(response, TLV_TYPE_NETWORK_INTERFACE, entries, tlv_cnt);
+			packet_add_group(response, TLV_TYPE_NETWORK_INTERFACE, group);
 			dprintf("done Adding TLV to group");
 		}
 	}
 
-	if (ifaces)
+	if (ifaces) {
 		free(ifaces);
-	if (entries)
-		free(entries);
-
+	}
 
 	return result;
 }

--- a/c/meterpreter/source/extensions/stdapi/server/net/config/interface.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/config/interface.c
@@ -18,7 +18,7 @@ DWORD get_interfaces_windows_mib(Remote *remote, Packet *response)
 		return ERROR_OUTOFMEMORY;
 	}
 
-	// attempt with an insufficient buffer
+	// attempt with an insufficient buffer size
 	DWORD result = GetIpAddrTable(table, &tableSize, TRUE);
 	if (result == ERROR_INSUFFICIENT_BUFFER)
 	{


### PR DESCRIPTION
This moves the existing network interface enumeration code over to the group TLV packet approach which allows for arbitrary numbers of entities to be added on the fly instead of fixed numbers.

Should fix the issue that @mubix  reported over here: https://github.com/rapid7/metasploit-payloads/issues/82

I've not been able to test this on a machine with so many interfaces yet, but it works just fine on my existing machines.

I'd like to request that @bcook-r7 take a look at the POSIX changes. I was able to compile them but I can't test any POSIX code as the binaries that I generate don't run (Fedora 22).

## Verification

- [ ] Create a Meterpreter session.
- [ ] run `ipconfig`.
- [ ] Things run just fine as they did before.
- [ ] There is no longer a limit on the number of interfaces (ping @mubix).

Thanks!