### PR TITLE
Fixed stdapi_fs_mount_show to show full mapped drive path for Windows in Python meterpreter

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -239,7 +239,7 @@ if has_ctypes:
 		_fields_ = [("User", SID_AND_ATTRIBUTES)]
 
 	class UNIVERSAL_NAME_INFO(ctypes.Structure):
-		_fields_ = [("lpUniversalName", ctypes.c_char_p)]
+		_fields_ = [("lpUniversalName", ctypes.c_wchar_p)]
 
 	class EVENTLOGRECORD(ctypes.Structure):
 		_fields_ = [("Length", ctypes.c_uint32),


### PR DESCRIPTION
A bug in stdapi_fs_mount_show causing it to display the mapped drive path cut off. Because the unicode path retrieved by a call to WNetGetUniversalNameW was cast to char instead of wchar.

I have modified it to use wchar. It is fixed now.

Output after fix:

```
meterpreter > show_mount

Mounts / Drives
===============

Name  Type    Size (Total)  Size (Free)  Mapped to
----  ----    ------------  -----------  ---------
C:    fixed   119.21 GiB     20.40 GiB
D:    fixed   103.12 GiB     26.24 GiB
Z:    remote  103.12 GiB     26.24 GiB   \\LENOVO-PC\Dropbox


Total mounts/drives: 3

meterpreter >
```

Output before fix:

```
meterpreter > show_mount

Mounts / Drives
===============

Name  Type    Size (Total)  Size (Free)  Mapped to
----  ----    ------------  -----------  ---------
C:    fixed   119.21 GiB     20.40 GiB
D:    fixed   103.12 GiB     26.24 GiB
Z:    remote  103.12 GiB     26.24 GiB   \


Total mounts/drives: 3

meterpreter >
```