### PR TITLE
Add Railgun Support To The Python Meterpreter

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1541,7 +1541,7 @@ def stdapi_railgun_api(request, response):
 	buff_blob_inout = packet_get_tlv(request, TLV_TYPE_RAILGUN_BUFFERBLOB_INOUT)['value']
 	dll_name = packet_get_tlv(request, TLV_TYPE_RAILGUN_DLLNAME)['value']
 	func_name = packet_get_tlv(request, TLV_TYPE_RAILGUN_FUNCNAME)['value']
-	call_conv = packet_get_tlv(request, TLV_TYPE_RAILGUN_CALLCONV)['value']
+	call_conv = packet_get_tlv(request, TLV_TYPE_RAILGUN_CALLCONV).get('value', ('stdcall' if has_windll else 'cdecl'))
 
 	buff_blob_in = bytes_to_ctarray(buff_blob_in)
 	buff_blob_out = (ctypes.c_byte * size_out)()
@@ -1604,6 +1604,13 @@ def stdapi_railgun_api(request, response):
 	response += tlv_pack(TLV_TYPE_RAILGUN_BACK_RET, result)
 	response += tlv_pack(TLV_TYPE_RAILGUN_BACK_BUFFERBLOB_OUT, ctarray_to_bytes(buff_blob_out))
 	response += tlv_pack(TLV_TYPE_RAILGUN_BACK_BUFFERBLOB_INOUT, ctarray_to_bytes(buff_blob_inout))
+	return ERROR_SUCCESS, response
+
+@meterpreter.register_function_windll
+def stdapi_railgun_api_multi(request, response):
+	for group_tlv in packet_enum_tlvs(request, tlv_type=TLV_TYPE_RAILGUN_MULTI_GROUP):
+		group_result = stdapi_railgun_api(group_tlv['value'], '')[1]
+		response += tlv_pack(TLV_TYPE_RAILGUN_MULTI_GROUP, group_result)
 	return ERROR_SUCCESS, response
 
 @meterpreter.register_function_windll

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1502,10 +1502,15 @@ def _win_format_message(source, msg_id):
 	FormatMessage = ctypes.windll.kernel32.FormatMessageA
 	FormatMessage.argtypes = [ctypes.c_uint32, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_void_p]
 	FormatMessage.restype = ctypes.c_uint32
+	LocalFree = ctypes.windll.kernel32.LocalFree
+	LocalFree.argtypes = [ctypes.c_void_p]
+
 	buff = ctypes.c_char_p()
 	if not FormatMessage(msg_flags, source, msg_id, EN_US, ctypes.byref(buff), 0, None):
 		return None
-	return buff.value.decode('utf-8').rstrip()
+	message = buff.value.decode('utf-8').rstrip()
+	LocalFree(buff)
+	return message
 
 def _win_memread(address, size, handle=-1):
 	ReadProcessMemory = ctypes.windll.kernel32.ReadProcessMemory

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1585,7 +1585,7 @@ def stdapi_railgun_api(request, response):
 	GetModuleHandle = ctypes.windll.kernel32.GetModuleHandleA
 	GetModuleHandle.argtypes = [ctypes.c_char_p]
 	GetModuleHandle.restype = ctypes.c_void_p
-	dll_handle = GetModuleHandle(dll_name)
+	dll_handle = GetModuleHandle(bytes(dll_name, 'UTF-8'))
 
 	prototype = func_type(native, *func_args)
 	func = prototype((func_name, ctypes.WinDLL(dll_name)))
@@ -1609,7 +1609,7 @@ def stdapi_railgun_api(request, response):
 @meterpreter.register_function_windll
 def stdapi_railgun_api_multi(request, response):
 	for group_tlv in packet_enum_tlvs(request, tlv_type=TLV_TYPE_RAILGUN_MULTI_GROUP):
-		group_result = stdapi_railgun_api(group_tlv['value'], '')[1]
+		group_result = stdapi_railgun_api(group_tlv['value'], bytes())[1]
 		response += tlv_pack(TLV_TYPE_RAILGUN_MULTI_GROUP, group_result)
 	return ERROR_SUCCESS, response
 

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1582,6 +1582,7 @@ def stdapi_railgun_api(request, response):
 		else:
 			raise ValueError('unknown argument type: ' + str(arg_type))
 
+	debug_print('[*] railgun calling: ' + dll_name + '.' + func_name)
 	GetModuleHandle = ctypes.windll.kernel32.GetModuleHandleA
 	GetModuleHandle.argtypes = [ctypes.c_char_p]
 	GetModuleHandle.restype = ctypes.c_void_p


### PR DESCRIPTION
This is the metasploit-payloads side of the addition to add support for Railgun features to the Python meterpreter when running on Windows hosts. The accompanying metasploit-framework PR will have testing steps.