### PR TITLE
Fix android/java offset for config parsing

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Meterpreter.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Meterpreter.java
@@ -48,9 +48,9 @@ public class Meterpreter {
 
     protected void loadConfiguration(DataInputStream in, OutputStream rawOut, byte[] configuration) throws MalformedURLException {
 
-        // socket handle is 4 bytes, followed by exit func, both of
+        // socket handle is 8 bytes, followed by exit func, both of
         // which we ignore.
-        int csr = 8;
+        int csr = 12;
 
         // We start with the expiry, which is a 32 bit int
         setExpiry(ConfigParser.unpack32(configuration, csr));
@@ -83,7 +83,7 @@ public class Meterpreter {
             }
             this.transports.add(t);
         }
-        
+
         // we don't currently support extensions, so when we reach the end of the
         // list of transports we just bomb out.
     }

--- a/java/meterpreter/shared/src/main/java/com/metasploit/stage/ConfigParser.java
+++ b/java/meterpreter/shared/src/main/java/com/metasploit/stage/ConfigParser.java
@@ -39,4 +39,11 @@ public class ConfigParser  {
         return res;
     }
 
+    public static long unpack64(byte[] bytes, int offset) {
+        long res = 0;
+        for (int i = 0; i < 8; i++) {
+          res = res | (((long)bytes[i + offset]) & 0xFF) << (i * 8);
+        }
+        return res;
+    }
 }


### PR DESCRIPTION
Because android and windows meterpreter use the same config blob, size changes in one affect the other. This adds the extra 4 bytes needed to store the named pipe config to the Java parser, fixing https://github.com/rapid7/metasploit-framework/issues/8938