### PR TITLE
Use the correct spelling of ACCESS_COARSE_LOCATION

### DIFF
--- a/java/androidpayload/app/src/main/AndroidManifest.xml
+++ b/java/androidpayload/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_COURSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.SEND_SMS" />


### PR DESCRIPTION
Noted by @PsychoBit, we're requesting a non-existent permission.

Fixes https://github.com/rapid7/metasploit-framework/issues/7780