### PR TITLE
disable javapayload ShellTest

### DIFF
--- a/java/javapayload/src/test/java/javapayload/stage/ShellTest.java
+++ b/java/javapayload/src/test/java/javapayload/stage/ShellTest.java
@@ -21,7 +21,7 @@ public class ShellTest extends TestCase {
             timeout -= 100;
         }
         String shellOutput = new String(out.toByteArray(), "ISO-8859-1");
-        Assert.assertTrue("MagicToken missing in shell output: " + shellOutput, shellOutput.contains("MagicToken"));
-        Assert.assertEquals(-1, in.read());
+//        Assert.assertTrue("MagicToken missing in shell output: " + shellOutput, shellOutput.contains("MagicToken"));
+//        Assert.assertEquals(-1, in.read());
     }
 }


### PR DESCRIPTION
I could never figure out why this test fails intermittently, I think it's best we disable it in order to avoid confusing contributors.
https://github.com/rapid7/metasploit-payloads/pull/287