### PR TITLE
Fix python meterpreter> shell on Solaris 11.1

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1,4 +1,3 @@
-# vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab
 import fnmatch
 import getpass
 import os

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -987,9 +987,12 @@ def stdapi_sys_process_execute(request, response):
         if has_pty:
             master, slave = pty.openpty()
             if has_termios:
-                settings = termios.tcgetattr(master)
-                settings[3] = settings[3] & ~termios.ECHO
-                termios.tcsetattr(master, termios.TCSADRAIN, settings)
+                try:
+                    settings = termios.tcgetattr(master)
+                    settings[3] = settings[3] & ~termios.ECHO
+                    termios.tcsetattr(master, termios.TCSADRAIN, settings)
+                except:
+                    pass
             proc_h = STDProcess(args, stdin=slave, stdout=slave, stderr=slave, bufsize=0)
             proc_h.stdin = os.fdopen(master, 'wb')
             proc_h.stdout = os.fdopen(master, 'rb')

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab
 import binascii
 import code
 import os


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/9497
I'll include details on that ticket.
I've also removed `noexpandtab` because we're using spaces now.