### PR TITLE
Remove erroneously copied path check

### DIFF
--- a/gem/lib/metasploit-payloads.rb
+++ b/gem/lib/metasploit-payloads.rb
@@ -26,7 +26,7 @@ module MetasploitPayloads
     # each time. We only do this is MSF is installed.
     extra_paths.each do |extra_path|
       if ::File.readable? extra_path
-        warn_local_path(extra_path) if ::File.readable? gem_path
+        warn_local_path(extra_path)
         return extra_path
       end
     end


### PR DESCRIPTION
This lets the local file warning fire off correctly.

- [ ] Copy `metsrv.*.dll` to `~/.msf4/payloads/meterpreter`
- [ ] Configure `multi/handler` to use a Windows Meterpreter
- [ ] See the local file warning