### PR TITLE
Adjust proxy code to support DNS/DHCP resolution

### DIFF
--- a/c/meterpreter/source/server/win/server_transport_winhttp.c
+++ b/c/meterpreter/source/server/win/server_transport_winhttp.c
@@ -51,18 +51,27 @@ static HINTERNET get_request_winhttp(HttpTransportContext *ctx, BOOL isGet, cons
 				dprintf("[PROXY] Proxy: %S", ieConfig.lpszProxy);
 				dprintf("[PROXY] Proxy Bypass: %S", ieConfig.lpszProxyBypass);
 
-				if (ieConfig.lpszAutoConfigUrl)
+				if (ieConfig.lpszAutoConfigUrl || ieConfig.fAutoDetect)
 				{
 					WINHTTP_AUTOPROXY_OPTIONS autoProxyOpts = { 0 };
 					WINHTTP_PROXY_INFO proxyInfo = { 0 };
 
-					dprintf("[PROXY] IE config set to autodetect with URL %S", ieConfig.lpszAutoConfigUrl);
+					if (ieConfig.fAutoDetect)
+					{
+						dprintf("[PROXY] IE config set to autodetect with DNS or DHCP");
 
-					autoProxyOpts.dwFlags = WINHTTP_AUTOPROXY_AUTO_DETECT | WINHTTP_AUTOPROXY_CONFIG_URL;
-					autoProxyOpts.dwAutoDetectFlags = WINHTTP_AUTO_DETECT_TYPE_DHCP | WINHTTP_AUTO_DETECT_TYPE_DNS_A;
+						autoProxyOpts.dwFlags = WINHTTP_AUTOPROXY_AUTO_DETECT;
+						autoProxyOpts.dwAutoDetectFlags = WINHTTP_AUTO_DETECT_TYPE_DHCP | WINHTTP_AUTO_DETECT_TYPE_DNS_A;
+					}
+					else
+					{
+						dprintf("[PROXY] IE config set to autodetect with URL %S", ieConfig.lpszAutoConfigUrl);
+
+						autoProxyOpts.dwFlags = WINHTTP_AUTOPROXY_CONFIG_URL;
+						autoProxyOpts.lpszAutoConfigUrl = ieConfig.lpszAutoConfigUrl;
+					}
+
 					autoProxyOpts.fAutoLogonIfChallenged = TRUE;
-					autoProxyOpts.lpszAutoConfigUrl = ieConfig.lpszAutoConfigUrl;
-
 					if (WinHttpGetProxyForUrl(ctx->internet, ctx->url, &autoProxyOpts, &proxyInfo))
 					{
 						ctx->proxy_for_url = malloc(sizeof(WINHTTP_PROXY_INFO));


### PR DESCRIPTION
This code is blatantly poached from the blog post located [here](https://medium.com/@br4nsh/a-meterpreter-and-windows-proxy-case-4af2b866f4a1), which was written by Juan Caillava (I can't find him on github and his Twitter is protected). A great deal of time and effort went into that research and all credit for this work should go to him.

This fixes the case where Meterpreter fails to load proxy URLs from a DHCP- or DNS-based configuration. I don't have anything locally that I can test this with at this point, so I can't vouch for its function. However, I know that in many cases in the past there have been reports Meterpreter failing to pick up proxy settings correctly (Juan's was one of them).

Hopefully this fixes the issue in those cases.

## Verification
- [ ] Create a staged or stageless meterpreter payload for Windows
- [ ] Create a matching listener
- [ ] Configure a Windows machine so that proxy settings are defined via DNS (and another with DHCP if possible).
- [ ] Launch the payload.
- [ ] Confirm that the sessions that have been established function correctly and pivot through the proxies as expected.

I appreciate any help that goes into testing this, and I apologise that I can't really do much to help here. @bcook-r7 if you guys at R7 have an internal set up that this can be tested on I'd super appreciate it.

Again, this is not my work. This is me poaching the fruits of someone else's labour and no credit should head in my direction. I'm just the guy who did the PR.

## Edit

Thanks to @timwr for pointing out that @bransh is the dude behind the work, all kudos should be pointed at him.

Fixes #151 