### PR TITLE
update maven android api level

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,7 @@ RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter tools --no
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter platform-tools --no-ui -a
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter build-tools-23.0.0 --no-ui -a
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter android-10 --no-ui -a
+RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter android-19 --no-ui -a
 RUN echo y | /usr/local/android-sdk/tools/android update sdk --filter android-3 --no-ui -a
 
 # Pre-cache Maven artifacts

--- a/java/README.md
+++ b/java/README.md
@@ -56,7 +56,7 @@ http://maven.apache.org/plugins/maven-idea-plugin/
 
 1. Download the [Android SDK](https://developer.android.com/sdk/index.html), and the [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html) somewhere
 2. Launch the `sdk/tool/android` program
-3. Install API version 10, and update the "Android SDK Tools" and "Android SDK Platform-tools"
+3. Install API version 10 and 19, and update the "Android SDK Tools" and "Android SDK Platform-tools"
 4. Compile android meterpreter:
 
 ```

--- a/java/androidpayload/library/pom.xml
+++ b/java/androidpayload/library/pom.xml
@@ -59,7 +59,7 @@
 				<artifactId>android-maven-plugin</artifactId>
 				<configuration>
 					<sdk>
-						<!-- platform or api level (api level 10 = platform 2.3)-->
+						<!-- platform or api level (api level 19 = platform 4.4 (kitkat))-->
 						<platform>19</platform>
 					</sdk>
 				</configuration>

--- a/java/androidpayload/library/pom.xml
+++ b/java/androidpayload/library/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>com.google.android</groupId>
 			<artifactId>android</artifactId>
-			<version>2.3.3</version>
+			<version>4.1.1.4</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -60,7 +60,7 @@
 				<configuration>
 					<sdk>
 						<!-- platform or api level (api level 10 = platform 2.3)-->
-						<platform>10</platform>
+						<platform>19</platform>
 					</sdk>
 				</configuration>
 			</plugin>

--- a/java/androidpayload/library/pom.xml
+++ b/java/androidpayload/library/pom.xml
@@ -64,7 +64,16 @@
 					</sdk>
 				</configuration>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
 	</build>
 	<profiles>
 		<profile>

--- a/java/version-compatibility-check/android-api/pom.xml
+++ b/java/version-compatibility-check/android-api/pom.xml
@@ -2,14 +2,14 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.metasploit</groupId>
-	<artifactId>Metasploit-JavaPayload-Compatibility-android-api10</artifactId>
+	<artifactId>Metasploit-JavaPayload-Compatibility-android-api</artifactId>
 	<parent>
 		<groupId>com.metasploit</groupId>
 		<artifactId>Metasploit-JavaPayload-Compatibility-parent</artifactId>
 		<version>1-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>JavaPayload Compatibility Checks (Android API 10)</name>
+	<name>JavaPayload Compatibility Checks (Android API)</name>
 	<url>http://www.metasploit.com/</url>
 	<dependencies>
 		<dependency>

--- a/java/version-compatibility-check/android-api10/pom.xml
+++ b/java/version-compatibility-check/android-api10/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.google.android</groupId>
 			<artifactId>android</artifactId>
-			<version>2.3.3</version>
+			<version>4.1.1.4</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -72,8 +72,8 @@
 						<configuration>
 							<signature>
 								<groupId>net.sf.androidscents.signature</groupId>
-								<artifactId>android-api-level-10</artifactId>
-								<version>2.3.3_r2</version>
+								<artifactId>android-api-level-L</artifactId>
+								<version>L_r1</version>
 							</signature>
 						</configuration>
 					</execution>

--- a/java/version-compatibility-check/pom.xml
+++ b/java/version-compatibility-check/pom.xml
@@ -51,6 +51,6 @@
 	<modules>
 		<module>java16</module>
 		<module>java15</module>
-		<module>android-api10</module>
+		<module>android-api</module>
 	</modules>
 </project>


### PR DESCRIPTION
This pr updates the android api level so we can use more recent Android apis.
Also includes a minor fix to the java version in the android pom.xml so that Intellij no longer complains about the @Overrides.