### PR TITLE
Add session GUID support to Meterpreter payloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 DATADIR:=../metasploit-framework/data
 METERPDIR:=$(DATADIR)/meterpreter
 
-install: \
-	install-c-windows \
+install-all: \
+	install-windows \
     install-java \
     install-php \
     install-python
 
-install-c-windows:
+install-windows:
 	@echo "Installing Windows payloads"
 	@if [ -d c/meterpreter/output/x86 ]; then \
 		cp -a c/meterpreter/output/x86/*.dll $(METERPDIR); \

--- a/c/meterpreter/source/common/config.h
+++ b/c/meterpreter/source/common/config.h
@@ -25,6 +25,7 @@ typedef struct _MetsrvSession
 	DWORD exit_func;                      ///! Exit func identifier for when the session ends.
 	int expiry;                           ///! The total number of seconds to wait before killing off the session.
 	BYTE uuid[UUID_SIZE];                 ///! UUID
+	BYTE session_guid[sizeof(GUID)];      ///! Current session GUID
 } MetsrvSession;
 
 typedef struct _MetsrvTransportCommon

--- a/c/meterpreter/source/common/core.h
+++ b/c/meterpreter/source/common/core.h
@@ -163,6 +163,7 @@ typedef enum
 	// session/machine identification
 	TLV_TYPE_MACHINE_ID          = TLV_VALUE(TLV_META_TYPE_STRING,    460),   ///! Represents a machine identifier.
 	TLV_TYPE_UUID                = TLV_VALUE(TLV_META_TYPE_RAW,       461),   ///! Represents a UUID.
+	TLV_TYPE_SESSION_GUID        = TLV_VALUE(TLV_META_TYPE_RAW,       462),   ///! Represents a Session GUID.
 
 	// Cryptography
 	TLV_TYPE_CIPHER_NAME         = TLV_VALUE(TLV_META_TYPE_STRING,    500),   ///! Represents the name of a cipher.

--- a/c/meterpreter/source/server/remote_dispatch_common.c
+++ b/c/meterpreter/source/server/remote_dispatch_common.c
@@ -7,6 +7,8 @@ PLIST gExtensionList = NULL;
 
 DWORD request_core_enumextcmd(Remote* remote, Packet* packet);
 DWORD request_core_machine_id(Remote* remote, Packet* packet);
+DWORD request_core_get_session_guid(Remote* remote, Packet* packet);
+DWORD request_core_set_session_guid(Remote* remote, Packet* packet);
 DWORD request_core_set_uuid(Remote* remote, Packet* packet);
 BOOL request_core_patch_url(Remote* remote, Packet* packet, DWORD* result);
 
@@ -16,6 +18,8 @@ Command customCommands[] =
 	COMMAND_REQ("core_loadlib", request_core_loadlib),
 	COMMAND_REQ("core_enumextcmd", request_core_enumextcmd),
 	COMMAND_REQ("core_machine_id", request_core_machine_id),
+	COMMAND_REQ("core_get_session_guid", request_core_get_session_guid),
+	COMMAND_REQ("core_set_session_guid", request_core_set_session_guid),
 	COMMAND_REQ("core_set_uuid", request_core_set_uuid),
 	COMMAND_INLINE_REP("core_patch_url", request_core_patch_url),
 	COMMAND_TERMINATOR

--- a/c/meterpreter/source/server/server_setup_win.c
+++ b/c/meterpreter/source/server/server_setup_win.c
@@ -236,6 +236,8 @@ static void config_create(Remote* remote, LPBYTE uuid, MetsrvConfig** config, LP
 	// start by preparing the session, using the given UUID if specified, otherwise using
 	// the existing session UUID
 	memcpy(sess->uuid, uuid == NULL ? remote->orig_config->session.uuid : uuid, UUID_SIZE);
+	// session GUID should persist across migration
+	memcpy(sess->session_guid, remote->orig_config->session.session_guid, sizeof(GUID));
 	sess->expiry = remote->sess_expiry_end - current_unix_timestamp();
 	sess->exit_func = EXITFUNC_THREAD; // migration we default to this.
 
@@ -313,6 +315,12 @@ DWORD server_setup(MetsrvConfig* config)
 		config->session.uuid[4], config->session.uuid[5], config->session.uuid[6], config->session.uuid[7],
 		config->session.uuid[8], config->session.uuid[9], config->session.uuid[10], config->session.uuid[11],
 		config->session.uuid[12], config->session.uuid[13], config->session.uuid[14], config->session.uuid[15]);
+
+	dprintf("[SERVER] Session GUID: %02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+		config->session.session_guid[0], config->session.session_guid[1], config->session.session_guid[2], config->session.session_guid[3],
+		config->session.session_guid[4], config->session.session_guid[5], config->session.session_guid[6], config->session.session_guid[7],
+		config->session.session_guid[8], config->session.session_guid[9], config->session.session_guid[10], config->session.session_guid[11],
+		config->session.session_guid[12], config->session.session_guid[13], config->session.session_guid[14], config->session.session_guid[15]);
 
 	// if hAppInstance is still == NULL it means that we havent been
 	// reflectivly loaded so we must patch in the hAppInstance value

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Meterpreter.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Meterpreter.java
@@ -43,6 +43,7 @@ public class Meterpreter {
     private final TransportList transports = new TransportList();
     protected int ignoreBlocks = 0;
     private byte[] uuid;
+    private byte[] sessionGUID;
     private long sessionExpiry;
 
     protected void loadConfiguration(DataInputStream in, OutputStream rawOut, byte[] configuration) throws MalformedURLException {
@@ -58,6 +59,9 @@ public class Meterpreter {
         // this is followed with the UUID
         this.uuid = ConfigParser.readBytes(configuration, csr, ConfigParser.UUID_LEN);
         csr += ConfigParser.UUID_LEN;
+
+        this.sessionGUID = ConfigParser.readBytes(configuration, csr, ConfigParser.GUID_LEN);
+        csr += ConfigParser.GUID_LEN;
 
         // here we need to loop through all the given transports, we know that we're
         // going to get at least one.
@@ -90,6 +94,14 @@ public class Meterpreter {
 
     public void setUUID(byte[] newUuid) {
         this.uuid = newUuid;
+    }
+
+    public byte[] getSessionGUID() {
+        return this.sessionGUID;
+    }
+
+    public void setSessionGUID(byte[] guid) {
+        this.sessionGUID = guid;
     }
 
     public long getExpiry() {
@@ -139,6 +151,7 @@ public class Meterpreter {
         this.loadExtensions = loadExtensions;
         this.commandManager = new CommandManager();
         this.channels.add(null); // main communication channel?
+
         if (redirectErrors) {
             errBuffer = new ByteArrayOutputStream();
             err = new PrintStream(errBuffer);

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
@@ -64,8 +64,9 @@ public interface TLVType {
     public static final int TLV_TYPE_TRANS_RETRY_WAIT   = TLVPacket.TLV_META_TYPE_UINT   | 440;
     public static final int TLV_TYPE_TRANS_GROUP        = TLVPacket.TLV_META_TYPE_GROUP  | 441;
 
-    public static final int TLV_TYPE_MACHINE_ID = TLVPacket.TLV_META_TYPE_STRING | 460;
-    public static final int TLV_TYPE_UUID       = TLVPacket.TLV_META_TYPE_RAW    | 461;
+    public static final int TLV_TYPE_MACHINE_ID   = TLVPacket.TLV_META_TYPE_STRING | 460;
+    public static final int TLV_TYPE_UUID         = TLVPacket.TLV_META_TYPE_RAW    | 461;
+    public static final int TLV_TYPE_SESSION_GUID = TLVPacket.TLV_META_TYPE_RAW    | 462;
 
     public static final int TLV_TYPE_CIPHER_NAME = TLVPacket.TLV_META_TYPE_STRING | 500;
     public static final int TLV_TYPE_CIPHER_PARAMETERS = TLVPacket.TLV_META_TYPE_GROUP | 501;

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
@@ -21,6 +21,8 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand("core_loadlib", core_loadlib.class);
         mgr.registerCommand("core_set_uuid", core_set_uuid.class);
         mgr.registerCommand("core_machine_id", core_machine_id.class);
+        mgr.registerCommand("core_get_session_guid", core_get_session_guid.class);
+        mgr.registerCommand("core_set_session_guid", core_set_session_guid.class);
         mgr.registerCommand("core_patch_url", core_patch_url.class);
         mgr.registerCommand("core_shutdown", core_shutdown.class);
         mgr.registerCommand("core_transport_set_timeouts", core_transport_set_timeouts.class);

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_get_session_guid.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_get_session_guid.java
@@ -1,0 +1,15 @@
+package com.metasploit.meterpreter.core;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.Utils;
+import com.metasploit.meterpreter.command.Command;
+
+public class core_get_session_guid implements Command {
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        response.add(TLVType.TLV_TYPE_SESSION_GUID, meterpreter.getSessionGUID());
+        return ERROR_SUCCESS;
+    }
+}

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_set_session_guid.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_set_session_guid.java
@@ -1,0 +1,18 @@
+package com.metasploit.meterpreter.core;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.Utils;
+import com.metasploit.meterpreter.command.Command;
+
+public class core_set_session_guid implements Command {
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        byte[] newGuid = request.getRawValue(TLVType.TLV_TYPE_SESSION_GUID, null);
+        if (newGuid != null) {
+            meterpreter.setSessionGUID(newGuid);
+        }
+        return ERROR_SUCCESS;
+    }
+}

--- a/java/meterpreter/shared/src/main/java/com/metasploit/stage/ConfigParser.java
+++ b/java/meterpreter/shared/src/main/java/com/metasploit/stage/ConfigParser.java
@@ -5,6 +5,7 @@ import java.io.UnsupportedEncodingException;
 public class ConfigParser  {
 
     public static final int UUID_LEN = 16;
+    public static final int GUID_LEN = 16;
     public static final int URL_LEN = 512;
 
     public static final int UA_LEN = 256;

--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -32,7 +32,8 @@ if (!isset($GLOBALS['readers'])) {
 
 # global list of extension commands
 if (!isset($GLOBALS['commands'])) {
-    $GLOBALS['commands'] = array("core_loadlib", "core_machine_id", "core_set_uuid");
+    $GLOBALS['commands'] = array("core_loadlib", "core_machine_id", "core_set_uuid",
+        "core_set_session_guid", "core_get_session_guid");
 }
 
 function register_command($c) {
@@ -103,6 +104,7 @@ function socket_set_option($sock, $type, $opt, $value) {
 # Payload definitions
 #
 define("PAYLOAD_UUID", "");
+define("SESSION_GUID", "");
 
 #
 # Constants
@@ -178,6 +180,7 @@ define("TLV_TYPE_TARGET_PATH",         TLV_META_TYPE_STRING | 401);
 
 define("TLV_TYPE_MACHINE_ID",          TLV_META_TYPE_STRING | 460);
 define("TLV_TYPE_UUID",                TLV_META_TYPE_RAW    | 461);
+define("TLV_TYPE_SESSION_GUID",        TLV_META_TYPE_RAW    | 462);
 
 define("TLV_TYPE_CIPHER_NAME",         TLV_META_TYPE_STRING | 500);
 define("TLV_TYPE_CIPHER_PARAMETERS",   TLV_META_TYPE_GROUP  | 501);
@@ -460,6 +463,21 @@ function get_hdd_label() {
     }
   }
   return "";
+}
+
+function core_get_session_guid($req, &$pkt) {
+  packet_add_tlv($pkt, create_tlv(TLV_TYPE_SESSION_GUID, $GLOBALS['SESSION_GUID']));
+  return ERROR_SUCCESS;
+}
+
+function core_set_session_guid($req, &$pkt) {
+    my_print("doing core_set_session_guid");
+    $new_guid = packet_get_tlv($req, TLV_TYPE_SESSION_GUID);
+    if ($new_guid != null) {
+      $GLOBALS['SESSION_ID'] = $new_guid['value'];
+      my_print("New Session GUID is {$GLOBALS['SESSION_GUID']}");
+    }
+    return ERROR_SUCCESS;
 }
 
 function core_machine_id($req, &$pkt) {
@@ -1227,6 +1245,7 @@ error_reporting(0);
 # Add the payload UUID to globals, and use that from now on so that we can
 # update it as required.
 $GLOBALS['UUID'] = PAYLOAD_UUID;
+$GLOBALS['SESSION_GUID'] = SESSION_GUID;
 
 # If we don't have a socket we're standalone, setup the connection here.
 # Otherwise, this is a staged payload, don't bother connecting

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -64,6 +64,7 @@ HTTP_CONNECTION_URL = None
 HTTP_PROXY = None
 HTTP_USER_AGENT = None
 PAYLOAD_UUID = ''
+SESSION_GUID = ''
 SESSION_COMMUNICATION_TIMEOUT = 300
 SESSION_EXPIRATION_TIMEOUT = 604800
 SESSION_RETRY_TOTAL = 3600
@@ -157,6 +158,7 @@ TLV_TYPE_TRANS_GROUP           = TLV_META_TYPE_GROUP   | 441
 
 TLV_TYPE_MACHINE_ID            = TLV_META_TYPE_STRING  | 460
 TLV_TYPE_UUID                  = TLV_META_TYPE_RAW     | 461
+TLV_TYPE_SESSION_GUID          = TLV_META_TYPE_RAW     | 462
 
 TLV_TYPE_CIPHER_NAME           = TLV_META_TYPE_STRING  | 500
 TLV_TYPE_CIPHER_PARAMETERS     = TLV_META_TYPE_GROUP   | 501
@@ -902,6 +904,16 @@ class PythonMeterpreter(object):
 		for func_name in self.extension_functions.keys():
 			if func_name.split('_', 1)[0] == extension_name:
 				response += tlv_pack(TLV_TYPE_STRING, func_name)
+		return ERROR_SUCCESS, response
+
+	def _core_get_session_guid(self, request, response):
+		response += tlv_pack(TLV_TYPE_SESSION_GUID, SESSION_GUID)
+		return ERROR_SUCCESS, response
+
+	def _core_set_session_guid(self, request, response):
+		new_guid = packet_get_tlv(request, TLV_TYPE_SESSION_GUID)
+		if new_guid:
+			SESSION_GUID = new_guid['value']
 		return ERROR_SUCCESS, response
 
 	def _core_machine_id(self, request, response):


### PR DESCRIPTION
This is the associated payloads PR that goes with the MSF PR located here: https://github.com/rapid7/metasploit-framework/pull/8523

Full detail and motivation for this code change can be found in the MSF PR description.