### PR TITLE
winpmem fixes

### DIFF
--- a/c/meterpreter/source/extensions/winpmem/winpmem.h
+++ b/c/meterpreter/source/extensions/winpmem/winpmem.h
@@ -58,8 +58,8 @@ protected:
 	int extract_file_(__int64 resource_id, TCHAR *filename);
 	virtual __int64 write_coredump_header_(struct PmemMemoryInfo *info);
 
-	int pad(SIZE_T length);
-	int copy_memory(SIZE_T start, SIZE_T end);
+	int pad(uint64_t length);
+	int copy_memory(uint64_t start, uint64_t end);
 
 	// The file handle to the pmem device.
 	HANDLE fd_;
@@ -73,7 +73,7 @@ protected:
 	bool driver_is_tempfile_;
 
 	// This is the maximum size of memory calculated.
-	SIZE_T max_physical_memory_;
+	uint64_t max_physical_memory_;
 
 	// Current offset in output file (Total bytes written so far).
 	unsigned __int64 out_offset;

--- a/c/meterpreter/source/extensions/winpmem/winpmem_meterpreter.cpp
+++ b/c/meterpreter/source/extensions/winpmem/winpmem_meterpreter.cpp
@@ -1,3 +1,4 @@
+#define DEBUGTRACE 1
 extern "C"{
 	/*!
 	 * @file WINPMEM.cpp
@@ -100,7 +101,7 @@ HANDLE WinPmem_meterpreter::get_fd() {
 	return fd_;
 }
 
-SIZE_T WinPmem_meterpreter::get_max_physical_memory() {
+uint64_t WinPmem_meterpreter::get_max_physical_memory() {
 	return max_physical_memory_;
 }
 
@@ -216,7 +217,7 @@ DWORD dump_ram(Remote *remote, Packet *packet)
 		goto end;
 	};
 
-	//Initialize max_physical_memory_ when calling print_memory_info !!!!
+	// Initialize max_physical_memory_ when calling print_memory_info !!!!
 	pmem_handle->print_memory_info();
 
 	Channel *newChannel;
@@ -326,8 +327,8 @@ static DWORD winpmem_channel_read(Channel *channel, Packet *request,
 		dprintf("[WINPMEM] Memory end reached.");
 		return ERROR_SUCCESS;
 	}
+
 	if (ctx->pmem_info.Run[ctx->index].start > ctx->offset) {
-		//PADDING
 		uint64_t padding_size = ctx->pmem_info.Run[ctx->index].start - ctx->offset;
 		DWORD padding_size_max = (DWORD)min(padding_size, bufferSize);
 		ZeroMemory(buffer, padding_size_max);

--- a/c/meterpreter/source/extensions/winpmem/winpmem_meterpreter.h
+++ b/c/meterpreter/source/extensions/winpmem/winpmem_meterpreter.h
@@ -36,7 +36,7 @@ class WinPmem_meterpreter : public WinPmem {
 public:
 	virtual int extract_file_(__int64 resource_id, TCHAR *filename);
 	virtual HANDLE get_fd();
-	virtual SIZE_T get_max_physical_memory();
+	virtual uint64_t get_max_physical_memory();
 };
 
 class WinPmem_meterpreter32 : public WinPmem_meterpreter {


### PR DESCRIPTION
Use prefix for debug messages, 64-bit consistently for memory sizes and offsets. There is no real functional change, this just makes the code a bit better.

Fixes #218