### PR TITLE
fix registry class, take 2

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
@@ -712,42 +712,16 @@ DWORD request_registry_query_class(Remote *remote, Packet *packet)
 		goto err;
 	}
 
-	/*
-	 * RegQueryInfoKeyW returns the length in chars minus the NULL terminator
-	 */
-	DWORD classNameLen = 0;
-	result = RegQueryInfoKeyW(hkey, NULL, NULL,
-		NULL, NULL, NULL, &classNameLen, NULL, NULL, NULL, NULL, NULL);
-	if (result != ERROR_SUCCESS) {
-		goto err;
+	DWORD classNameLen = 4096;
+	char className[4096];
+
+	result = RegQueryInfoKeyA(hkey, className, &classNameLen,
+		NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+	if (result == ERROR_SUCCESS) {
+		packet_add_tlv_raw(response, TLV_TYPE_VALUE_DATA,
+			className, classNameLen);
 	}
 
-	classNameLen++;
-	wchar_t *className = calloc(classNameLen, sizeof(wchar_t));
-	if (className == NULL) {
-		result = ERROR_NOT_ENOUGH_MEMORY;
-		goto err;
-	}
-
-	if (className) {
-		result = RegQueryInfoKeyW(hkey, className, &classNameLen,
-		    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-		if (result == ERROR_SUCCESS) {
-			char *tmp = wchar_to_utf8(className);
-			if (tmp) {
-				packet_add_tlv_string(response, TLV_TYPE_VALUE_DATA, tmp);
-				free(tmp);
-			} else {
-				packet_add_tlv_raw(response,
-						TLV_TYPE_VALUE_DATA, className,
-						classNameLen * sizeof(wchar_t));
-			}
-		}
-	} else {
-		result = ERROR_NOT_ENOUGH_MEMORY;
-	}
-
-	free(className);
 err:
 	packet_transmit_response(result, remote, response);
 out:


### PR DESCRIPTION
follow up from #99, it turns out that the original PR fixed hashdump by fluke. The class length was still coming back as '0', but the metasploit code could handle that (albeit it was not optimal). Examining our use in metasploit-framework/lib/msf/core/post/windows/priv.rb seems to indicate that we expect this to come back as as something like ascii text anyway (and that appears to be only one of a couple of uses for the user-defined class name for registry keys)

So, this PR switches back to the original static buffer method that we used earlier, since dynamically getting the length seems to be busted for this API. 

 - [x] To verify, ensure that hashdump and friends work with this PR

MS-1479