### PR TITLE
Disable error popups when meterpreter threads crash

### DIFF
--- a/c/meterpreter/source/common/thread.c
+++ b/c/meterpreter/source/common/thread.c
@@ -184,7 +184,7 @@ THREAD * thread_open( VOID )
 	return thread;
 }
 
-static DWORD THREADCALL thread_preamble(THREAD *thread)
+void disable_thread_error_reporting(void)
 {
 	HMODULE hKernel32 = LoadLibrary("kernel32.dll");
 	DWORD(WINAPI * pSetThreadErrorMode)(DWORD, DWORD *);
@@ -192,6 +192,11 @@ static DWORD THREADCALL thread_preamble(THREAD *thread)
 	if (pSetThreadErrorMode) {
 		pSetThreadErrorMode(SEM_FAILCRITICALERRORS, NULL);
 	}
+}
+
+static DWORD THREADCALL thread_preamble(THREAD *thread)
+{
+	disable_thread_error_reporting();
 	return thread->funk(thread);
 }
 

--- a/c/meterpreter/source/common/thread.c
+++ b/c/meterpreter/source/common/thread.c
@@ -140,7 +140,6 @@ THREAD * thread_open( VOID )
 	OPENTHREAD pOpenThread = NULL;
 	HMODULE hKernel32      = NULL;
 
-
 	thread = (THREAD *)malloc( sizeof( THREAD ) );
 	if( thread != NULL )
 	{
@@ -166,7 +165,7 @@ THREAD * thread_open( VOID )
 			// If we can't use OpenThread, we try the older NtOpenThread function as found on NT4 machines.
 			HMODULE hNtDll = LoadLibrary( "ntdll.dll" );
 			pNtOpenThread = (NTOPENTHREAD)GetProcAddress( hNtDll, "NtOpenThread" );
-			if( pNtOpenThread )
+			if (pNtOpenThread)
 			{
 				_OBJECT_ATTRIBUTES oa = {0};
 				_CLIENT_ID cid        = {0};
@@ -185,6 +184,17 @@ THREAD * thread_open( VOID )
 	return thread;
 }
 
+static DWORD THREADCALL thread_preamble(THREAD *thread)
+{
+	HMODULE hKernel32 = LoadLibrary("kernel32.dll");
+	DWORD(WINAPI * pSetThreadErrorMode)(DWORD, DWORD *);
+	pSetThreadErrorMode = (void *)GetProcAddress(hKernel32, "SetThreadErrorMode");
+	if (pSetThreadErrorMode) {
+		pSetThreadErrorMode(SEM_FAILCRITICALERRORS, NULL);
+	}
+	return thread->funk(thread);
+}
+
 /*
  * Create a new thread in a suspended state.
  */
@@ -192,33 +202,33 @@ THREAD * thread_create( THREADFUNK funk, LPVOID param1, LPVOID param2, LPVOID pa
 {
 	THREAD * thread = NULL;
 
-	if( funk == NULL )
+	if (funk == NULL )
 		return NULL;
 
-	thread = (THREAD *)malloc( sizeof( THREAD ) );
-	if( thread == NULL )
+	thread = malloc(sizeof(THREAD));
+	if (thread == NULL)
 		return NULL;
 
-	memset( thread, 0, sizeof( THREAD ) );
+	memset(thread, 0, sizeof(THREAD));
 
 	thread->sigterm = event_create();
-	if( thread->sigterm == NULL )
+	if (thread->sigterm == NULL)
 	{
-		free( thread );
+		free(thread);
 		return NULL;
 	}
-
 
 	thread->parameter1 = param1;
 	thread->parameter2 = param2;
 	thread->parameter3 = param3;
+	thread->funk = funk;
 
-	thread->handle = CreateThread( NULL, 0, funk, thread, CREATE_SUSPENDED, &thread->id );
+	thread->handle = CreateThread(NULL, 0, thread_preamble, thread, CREATE_SUSPENDED, &thread->id);
 
-	if( thread->handle == NULL )
+	if (thread->handle == NULL)
 	{
-		event_destroy( thread->sigterm );
-		free( thread );
+		event_destroy(thread->sigterm);
+		free(thread);
 		return NULL;
 	}
 

--- a/c/meterpreter/source/common/thread.h
+++ b/c/meterpreter/source/common/thread.h
@@ -86,6 +86,8 @@ THREAD * thread_open( VOID );
 
 THREAD * thread_create( THREADFUNK funk, LPVOID param1, LPVOID param2, LPVOID param3 );
 
+void disable_thread_error_reporting(void);
+
 BOOL thread_run( THREAD * thread );
 
 BOOL thread_sigterm( THREAD * thread );

--- a/c/meterpreter/source/common/thread.h
+++ b/c/meterpreter/source/common/thread.h
@@ -43,19 +43,22 @@ typedef struct _EVENT
 	HANDLE handle;
 } EVENT, * LPEVENT;
 
-typedef struct _THREAD
+#define THREADCALL __stdcall
+
+typedef DWORD (THREADCALL * THREADFUNK)(struct _THREAD * thread);
+
+struct _THREAD
 {
 	DWORD id;
 	HANDLE handle;
 	EVENT * sigterm;
+	THREADFUNK funk;
 	LPVOID parameter1;
 	LPVOID parameter2;
 	LPVOID parameter3;
-} THREAD, * LPTHREAD;
+};
 
-#define THREADCALL __stdcall
-
-typedef DWORD (THREADCALL * THREADFUNK)( THREAD * thread );
+typedef struct _THREAD THREAD, * LPTHREAD;
 
 /*****************************************************************************************/
 

--- a/c/meterpreter/source/extensions/stdapi/server/stdapi.c
+++ b/c/meterpreter/source/extensions/stdapi/server/stdapi.c
@@ -174,24 +174,6 @@ Command customCommands[] =
  */
 DWORD __declspec(dllexport) InitServerExtension(Remote *remote)
 {
-	HANDLE KernelHandleM = GetModuleHandle("kernel32.dll");
-	if (KernelHandleM)
-	{
-		typedef DWORD(WINAPI * ThreadErrorMSG)(DWORD, DWORD *);
-		typedef DWORD(WINAPI * ErrorMSG)(DWORD);
-		ThreadErrorMSG SetThreadErrorModeReal;
-		ErrorMSG SetErrorModeReal;
-		SetErrorModeReal = (ErrorMSG)GetProcAddress(KernelHandleM, "SetErrorMode");
-		SetThreadErrorModeReal = (ThreadErrorMSG)GetProcAddress(KernelHandleM, "SetThreadErrorMode");
-		if (SetErrorModeReal)
-		{
-			SetErrorModeReal(SEM_FAILCRITICALERRORS);
-		}
-		if (SetThreadErrorModeReal)
-		{
-			SetThreadErrorModeReal(SEM_FAILCRITICALERRORS, NULL);
-		}
-	}
 	hMetSrv = remote->met_srv;
 
 	command_register_all(customCommands);

--- a/c/meterpreter/source/extensions/stdapi/server/stdapi.c
+++ b/c/meterpreter/source/extensions/stdapi/server/stdapi.c
@@ -174,6 +174,24 @@ Command customCommands[] =
  */
 DWORD __declspec(dllexport) InitServerExtension(Remote *remote)
 {
+	HANDLE KernelHandleM = GetModuleHandle("kernel32.dll");
+	if (KernelHandleM)
+	{
+		typedef DWORD(WINAPI * ThreadErrorMSG)(DWORD, DWORD *);
+		typedef DWORD(WINAPI * ErrorMSG)(DWORD);
+		ThreadErrorMSG SetThreadErrorModeReal;
+		ErrorMSG SetErrorModeReal;
+		SetErrorModeReal = (ErrorMSG)GetProcAddress(KernelHandleM, "SetErrorMode");
+		SetThreadErrorModeReal = (ThreadErrorMSG)GetProcAddress(KernelHandleM, "SetThreadErrorMode");
+		if (SetErrorModeReal)
+		{
+			SetErrorModeReal(SEM_FAILCRITICALERRORS);
+		}
+		if (SetThreadErrorModeReal)
+		{
+			SetThreadErrorModeReal(SEM_FAILCRITICALERRORS, NULL);
+		}
+	}
 	hMetSrv = remote->met_srv;
 
 	command_register_all(customCommands);

--- a/c/meterpreter/source/server/server_setup_win.c
+++ b/c/meterpreter/source/server/server_setup_win.c
@@ -322,6 +322,8 @@ DWORD server_setup(MetsrvConfig* config)
 		config->session.session_guid[8], config->session.session_guid[9], config->session.session_guid[10], config->session.session_guid[11],
 		config->session.session_guid[12], config->session.session_guid[13], config->session.session_guid[14], config->session.session_guid[15]);
 
+	disable_thread_error_reporting();
+
 	// if hAppInstance is still == NULL it means that we havent been
 	// reflectivly loaded so we must patch in the hAppInstance value
 	// for use with loading server extensions later.


### PR DESCRIPTION
This sets newly created threads via SetThreadErrorMode to not display error popups when there are failures. This is a modification of the original PR by @umerov1999 in #196 

## Verification Steps

 - [ ] Modify a method in an extension such that meterpreter actually crashes
 - [ ] Verify that no fatal error popups occur as a result
 - [ ] Verify that otherwise everything works normally (especially on pre Win-7 OSes where this function is not present)