### PR TITLE
fix reliability for PHP packet dispatch

### DIFF
--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -1136,10 +1136,9 @@ function read($resource, $len=null) {
             $md = stream_get_meta_data($resource);
             dump_array($md, "Metadata for {$resource}");
             if ($md['unread_bytes'] > 0) {
-                $buff .= fread($resource, $md['unread_bytes']);
+                $buff .= fread($resource, min($len, $md['unread_bytes']));
                 break;
             } else {
-                #$len = 1;
                 $tmp = fread($resource, $len);
                 $buff .= $tmp;
                 if (strlen($tmp) < $len) {
@@ -1150,7 +1149,7 @@ function read($resource, $len=null) {
             if ($resource != $msgsock) { my_print("buff: '$buff'"); }
             $r = Array($resource);
         }
-        my_print(sprintf("Done with the big read loop on $resource, got %d bytes", strlen($buff)));
+        my_print(sprintf("Done with the big read loop on $resource, got %d bytes, asked for %d bytes", strlen($buff), $len));
         break;
     default:
         # then this is possibly a closed channel resource, see if we have any
@@ -1364,7 +1363,7 @@ while (false !== ($cnt = select($r, $w, $e, $t))) {
         $ready = $r[$i];
         if ($ready == $msgsock) {
             $packet = read($msgsock, 32);
-            #my_print(sprintf("Read returned %s bytes", strlen($request)));
+            my_print(sprintf("Read returned %s bytes", strlen($packet)));
             if (false==$packet) {
                 my_print("Read failed on main socket, bailing");
                 # We failed on the main socket.  There's no way to continue, so
@@ -1374,7 +1373,7 @@ while (false !== ($cnt = select($r, $w, $e, $t))) {
             $xor = substr($packet, 0, 4);
             $header = xor_bytes($xor, substr($packet, 4, 28));
             $len_array = unpack("Nlen", substr($header, 20, 4));
-            # length of the packet should be the packet header size 
+            # length of the packet should be the packet header size
             # minus 8 for the tlv length + the required data length
             $len = $len_array['len'] + 32 - 8;
             # packet type should always be 0, i.e. PACKET_TYPE_REQUEST


### PR DESCRIPTION
A bug in the read function would cause a too-large read when there are multiple packets or other things in the control channel. This would cause the subsequent packet to fail to parse, leading to the current message getting discarded.

This fixes the bug in https://github.com/rapid7/metasploit-framework/issues/8722 but also probably many other PHP meterpreter reliability issues, since the bug was in the core read() function.

## Verification Steps

Follow original issue steps to reproduce.