### PR TITLE
Fix packet pivoting in HTTP transports

### DIFF
--- a/c/meterpreter/source/common/base.c
+++ b/c/meterpreter/source/common/base.c
@@ -458,7 +458,8 @@ BOOL command_handle(Remote *remote, Packet *packet)
 		baseCommand = command_locate_base(lpMethod);
 		extensionCommand = command_locate_extension(lpMethod);
 
-		if (baseCommand == NULL && extensionCommand == NULL) {
+		if (baseCommand == NULL && extensionCommand == NULL)
+		{
 			dprintf("[DISPATCH] Command not found: %s", lpMethod);
 			// We have no matching command for this packet, so it won't get handled. We
 			// need to send an empty response and clean up here before exiting out.

--- a/c/meterpreter/source/server/win/server_transport_tcp.c
+++ b/c/meterpreter/source/server/win/server_transport_tcp.c
@@ -539,7 +539,7 @@ static DWORD server_dispatch_tcp(Remote* remote, THREAD* dispatchThread)
 
 			if (packet == NULL)
 			{
-				dprintf("[DISPATCH] No packet received, probably just metsrv being ignored");
+				dprintf("[DISPATCH] No packet received, probably just metsrv being ignored or a pivot packet being handled.");
 			}
 			else
 			{


### PR DESCRIPTION
Windows Meterpreter that uses http/s-based transports wasn't correctly checking for cases where pivoted packets were handled. When pivoted packets are forwarded to the correct handler, the packet is set to NULL. For TCP transports, a check already existed to carry on when the packet was NULL, but this wasn't the case for HTTP/S.

This commit fixes this problem and so the pivot session no longer dies when Meterpreter is using an HTTP/S transport.

For funzies, the fix for this was implemented on a live stream to help other people learn some of Meterp's internals. That video can be found here: https://www.youtube.com/watch?v=de-UYWnafow

This fixes https://github.com/rapid7/metasploit-framework/issues/9903

## Verification

- [ ] Create a Windows x86 meterpreter sessions over HTTP.
- [ ] Create a pivot listener using the `pivot add` command.
- [ ] Create a matching `reverse_named_pipe` pivot payload.
- [ ] Launch the pivot payload, verify a pivoted session comes back.
- [ ] Validate that neither pivot session not pivoted session crash.
- [ ] Make sure all commands work through both sessions.

- [ ] Do the above for HTTPS, x64 and TCP as well.