### PR TITLE
fix java/android process_execute with escaped arguments

### DIFF
--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_execute_V1_3.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_execute_V1_3.java
@@ -3,8 +3,14 @@ package com.metasploit.meterpreter.stdapi;
 import java.io.IOException;
 
 public class stdapi_sys_process_execute_V1_3 extends stdapi_sys_process_execute {
-    protected Process execute(String[] cmdarray) throws IOException {
-        Process proc = Runtime.getRuntime().exec(cmdarray, null, Loader.cwd);
-        return proc;
+
+    @Override
+    protected Process execute(String cmdstr) throws IOException {
+        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+            return super.execute(cmdstr);
+        }
+        Process process = Runtime.getRuntime().exec(new String[]{"sh", "-c", cmdstr}, null, Loader.cwd);
+        return process;
     }
+
 }


### PR DESCRIPTION
The easiest way to test this is to run something like:
`cmd_exec("sh -c 'echo test'");`
Previously this would fail, but now it should return 'test'.
Another side effect of this is that when you do `meterpreter > shell` you end up in the correct directory :)