### PR TITLE
fix Android config parsing

### DIFF
--- a/java/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -74,6 +74,10 @@ public class Payload {
         csr += 4;
         byte[] uuid = ConfigParser.readBytes(configBytes, csr, ConfigParser.UUID_LEN);
         csr += ConfigParser.UUID_LEN;
+
+        byte[] sessionGUID = ConfigParser.readBytes(configBytes, csr, ConfigParser.GUID_LEN);
+        csr += ConfigParser.GUID_LEN;
+
         String url = ConfigParser.readString(configBytes, csr, ConfigParser.URL_LEN);
         csr += ConfigParser.URL_LEN;
         commTimeout = ConfigParser.unpack32(configBytes, csr);


### PR DESCRIPTION
Apologies guys. I didn't test the Android payload after the session GUID change came in:
This fixes https://github.com/rapid7/metasploit-framework/pull/8523
This fix ensures the config is parsed correctly and fixes Android payloads generated from the latest MSF version.