### PR TITLE
Fix str format method for Python 2.5

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -883,7 +883,7 @@ class PythonMeterpreter(object):
 					None, fs_buf, ctypes.sizeof(fs_buf)):
 				return ERROR_FAILURE_WINDOWS
 			serial_num = serial_num.value
-			serial = "{0:04x}-{1:04x}".format((serial_num >> 16) & 0xFFFF, serial_num & 0xFFFF)
+			serial = "%04x" % ((serial_num >> 16) & 0xffff) + '-' "%04x" % (serial_num & 0xffff)
 		else:
 			serial = get_hdd_label()
 


### PR DESCRIPTION
There is currently a bug in the Python meterpreter causing it to not load on Python2.5 (the oldest supported version) which does not support the new style string format methods. This PR addresses the issue by using the old-style percent formatting in the `_core_machine_id` method.

Testing steps:
 - [x] Load msfconsole
 - [x] Generate a Python Meterpreter payload
 - [x] Get a session executing the payload using Python 2.5.x
 - [x] Run the `post/test/meterpreter` module, and ensure all tests pass