### PR TITLE
Fixed OSX crashes for python meterpreter

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -22,14 +22,6 @@ except ImportError:
 else:
 	has_windll = hasattr(ctypes, 'windll')
 
-# this MUST be imported for urllib to work on OSX
-try:
-	import SystemConfiguration as osxsc
-	osxsc.SCNetworkInterfaceCopyAll()
-	has_osxsc = True
-except ImportError:
-	has_osxsc = False
-
 try:
 	urllib_imports = ['ProxyHandler', 'Request', 'build_opener', 'install_opener', 'urlopen']
 	if sys.version_info[0] < 3:


### PR DESCRIPTION
SystemConfiguration is no longer needed in the python meterpreter (already loaded in ext_server_stdapi.py where needed).

Also has_osxsc variable is no longer used.

SystemConfiguration is causing crashes in certain versions of python on OSX including but not limited to 2.6.9 and 2.7.10. Suspect this is due to the double loading. Everything seems to work correctly when this is taken out of the meterpreter.py and only loaded when needed in stdapi.