### PR TITLE
Python Meterpreter OSX Railgun

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1900,7 +1900,7 @@ def stdapi_railgun_api(request, response):
 		errno = p_errno.contents
 		last_error = ctypes.c_int(0)
 		p_errno.contents = last_error
-		func = prototype((func_name, ctypes.CDLL(lib_name)))
+		func = prototype((func_name, ctypes.CDLL(ctypes.util.find_library(lib_name) or lib_name)))
 		result = func(*call_args)
 		p_errno.contents = errno
 		last_error = last_error.value

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -14,6 +14,7 @@ import time
 
 try:
 	import ctypes
+	import ctypes.util
 	has_ctypes = True
 	has_windll = hasattr(ctypes, 'windll')
 except ImportError:
@@ -69,10 +70,10 @@ else:
 	unicode = lambda x: (x.decode('UTF-8') if isinstance(x, bytes) else x)
 
 if has_ctypes:
+	size_t = getattr(ctypes, 'c_uint' + str(ctypes.sizeof(ctypes.c_void_p) * 8))
 	#
 	# Windows Structures
 	#
-	size_t = getattr(ctypes, 'c_uint' + str(ctypes.sizeof(ctypes.c_void_p) * 8))
 	class EVENTLOGRECORD(ctypes.Structure):
 		_fields_ = [("Length", ctypes.c_uint32),
 			("Reserved", ctypes.c_uint32),
@@ -1770,6 +1771,33 @@ def _linux_memwrite(address, data):
 		raise RuntimeError('operation failed')
 	return size
 
+def _osx_memread(address, size):
+	libc = ctypes.CDLL(ctypes.util.find_library('c'))
+	task = libc.mach_task_self()
+	libc.mach_vm_read.argtypes = [ctypes.c_uint32, size_t, size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_uint32)]
+	libc.mach_vm_read.restype = ctypes.c_uint32
+	pointer = ctypes.c_void_p()
+	out_size = ctypes.c_uint32()
+	result = libc.mach_vm_read(task, address, size, ctypes.byref(pointer), ctypes.byref(out_size))
+	if result == 1:  # KERN_INVALID_ADDRESS
+		raise RuntimeError('invalid address')
+	elif result == 2:  # KERN_PROTECTION_FAILURE
+		raise RuntimeError('invalid permissions')
+	if result != 0 or size != out_size.value:
+		raise RuntimeError('operation failed')
+	buff = ctypes.cast(pointer, ctypes.POINTER(ctypes.c_byte * out_size.value))
+	return ctarray_to_bytes(buff.contents)
+
+def _osx_memwrite(address, data):
+	libc = ctypes.CDLL(ctypes.util.find_library('c'))
+	task = libc.mach_task_self()
+	libc.mach_vm_write.argtypes = [ctypes.c_uint32, size_t, ctypes.c_void_p, ctypes.c_uint32]
+	libc.mach_vm_write.restype = ctypes.c_uint32
+	buff = bytes_to_ctarray(data)
+	if libc.mach_vm_write(task, address, buff, len(buff)) != 0:
+		raise RuntimeError('operation failed')
+	return len(buff)
+
 def _win_format_message(source, msg_id):
 	EN_US = 0
 	msg_flags = 0
@@ -1907,12 +1935,14 @@ def stdapi_railgun_api_multi(request, response):
 		response += tlv_pack(TLV_TYPE_RAILGUN_MULTI_GROUP, group_result)
 	return ERROR_SUCCESS, response
 
-@register_function_if(sys.platform.startswith('linux') or has_windll)
+@register_function_if(sys.platform == 'darwin' or sys.platform.startswith('linux') or has_windll)
 def stdapi_railgun_memread(request, response):
 	address = packet_get_tlv(request, TLV_TYPE_RAILGUN_MEM_ADDRESS)['value']
 	length = packet_get_tlv(request, TLV_TYPE_RAILGUN_MEM_LENGTH)['value']
 	debug_print('[*] railgun reading ' + str(length) + ' bytes from 0x' + hex(address))
-	if sys.platform.startswith('linux'):
+	if sys.platform.startswith('darwin'):
+		result = _osx_memread(address, length)
+	elif sys.platform.startswith('linux'):
 		result = _linux_memread(address, length)
 	elif has_windll:
 		result = _win_memread(address, length)
@@ -1923,13 +1953,15 @@ def stdapi_railgun_memread(request, response):
 	response += tlv_pack(TLV_TYPE_RAILGUN_MEM_DATA, result)
 	return ERROR_SUCCESS, response
 
-@register_function_if(sys.platform.startswith('linux') or has_windll)
+@register_function_if(sys.platform == 'darwin' or sys.platform.startswith('linux') or has_windll)
 def stdapi_railgun_memwrite(request, response):
 	address = packet_get_tlv(request, TLV_TYPE_RAILGUN_MEM_ADDRESS)['value']
 	data = packet_get_tlv(request, TLV_TYPE_RAILGUN_MEM_DATA)['value']
 	length = packet_get_tlv(request, TLV_TYPE_RAILGUN_MEM_LENGTH)['value']
 	debug_print('[*] railgun writing ' + str(len(data)) + ' bytes to 0x' + hex(address))
-	if sys.platform.startswith('linux'):
+	if sys.platform.startswith('darwin'):
+		result = _osx_memwrite(address, data)
+	elif sys.platform.startswith('linux'):
 		result = _linux_memwrite(address, data)
 	elif has_windll:
 		result = _win_memwrite(address, data)

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1839,7 +1839,7 @@ def _win_memwrite(address, data, handle=-1):
 		return None
 	return written.value
 
-@register_function_if(sys.platform.startswith('linux') or has_windll)
+@register_function_if(sys.platform == 'darwin' or sys.platform.startswith('linux') or has_windll)
 def stdapi_railgun_api(request, response):
 	size_out = packet_get_tlv(request, TLV_TYPE_RAILGUN_SIZE_OUT)['value']
 	stack_blob = packet_get_tlv(request, TLV_TYPE_RAILGUN_STACKBLOB)['value']
@@ -1891,8 +1891,11 @@ def stdapi_railgun_api(request, response):
 
 	debug_print('[*] railgun calling: ' + lib_name + '!' + func_name)
 	prototype = func_type(native, *func_args)
-	if sys.platform.startswith('linux'):
-		libc = ctypes.cdll.LoadLibrary('libc.so.6')
+	if sys.platform == 'darwin' or sys.platform.startswith('linux'):
+		if sys.platform == 'darwin':
+			libc = ctypes.CDLL(ctypes.util.find_library('c'))
+		else:
+			libc = ctypes.cdll.LoadLibrary('libc.so.6')
 		p_errno = ctypes.cast(libc.errno, ctypes.POINTER(ctypes.c_int))
 		errno = p_errno.contents
 		last_error = ctypes.c_int(0)
@@ -1928,7 +1931,7 @@ def stdapi_railgun_api(request, response):
 	response += tlv_pack(TLV_TYPE_RAILGUN_BACK_BUFFERBLOB_INOUT, ctarray_to_bytes(buff_blob_inout))
 	return ERROR_SUCCESS, response
 
-@register_function_if(sys.platform.startswith('linux') or has_windll)
+@register_function_if(sys.platform == 'darwin' or sys.platform.startswith('linux') or has_windll)
 def stdapi_railgun_api_multi(request, response):
 	for group_tlv in packet_enum_tlvs(request, tlv_type=TLV_TYPE_RAILGUN_MULTI_GROUP):
 		group_result = stdapi_railgun_api(group_tlv['value'], bytes())[1]

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -516,6 +516,8 @@ class Transport(object):
 		try:
 			pkt = self._get_packet()
 		except:
+			if DEBUGGING:
+				traceback.print_exc(file=sys.stderr)
 			return None
 		if pkt is None:
 			return None
@@ -529,6 +531,8 @@ class Transport(object):
 			raw = struct.pack('BBBB', *xor_key[::-1]) + xor_bytes(xor_key, pkt)
 			self._send_packet(raw)
 		except:
+			if DEBUGGING:
+				traceback.print_exc(file=sys.stderr)
 			return False
 		self.communication_last = time.time()
 		return True
@@ -684,7 +688,7 @@ class TcpTransport(Transport):
 		first = self._first_packet
 		self._first_packet = False
 		if not select.select([self.socket], [], [], 0.5)[0]:
-			return ''
+			return bytes()
 		packet = self.socket.recv(12)
 		if packet == '':  # remote is closed
 			self.request_retire = True

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -231,6 +231,13 @@ def debug_print(msg):
 		print(msg)
 
 @export
+def debug_traceback(msg=None):
+	if DEBUGGING:
+		if msg:
+			print(msg)
+		traceback.print_exc(file=sys.stderr)
+
+@export
 def error_result(exception=None):
 	if not exception:
 		_, exception, _ = sys.exc_info()
@@ -516,8 +523,7 @@ class Transport(object):
 		try:
 			pkt = self._get_packet()
 		except:
-			if DEBUGGING:
-				traceback.print_exc(file=sys.stderr)
+			debug_traceback()
 			return None
 		if pkt is None:
 			return None
@@ -531,8 +537,7 @@ class Transport(object):
 			raw = struct.pack('BBBB', *xor_key[::-1]) + xor_bytes(xor_key, pkt)
 			self._send_packet(raw)
 		except:
-			if DEBUGGING:
-				traceback.print_exc(file=sys.stderr)
+			debug_traceback()
 			return False
 		self.communication_last = time.time()
 		return True
@@ -1184,9 +1189,7 @@ class PythonMeterpreter(object):
 					return
 				result, resp = result
 			except Exception:
-				debug_print('[-] method ' + handler_name + ' resulted in an error')
-				if DEBUGGING:
-					traceback.print_exc(file=sys.stderr)
+				debug_traceback('[-] method ' + handler_name + ' resulted in an error')
 				result = error_result()
 			else:
 				if result != ERROR_SUCCESS:

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -60,6 +60,7 @@ random.seed()
 
 # these values will be patched, DO NOT CHANGE THEM
 DEBUGGING = False
+TRY_TO_FORK = True
 HTTP_CONNECTION_URL = None
 HTTP_PROXY = None
 HTTP_USER_AGENT = None
@@ -1196,7 +1197,8 @@ class PythonMeterpreter(object):
 		resp += tlv_pack(reqid_tlv)
 		return tlv_pack_response(result, resp)
 
-if not hasattr(os, 'fork') or (hasattr(os, 'fork') and os.fork() == 0):
+_try_to_fork = TRY_TO_FORK and hasattr(os, 'fork')
+if not _try_to_fork or (_try_to_fork and os.fork() == 0):
 	if hasattr(os, 'setsid'):
 		try:
 			os.setsid()


### PR DESCRIPTION
This PR adds support to the Python Meterpreter for making Railgun calls on the OSX platform. It also implements a few things to aid in debugging including the new `MeterpreterTryToFork` option, and a `debug_traceback` function.

I'll have testing steps included in the corresponding Metasploit PR that I will have opened momentarily.