### PR TITLE
Change PHP meterpreter header comment style

### DIFF
--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -1,4 +1,4 @@
-//<?php
+/*<?php /**/
 
 # Everything that needs to be global has to be made so explicitly so we can run
 # inside a call to create_user_func($user_input);


### PR DESCRIPTION
This commit fixes cases where stageless meterpreter payloads may not run
if they are loaded within a PHP context that's already inside the
opening and closing <?php ... ?> tags. While this is rare, it's possible
that this may happen. This approach matches that which we use for staged
payloads.

## Verification

- [x] Create a staged php payload & listener.
- [x] Run the staged payload and make sure it works.
- [x] Create a stageless php payload & listener.
- [x] Run the stageless payload and make sure it works.
- [x] To simulate the breaking case, edit the stageless payload and wrap the entire statement in `<?php` and `?>` tags, and run the payload again. It should still work.