### PR TITLE
add java/android core_enumextcmd

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/CommandManager.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/CommandManager.java
@@ -150,4 +150,11 @@ public class CommandManager {
     public String[] getNewCommands() {
         return (String[]) newCommands.toArray(new String[newCommands.size()]);
     }
+
+    /**
+     * Retrieves the list of commands
+     */
+    public String[] getCommands() {
+        return (String[]) registeredCommands.keySet().toArray(new String[registeredCommands.size()]);
+    }
 }

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
@@ -17,6 +17,7 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand("core_channel_open", core_channel_open.class);
         mgr.registerCommand("core_channel_read", core_channel_read.class);
         mgr.registerCommand("core_channel_write", core_channel_write.class);
+        mgr.registerCommand("core_enumextcmd", core_enumextcmd.class);
         mgr.registerCommand("core_loadlib", core_loadlib.class);
         mgr.registerCommand("core_uuid", core_uuid.class);
         mgr.registerCommand("core_machine_id", core_machine_id.class);

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_enumextcmd.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_enumextcmd.java
@@ -1,0 +1,26 @@
+package com.metasploit.meterpreter.core;
+
+import com.metasploit.meterpreter.CommandManager;
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+
+public class core_enumextcmd implements Command {
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        String command = request.getStringValue(TLVType.TLV_TYPE_STRING);
+        CommandManager commandManager = meterpreter.getCommandManager();
+        String[] commands = commandManager.getCommands();
+        for (String loadedCommand : commands) {
+            if (command.equals(loadedCommand.split("_")[0])) {
+                response.addOverflow(TLVType.TLV_TYPE_STRING, loadedCommand);
+            }
+        }
+        if ("android".equals(command)) {
+             // There are currently no commands prefixed with android but we still want to load the extension
+            response.addOverflow(TLVType.TLV_TYPE_STRING, "");
+        }
+        return ERROR_SUCCESS;
+    }
+}


### PR DESCRIPTION
This pr implements core_enumextcmd, which removes the need for fake data/meterpreter/ext_server_blah.jar files in the framework repository.