### PR TITLE
on reconnect to a new framework instance, we have to renegotiate AES

### DIFF
--- a/c/meterpreter/source/common/packet_encryption.c
+++ b/c/meterpreter/source/common/packet_encryption.c
@@ -485,9 +485,7 @@ DWORD request_negotiate_aes_key(Remote* remote, Packet* packet)
 	{
 		if (remote->enc_ctx != NULL)
 		{
-			dprintf("[ENC] context already created.");
-			// Done this before, so don't do it again.
-			break;
+			free_encryption_context(remote);
 		}
 
 		remote->enc_ctx = (PacketEncryptionContext*)calloc(1, sizeof(PacketEncryptionContext));


### PR DESCRIPTION
Currently, if we receive a new key renegotiate request, the system ignores it. However, if we do that, and we restart framework, framework currently forgets the AES keys it was previously using for the session, and can no longer interact with the session again, as per https://github.com/rapid7/metasploit-framework/issues/9175 and what I hinted at seeing in https://github.com/rapid7/metasploit-payloads/pull/250

When @swimminshell and I were the only ones seeing this, maybe we were the only ones restarting framework entirely between tests? This fixes it for me, though it's useless for MitM (though crypttlv never really was good for this, so not really an issue).

Steps to verify:

 * [x] Build with this PR
 * [x] Start an HTTP/HTTPS handler on metasploit-framework: `msfconsole -qx 'use exploit/multi/handler; set payload windows/meterpreter/reverse_https; set lhost 192.168.56.1; run'`
 * [x] Stage a new reverse_http/s session
 * [x] Background and run `exit -y`
 * [x] Start the handler again from scratch
 * [x] Observe failure to interact beyond the initial crypttlv negotiation is now fixed