### PR TITLE
audio output for windows meterpreter

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/audio/audio.h
+++ b/c/meterpreter/source/extensions/stdapi/server/audio/audio.h
@@ -1,0 +1,11 @@
+#ifndef _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_AUDIO_AUDIO_H
+#define _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_AUDIO_AUDIO_H
+
+#include <stdint.h>
+
+/*
+ * Channel allocation
+ */
+DWORD request_audio_output_channel_open(Remote *remote, Packet *packet);
+
+#endif

--- a/c/meterpreter/source/extensions/stdapi/server/audio/output.c
+++ b/c/meterpreter/source/extensions/stdapi/server/audio/output.c
@@ -1,0 +1,118 @@
+#include "precomp.h"
+
+#include <sys/stat.h>
+
+/***************************
+ * Audio Channel Operations *
+ ***************************/
+
+typedef struct
+{
+	size_t size;
+	void* buffer;
+} AudioContext;
+
+/*
+ * Writes the supplied data to the audio buffer
+ */
+static DWORD audio_channel_write(Channel *channel, Packet *request,
+		LPVOID context, LPVOID buffer, DWORD bufferSize,
+		LPDWORD bytesWritten)
+{
+	AudioContext *ctx = (AudioContext *)context;
+	DWORD result = ERROR_SUCCESS;
+	size_t written = 0;
+
+	// Write the entire buffer
+	if (bufferSize) {
+		if (!(ctx->buffer = calloc(1, bufferSize))) {
+			result = ERROR_NOT_ENOUGH_MEMORY;
+		} else {
+			memcpy(ctx->buffer, buffer, bufferSize);
+			written = bufferSize;
+		}
+	}
+
+	if (bytesWritten) {
+		*bytesWritten = (DWORD)written;
+	}
+
+	return result;
+}
+
+/*
+ * Play the audio on channel close
+ */
+static DWORD audio_channel_close(Channel *channel, Packet *request,
+		LPVOID context)
+{
+	AudioContext *ctx = (AudioContext *)context;
+
+	// Play the audio buffer
+	sndPlaySound(ctx->buffer, SND_SYNC | SND_MEMORY);
+
+	if (ctx->buffer) {
+		free(ctx->buffer);
+		ctx->buffer = 0;
+	}
+	free(ctx);
+
+	return ERROR_SUCCESS;
+}
+
+
+/*
+ * Handles the open request for a audio channel and returns a valid channel
+ */
+DWORD request_audio_output_channel_open(Remote *remote, Packet *packet)
+{
+	Packet *response = NULL;
+	DWORD res = ERROR_SUCCESS;
+	DWORD flags = 0;
+	PoolChannelOps chops = { 0 };
+	AudioContext *ctx;
+	Channel *newChannel = NULL;
+
+	// Allocate a response
+	response = packet_create_response(packet);
+
+	// Allocate storage for the audio buffer context
+	if (!(ctx = calloc(1, sizeof(AudioContext)))) {
+		res = ERROR_NOT_ENOUGH_MEMORY;
+		goto out;
+	}
+
+	// Get the channel flags
+	flags = packet_get_tlv_value_uint(packet, TLV_TYPE_FLAGS);
+
+	memset(&chops, 0, sizeof(chops));
+
+	// Initialize the pool operation handlers
+	chops.native.context = ctx;
+	chops.native.write   = audio_channel_write;
+	chops.native.close   = audio_channel_close;
+
+	// Check the response allocation & allocate a un-connected
+	// channel
+	if ((!response) || (!(newChannel = channel_create_pool(0, flags, &chops)))) {
+		res = ERROR_NOT_ENOUGH_MEMORY;
+		goto out;
+	}
+
+	// Add the channel identifier to the response
+	packet_add_tlv_uint(response, TLV_TYPE_CHANNEL_ID, channel_get_id(newChannel));
+
+out:
+	// Transmit the packet if it's valid
+	packet_transmit_response(res, remote, response);
+
+	// Clean up on failure
+	if (res != ERROR_SUCCESS) {
+		if (newChannel) {
+			channel_destroy(newChannel, NULL);
+		}
+	}
+
+	return res;
+}
+

--- a/c/meterpreter/source/extensions/stdapi/server/general.c
+++ b/c/meterpreter/source/extensions/stdapi/server/general.c
@@ -1,5 +1,6 @@
 #include "precomp.h"
 
+extern DWORD request_audio_output_channel_open(Remote *remote, Packet *packet);
 extern DWORD request_net_tcp_client_channel_open(Remote *remote, Packet *packet);
 extern DWORD request_net_tcp_server_channel_open(Remote *remote, Packet *packet);
 extern DWORD request_net_udp_channel_open(Remote *remote, Packet *packet);
@@ -12,6 +13,7 @@ struct
 } channel_open_handlers[] =
 {
 	{ "stdapi_fs_file",        request_fs_file_channel_open        },
+	{ "audio_output",          request_audio_output_channel_open   },
 	{ "stdapi_net_tcp_client", request_net_tcp_client_channel_open },
 	{ "stdapi_net_tcp_server", request_net_tcp_server_channel_open },
 	{ "stdapi_net_udp_client", request_net_udp_channel_open        },

--- a/c/meterpreter/source/extensions/stdapi/server/precomp.h
+++ b/c/meterpreter/source/extensions/stdapi/server/precomp.h
@@ -9,6 +9,7 @@
 #include <iphlpapi.h>
 #include "resource/resource.h"
 
+#include "audio/audio.h"
 #include "fs/fs.h"
 #include "sys/sys.h"
 #include "net/net.h"

--- a/c/meterpreter/workspace/ext_server_stdapi/ext_server_stdapi.vcxproj
+++ b/c/meterpreter/workspace/ext_server_stdapi/ext_server_stdapi.vcxproj
@@ -327,6 +327,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(PlatformSho
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\source\extensions\stdapi\server\audio\output.c" />
     <ClCompile Include="..\..\source\extensions\stdapi\server\fs\mount_win.c" />
     <ClCompile Include="..\..\source\extensions\stdapi\server\general.c" />
     <ClCompile Include="..\..\source\extensions\stdapi\server\net\config\arp.c" />
@@ -391,6 +392,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(PlatformSho
     <ClInclude Include="..\..\source\extensions\stdapi\server\webcam\audio.h" />
     <ClInclude Include="..\..\source\extensions\stdapi\server\webcam\bmp2jpeg.h" />
     <ClInclude Include="..\..\source\extensions\stdapi\server\webcam\webcam.h" />
+    <ClInclude Include="..\..\source\extensions\stdapi\server\audio\audio.h" />
     <ClInclude Include="..\..\source\extensions\stdapi\server\fs\fs.h" />
     <ClInclude Include="..\..\source\extensions\stdapi\server\fs\fs_local.h" />
     <ClInclude Include="..\..\source\extensions\stdapi\server\fs\search.h" />


### PR DESCRIPTION
This change implements the `meterpreter > play` audio command for Windows (thanks @DeveloppSoft!)
I'm not 100% convinced it's bug free
e.g:
what if channel.write is called multiple times? shouldn't it stream/realloc into the buffer?
also perhaps SND_SYNC might be more appropriate?
That said, it's working so I thought I'd PR early for feedback.