### PR TITLE
Add response return parameter in fail case

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -902,7 +902,7 @@ class PythonMeterpreter(object):
 	def _core_loadlib(self, request, response):
 		data_tlv = packet_get_tlv(request, TLV_TYPE_DATA)
 		if (data_tlv['type'] & TLV_META_TYPE_COMPRESSED) == TLV_META_TYPE_COMPRESSED:
-			return ERROR_FAILURE
+			return ERROR_FAILURE, response
 
 		self.last_registered_extension = None
 		symbols_for_extensions = {'meterpreter':self}


### PR DESCRIPTION
This fixes a small issue where Python meterpreter crashes when MSF (incorrectly) uses a session type that assumes that Python meterpreter supports compression when it doesn't. The return value for the function did not include the response parameter, resulting in Python not being happy when the function returns as the result was being bound to two values while only returning one.

I stumbled on this when doing horrible things with MSF's sessions. While this is really an edge-case that probably will never get hit during typical use, it's still "technically incorrect", hence the PR.

## Verification

Um, yeah, verifying this means doing horrible things to MSF. I think the best thing to do here is just look at the call sites for this function and note that they assume two values coming out, and not one.

Ping @zeroSteiner please sir!