### PR TITLE
fix record_mic TLV values

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/webcam/audio.h
+++ b/c/meterpreter/source/extensions/stdapi/server/webcam/audio.h
@@ -7,13 +7,13 @@
 		MAKE_CUSTOM_TLV(					\
 				TLV_META_TYPE_UINT,			\
 				TLV_TYPE_EXTENSION_AUDIO,	\
-				TLV_EXTENSIONS + 1)
+				TLV_EXTENSIONS + 10)
 
 #define TLV_TYPE_AUDIO_DATA					\
 		MAKE_CUSTOM_TLV(					\
 				TLV_META_TYPE_RAW,			\
 				TLV_TYPE_EXTENSION_AUDIO,	\
-				TLV_EXTENSIONS + 2)
+				TLV_EXTENSIONS + 11)
 
 DWORD request_ui_record_mic(Remote *remote, Packet *request);
 

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/webcam_audio_record_android.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/webcam_audio_record_android.java
@@ -20,8 +20,8 @@ public class webcam_audio_record_android extends webcam_audio_record implements 
     private static final int AUDIO_CHANNEL_ENCODING = AudioFormat.ENCODING_PCM_16BIT;
 
     private static final int TLV_EXTENSIONS = 20000;
-    private static final int TLV_TYPE_AUDIO_DURATION = TLVPacket.TLV_META_TYPE_UINT | (TLV_EXTENSIONS + 1);
-    private static final int TLV_TYPE_AUDIO_DATA = TLVPacket.TLV_META_TYPE_RAW | (TLV_EXTENSIONS + 2);
+    private static final int TLV_TYPE_AUDIO_DURATION = TLVPacket.TLV_META_TYPE_UINT | (TLV_EXTENSIONS + 10);
+    private static final int TLV_TYPE_AUDIO_DATA = TLVPacket.TLV_META_TYPE_RAW | (TLV_EXTENSIONS + 11);
 
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
We changed the TLV values when adding listen_mic.
This fixes the Android and Windows implementation (I've only tested Android though). 