### PR TITLE
Update kiwi to match Mimikatz 2.1.1 (TBAL)

### DIFF
--- a/c/meterpreter/workspace/ext_server_kiwi/ext_server_kiwi.vcxproj
+++ b/c/meterpreter/workspace/ext_server_kiwi/ext_server_kiwi.vcxproj
@@ -342,6 +342,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(PlatformSho
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_chrome.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_creds.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_keys.c" />
+    <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_ssh.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_wlan.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\kerberos\kuhl_m_kerberos.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\kerberos\kuhl_m_kerberos_ccache.c" />
@@ -442,6 +443,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(PlatformSho
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_chrome.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_creds.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_keys.h" />
+    <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_ssh.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_wlan.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\kerberos\kuhl_m_kerberos.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\kerberos\kuhl_m_kerberos_ccache.h" />

--- a/c/meterpreter/workspace/ext_server_kiwi/ext_server_kiwi.vcxproj.filters
+++ b/c/meterpreter/workspace/ext_server_kiwi/ext_server_kiwi.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\kull_m_cabinet.c">
       <Filter>common modules</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_ssh.c">
+      <Filter>local modules\dpapi\packages</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\source\extensions\kiwi\main.h" />
@@ -522,6 +525,9 @@
     </ClInclude>
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\modules\kull_m_cabinet.h">
       <Filter>common modules</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\dpapi\packages\kuhl_m_dpapi_ssh.h">
+      <Filter>local modules\dpapi\packages</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR just updates the source for the `kiwi` extension so that it has the most up to date Mimikatz source as of today (2.1.1 TBAL -- off the back of the defcon work from @gentilkiwi).

I haven't exposed any new features in MSF yet, that may come down the track. For now, the updated source itself should be a good start.