### PR TITLE
fix check_root on android 6.0 and up

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/check_root_android.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/check_root_android.java
@@ -53,8 +53,8 @@ public class check_root_android implements Command {
     private static boolean canExecuteCommand(String command) {
         boolean executedSuccesfully;
         try {
-            Runtime.getRuntime().exec(command);
-            executedSuccesfully = true;
+            Process process = Runtime.getRuntime().exec(command);
+            executedSuccesfully = process.waitFor() == 0;
         } catch (Exception e) {
             executedSuccesfully = false;
         }


### PR DESCRIPTION
On Android 6.0 and up the command 'which' is implemented, which means that ```which su``` will execute (but return with an exit code of 1 on a non-rooted device).
This fixes it so that check_root works correctly on all version of Android.