### PR TITLE
delete deps repo submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "source/ReflectiveDLLInjection"]
 	path = c/meterpreter/source/ReflectiveDLLInjection
 	url = https://github.com/rapid7/ReflectiveDLLInjection.git
-[submodule "deps"]
-	path = c/meterpreter/deps
-	url = https://github.com/rapid7/meterpreter-deps
 [submodule "c/meterpreter/source/extensions/kiwi/mimikatz"]
 	path = c/meterpreter/source/extensions/kiwi/mimikatz
 	url = https://github.com/rapid7/mimikatz


### PR DESCRIPTION
As we did in the mettle repo, this PR deletes the 'deps' repo. While checking in tarballs into an external repo feels kind of neat, it doesn't really provide a practical advantage, and just creates roadblocks to contributors. Future deps should just be checked right into the tree, like we did with python for instance, or downloaded from an external source.