### PR TITLE
support hidpi for screenshots

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/ui/desktop.c
+++ b/c/meterpreter/source/extensions/stdapi/server/ui/desktop.c
@@ -279,7 +279,7 @@ DWORD request_ui_desktop_set(Remote * remote, Packet * request)
 }
 
 /*
- * Worker thread for desktop screenshot. Creates a named pipe and reads in the 
+ * Worker thread for desktop screenshot. Creates a named pipe and reads in the
  * screenshot for the first client which connects to it.
  */
 DWORD THREADCALL desktop_screenshot_thread(THREAD * thread)


### PR DESCRIPTION
This is one of @wwebb-r7's patches that we've had off to the side for a while. It adds support for taking full screenshots from HiDPI screens. Today, if you do that, you only get 1/4th of the screen. Instead this scales the image appropriately.

There are bigger improvements in the pipe to use DX where available, which will even allow streaming video, but this is a good intermediate step.

Random note: I heard from @mubix recently that the screen grab function in the `espia` module works better in some cases that the one built into stdapi. I'm curious to understand why so we can just have one screenshot function that works, rather than two that only half work.