### PR TITLE
meterpreter payload fails sysinfo fix

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -591,6 +591,18 @@ def cstruct_unpack(structure, raw_data):
 	ctypes.memmove(ctypes.byref(structure), raw_data, ctypes.sizeof(structure))
 	return structure
 
+def get_system_arch():
+	uname_info = platform.uname()
+	arch = uname_info[4]
+	if has_windll:
+		sysinfo = SYSTEM_INFO()
+		ctypes.windll.kernel32.GetNativeSystemInfo(ctypes.byref(sysinfo))
+		values = {0:'x86', 5:'armle', 6:'IA64', 9:'x64'}
+		arch = values.get(sysinfo.wProcessorArchitecture, uname_info[4])
+	if arch == 'x86_64':
+		arch = 'x64'
+	return arch
+
 def get_stat_buffer(path):
 	si = os.stat(path)
 	rdev = 0


### PR DESCRIPTION
### Issue : Previously build python meterpreter payload fails sysinfo #8140
### Link: https://github.com/rapid7/metasploit-framework/issues/8140

## Steps to produce:

using previously created python meterpreter (example was created with framework on 11-Jan-2017)

```
./msfvenom -p python/meterpreter_reverse_https LHOST=127.0.0.1 LPORT=8443 > metPy_127_8443
python metPy_127_8443
```
execute following:

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload multi/meterpreter/reverse_https
payload => multi/meterpreter/reverse_https
msf exploit(handler) > set LHOST 127.0.0.1
LHOST => 127.0.0.1
msf exploit(handler) > set LPORT 8443
LPORT => 8443
msf exploit(handler) > run -j
[*] Exploit running as background job.

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started HTTPS reverse handler on https://127.0.0.1:8443
[*] Starting the payload handler...
msf exploit(handler) > [*] https://127.0.0.1:8443 handling request from 127.0.0.1; (UUID: pmp39mpo) Redirecting stageless connection from /Y7aV3PeSY0N4im2eIFzOzAl-raX-Go-eSvgMPeHzWeCmPCrDu0A0aUjR0Jj4WgnBe with UA 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko'
[*] https://127.0.0.1:8443 handling request from 127.0.0.1; (UUID: pmp39mpo) Attaching orphaned/stageless session...
[*] Meterpreter session 1 opened (127.0.0.1:8443 -> 127.0.0.1:36964) at 2017-03-26 12:35:19 +0530
WARNING: Local file /root/Framework/msf/metasploit-framework/data/meterpreter/ext_server_stdapi.py is being used
WARNING: Local files may be incompatible with the Metasploit Framework
Interrupt: use the 'exit' command to quit
msf exploit(handler) > sessions -v

Active sessions
===============

  Session ID: 1
        Type: meterpreter linux
        Info: root @ kali
      Tunnel: 127.0.0.1:8443 -> 127.0.0.1:36964 (127.0.0.1)
         Via: exploit/multi/handler
        UUID: 63b695dcf7926343/python=20/linux=6/2017-03-25T18:26:14Z
   MachineID: 13ede737d38bc1ea6c3d7cd865a4cbba
     CheckIn: 1s ago @ 2017-03-26 12:35:23 +0530
  Registered: No



msf exploit(handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : kali
OS              : Linux 4.6.0-kali1-amd64 #1 SMP Debian 4.6.4-1kali1 (2016-07-21)
Architecture    : x64
System Language : en_IN
Meterpreter     : python/linux
meterpreter > 

```

### Fix: sysinfo is displayed and sessions details contains the  "Info" label.

