### PR TITLE
Make active window tracking in keyscan subsystem discretionary

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/stdapi.c
+++ b/c/meterpreter/source/extensions/stdapi/server/stdapi.c
@@ -136,6 +136,7 @@ Command customCommands[] =
 	COMMAND_REQ("stdapi_ui_enable_keyboard", request_ui_enable_keyboard),
 	COMMAND_REQ("stdapi_ui_get_idle_time", request_ui_get_idle_time),
 	COMMAND_REQ("stdapi_ui_start_keyscan", request_ui_start_keyscan),
+	COMMAND_REQ("stdapi_ui_start_keyscan_actwin", request_ui_start_keyscan_actwin),
 	COMMAND_REQ("stdapi_ui_stop_keyscan", request_ui_stop_keyscan),
 	COMMAND_REQ("stdapi_ui_get_keys", request_ui_get_keys),
 	COMMAND_REQ("stdapi_ui_get_keys_utf8", request_ui_get_keys_utf8),

--- a/c/meterpreter/source/extensions/stdapi/server/ui/ui.h
+++ b/c/meterpreter/source/extensions/stdapi/server/ui/ui.h
@@ -8,6 +8,7 @@ DWORD request_ui_enable_mouse(Remote *remote, Packet *request);
 DWORD request_ui_get_idle_time(Remote *remote, Packet *request);
 
 DWORD request_ui_start_keyscan(Remote *remote, Packet *request);
+DWORD request_ui_start_keyscan_actwin(Remote *remote, Packet *request);
 DWORD request_ui_stop_keyscan(Remote *remote, Packet *request);
 DWORD request_ui_get_keys(Remote *remote, Packet *request);
 DWORD request_ui_get_keys_utf8(Remote *remote, Packet *request);


### PR DESCRIPTION
This update breaks out the active window tracking in the keyscan subsystem into a separate command.  It is no longer on by default, and `keyscan_start` will simply log keys as it did previously.  Users who want that functionality can still get it by use of the new command `keyscan_start_aw` (as in active window, the most concise albeit not so descriptive name I could think of).  I'll update with the associated framework PR when it's up.

EDIT: associated framework PR here ->>> https://github.com/rapid7/metasploit-framework/pull/8565