### PR TITLE
Add new core_native_arch method to the Python Meterpreter

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -923,6 +923,10 @@ class PythonMeterpreter(object):
 		response += tlv_pack(TLV_TYPE_MACHINE_ID, "%s:%s" % (serial, machine_name))
 		return ERROR_SUCCESS, response
 
+	def _core_native_arch(self, request, response):
+		response += tlv_pack(TLV_TYPE_STRING, get_native_arch())
+		return ERROR_SUCCESS, response
+
 	def _core_patch_url(self, request, response):
 		if not isinstance(self.transport, HttpTransport):
 			return ERROR_FAILURE, response


### PR DESCRIPTION
This PR is the metasploit-payloads side of the addition of a new core method for meterpreters to specify their process' native architecture. Adding this feature will allow for Metasploit to query the meterpreter session to identify the correct architecture which, in the case of some meterpreters, can't be done properly using `sesison.arch` or `session.sys.config.sysinfo['Architecture']` when running in a WOW64 process. Knowing this information is necessary for interacting with native API methods.

One question I have for reviewers is whether or not a new `TLV_TYPE_` constant should be used for this or if simply using `TLV_TYPE_STRING` is acceptable. I went with a string constant so the format can be consistent with `sysinfo['Architecture']`.

Testing steps will be outlined in the Metasploit side PR.