### PR TITLE
fix the length calculation for meterpreter registry class reads

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
@@ -716,8 +716,8 @@ DWORD request_registry_query_class(Remote *remote, Packet *packet)
 	 * RegQueryInfoKeyW returns the length in chars minus the NULL terminator
 	 */
 	DWORD classNameLen = 0;
-	result = RegQueryInfoKeyW(hkey, NULL, &classNameLen,
-		NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+	result = RegQueryInfoKeyW(hkey, NULL, NULL,
+		NULL, NULL, NULL, &classNameLen, NULL, NULL, NULL, NULL, NULL);
 	if (result != ERROR_SUCCESS) {
 		goto err;
 	}


### PR DESCRIPTION
Some recent unicode fixes for Meterpreter led to registry class reads being broken. This was most noticeable with hashdump modules:

```
msf exploit(handler) > use post/windows/gather/hashdump
msf post(hashdump) > set session -1
session => -1
msf post(hashdump) > run
[] Obtaining the boot key...
[-] Meterpreter Exception: Rex::Post::Meterpreter::RequestError stdapi_registry_query_class: Operation failed: The data area passed to a system call is too small.
[-] This script requires the use of a SYSTEM user context (hint: migrate into service process)
[] Post module execution completed
```

It appears that when one passes the length field in the RegQueryInfoKeyW for class length, it does not get filled in. But, if you use maxClassLen, it does. So, this PR just switches the positional arguments as appropriate:

```
[*] Obtaining the boot key...
^[[A[*] Calculating the hboot key using SYSKEY 00000000000000000000000000000000...
[*] Obtaining the user list and keys...
[*] Decrypting user keys...
[*] Dumping password hints...

bcook:"normal"
monkeyö:"blah"
路人甲:"normal"
```

MS-1479