### PR TITLE
fix various peinjector extension issues.

### DIFF
--- a/c/meterpreter/source/extensions/peinjector/libpeinfect.c
+++ b/c/meterpreter/source/extensions/peinjector/libpeinfect.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include "libpeinfect.h"
 #include "libpeinfect_obfuscator.h"
+#include "../../common/common.h"
 
  /* Min/Max Macros */
 #define MIN(_a, _b) ((_a) < (_b) ? (_a) : (_b))
@@ -251,7 +252,7 @@ static  int __peinfect_infect_alignment(PEINFECT *in, unsigned char *payload, si
 					}
 
 					/* Infect OK */
-					return i + 1;
+					return (int)i + 1;
 				}
 			}
 		}
@@ -317,7 +318,7 @@ static  int __peinfect_infect_alignment_resize(PEINFECT *in, unsigned char *payl
 				old_rawsize = out->section_header[i].SizeOfRawData;
 
 				/* New Space needed */
-				rawsize_delta = payloadsize - (old_rawsize - old_virtsize);
+				rawsize_delta = (uint32_t)(payloadsize - (old_rawsize - old_virtsize));
 
 				/* Save helper data for patch */
 				if (helper != NULL) {
@@ -349,7 +350,7 @@ static  int __peinfect_infect_alignment_resize(PEINFECT *in, unsigned char *payl
 					}
 
 					/* Infect OK */
-					return i + 1;
+					return (int)i + 1;
 				}
 			}
 		}
@@ -523,7 +524,7 @@ void peinfect_init(PEINFECT *out) {
 	memset(out, 0, sizeof(PEINFECT));
 
 	/* For the glory of beelzebub and random section names */
-	srand(time(NULL));
+	srand((uint32_t)time(NULL));
 
 	/* Allow all methods, except METHOD_CROSS_SECTION_JUMP */
 	out->methods = METHOD_NEW_SECTION; //METHOD_ALL & ~METHOD_CROSS_SECTION_JUMP; //VERIFY THIS
@@ -755,9 +756,9 @@ bool peinfect_infect_full_file(char *infile, PEINFECT *in, char *outfile) {
 	PEFILE pefile;
 
 	/* Open file */
-	FILE *fh = fopen(infile, "rb");
-
-	if (fh != NULL) {
+	FILE *fh;
+	wchar_t *file_w = utf8_to_wchar(infile);
+	if (_wfopen_s(&fh, file_w, L"rb") == 0) {
 
 		/* Get file size and allocate buffer */
 		if (!fseek(fh, 0L, SEEK_END)) {
@@ -792,6 +793,7 @@ bool peinfect_infect_full_file(char *infile, PEINFECT *in, char *outfile) {
 			fclose(fh);
 		}
 	}
+	free(file_w);
 
 	return returnVar;
 }

--- a/c/meterpreter/source/extensions/peinjector/libpeinfect_obfuscator.c
+++ b/c/meterpreter/source/extensions/peinjector/libpeinfect_obfuscator.c
@@ -187,7 +187,7 @@ bool add_garbage) {
   shellcode->entrys++;
 
   /* Return entry index */
-  return shellcode->entrys - 1;
+  return (int)shellcode->entrys - 1;
 }
 
 /* Add shellcode jmp/loop/call */
@@ -221,7 +221,7 @@ static  int __peinfector_obfuscator_shellcode_add_generic_jmp(SHELLCODE *shellco
   shellcode->entrys++;
 
   /* Return entry index */
-  return shellcode->entrys - 1;
+  return (int)shellcode->entrys - 1;
 }
 
 /* Add JMP Entry*/
@@ -262,7 +262,7 @@ static  int __peinfector_obfuscator_shellcode_get_jmp_pos(SHELLCODE *shellcode, 
     }
   }
 
-  return pos;
+  return (int)pos;
 }
 
 /* Calculates delta between 2 entrys (end entry 1 -> start entry 2) */
@@ -299,7 +299,7 @@ static  int __peinfector_obfuscator_shellcode_find_delta(SHELLCODE *shellcode, u
   }
 
   /* Return delta position */
-  return pos_2 - pos_1;
+  return (int)pos_2 - (int)pos_1;
 }
 
 static  void __peinfector_obfuscator_build_relative_jmp(unsigned char *shellcode, uint32_t pos, OPCODE opcode,
@@ -358,7 +358,7 @@ static  unsigned char* __peinfector_obfuscator_shellcode_generate(SHELLCODE *she
   }
 
   /* Jump to 0 entry */
-  jmp_delta = __peinfector_obfuscator_shellcode_find_delta(shellcode, *size, -1, 0);
+  jmp_delta = __peinfector_obfuscator_shellcode_find_delta(shellcode, (uint32_t)*size, -1, 0);
   __peinfector_obfuscator_build_relative_jmp(shellcode_buf, 0, OP_JMP, jmp_delta);
   pos = 2;
 
@@ -369,20 +369,20 @@ static  unsigned char* __peinfector_obfuscator_shellcode_generate(SHELLCODE *she
     if (shellcode->entry[i].garbage != NULL) {
       memcpy(shellcode_buf + pos, shellcode->entry[i].garbage, shellcode->entry[i].garbagesize);
     }
-    pos += shellcode->entry[i].garbagesize;
+    pos += (uint32_t)shellcode->entry[i].garbagesize;
 
     /* Write shellcode data */
     if (shellcode->entry[i].code != NULL) {
       memcpy(shellcode_buf + pos, shellcode->entry[i].code, shellcode->entry[i].codesize);
     }
-    pos += shellcode->entry[i].codesize + 2;
+    pos += (uint32_t)shellcode->entry[i].codesize + 2;
 
     /* Write jmps */
     /* Position of jmp cmd */
-    jmp_pos = __peinfector_obfuscator_shellcode_get_jmp_pos(shellcode, shellcode->entry[i].index);
+    jmp_pos = __peinfector_obfuscator_shellcode_get_jmp_pos(shellcode, (int)shellcode->entry[i].index);
     /* Difference to next entry */
-    jmp_delta = __peinfector_obfuscator_shellcode_find_delta(shellcode, *size, shellcode->entry[i].index,
-        shellcode->entry[i].target);
+    jmp_delta = __peinfector_obfuscator_shellcode_find_delta(shellcode, (uint32_t)*size, (int)shellcode->entry[i].index,
+        (int)shellcode->entry[i].target);
 
     switch (shellcode->entry[i].type) {
       case TYPE_CMD:
@@ -391,8 +391,8 @@ static  unsigned char* __peinfector_obfuscator_shellcode_generate(SHELLCODE *she
         break;
       case TYPE_LOOP:
         __peinfector_obfuscator_build_relative_jmp(shellcode_buf, jmp_pos, OP_LOOP, jmp_delta - 2);
-        jmp_delta = __peinfector_obfuscator_shellcode_find_delta(shellcode, *size, shellcode->entry[i].index,
-            shellcode->entry[i].index + 1);
+        jmp_delta = __peinfector_obfuscator_shellcode_find_delta(shellcode, (uint32_t)*size, (int)shellcode->entry[i].index,
+            (int)shellcode->entry[i].index + 1);
         __peinfector_obfuscator_build_relative_jmp(shellcode_buf, jmp_pos + 2, OP_JMP, jmp_delta);
         break;
       case TYPE_CALL:

--- a/c/meterpreter/source/extensions/peinjector/libpetool.c
+++ b/c/meterpreter/source/extensions/peinjector/libpetool.c
@@ -57,7 +57,7 @@ static  void __petool_adjust_optional_header(PEFILE *out) {
   /* Align SizeOfImage to Section Alignment */
   sizeofimage = __petool_align(
       out->section_header[out->pe_header.NumberOfSections - 1].VirtualAddress
-          + out->section_header[out->pe_header.NumberOfSections - 1].Misc.VirtualSize, section_alignment);
+          + out->section_header[out->pe_header.NumberOfSections - 1].Misc.VirtualSize, (uint32_t)section_alignment);
 
   /* Write new values into required fields */
   if (is_32_bit) {
@@ -108,18 +108,18 @@ static  bool __petool_increase_header_padding(size_t size, PEFILE *out) {
   /* Fix SizeOfHeaders */
   if (out->optional_header_32.Magic == NT_OPTIONAL_32_MAGIC) {
     if (out->optional_header_32.SizeOfHeaders < (header_raw_end + out->header_padding.memsize)) {
-      out->optional_header_32.SizeOfHeaders = header_raw_end + out->header_padding.memsize;
+      out->optional_header_32.SizeOfHeaders = (uint32_t)(header_raw_end + out->header_padding.memsize);
     }
   } else if (out->optional_header_64.Magic == NT_OPTIONAL_64_MAGIC) {
     if (out->optional_header_64.SizeOfHeaders < (header_raw_end + out->header_padding.memsize)) {
-      out->optional_header_64.SizeOfHeaders = header_raw_end + out->header_padding.memsize;
+      out->optional_header_64.SizeOfHeaders = (uint32_t)(header_raw_end + out->header_padding.memsize);
     }
   }
 
   /* Fix section positions */
   if ((out->pe_header.NumberOfSections > 0) && (out->section_header != NULL)) {
     for (i = 0; i < out->pe_header.NumberOfSections; ++i) {
-      out->section_header[i].PointerToRawData += size;
+      out->section_header[i].PointerToRawData += (uint32_t)size;
     }
   }
 
@@ -182,7 +182,7 @@ bool petool_resize_section(size_t section_index, size_t new_raw_size, size_t new
   }
 
   /* New Virtual Size */
-  out->section_header[section_index].Misc.VirtualSize = new_virtual_size;
+  out->section_header[section_index].Misc.VirtualSize = (uint32_t)new_virtual_size;
 
   /* Only needed if RawSize was changed */
   if (raw_change) {
@@ -203,17 +203,17 @@ bool petool_resize_section(size_t section_index, size_t new_raw_size, size_t new
     }
 
     /* Align new raw size */
-    new_raw_size = __petool_align(new_raw_size, file_alignment);
+    new_raw_size = __petool_align((uint32_t)new_raw_size, (uint32_t)file_alignment);
 
     /* Set new RawSize */
-    out->section_header[section_index].SizeOfRawData = new_raw_size;
+    out->section_header[section_index].SizeOfRawData = (uint32_t)new_raw_size;
 
     /* Get Size difference  */
     if (new_raw_size > old_raw_size) {
-      diff = new_raw_size - old_raw_size;
+      diff = (uint32_t)(new_raw_size - old_raw_size);
       shrink = false;
     } else {
-      diff = old_raw_size - new_raw_size;
+      diff = (uint32_t)(old_raw_size - new_raw_size);
       shrink = true;
     }
 
@@ -341,8 +341,8 @@ bool header_only, PEFILE *out) {
   }
 
   /* Calculate padded raw size & relative virtual address */
-  section_memsize = __petool_align(memsize, file_alignment);
-  section_rva = __petool_align(last_section_rva + last_section_virtualsize, section_alignment);
+  section_memsize = __petool_align((uint32_t)memsize, (uint32_t)file_alignment);
+  section_rva = __petool_align((uint32_t)(last_section_rva + last_section_virtualsize), (uint32_t)section_alignment);
 
   /* Header only, don't modify data */
   if (!header_only) {
@@ -369,11 +369,11 @@ bool header_only, PEFILE *out) {
 
   /* New Section Header */
   memset(&out->section_header[out->pe_header.NumberOfSections - 1], 0, sizeof(SECTION_HEADER));
-  out->section_header[out->pe_header.NumberOfSections - 1].PointerToRawData = section_raw_pointer;
-  out->section_header[out->pe_header.NumberOfSections - 1].SizeOfRawData = section_memsize;
-  out->section_header[out->pe_header.NumberOfSections - 1].VirtualAddress = section_rva;
-  out->section_header[out->pe_header.NumberOfSections - 1].Misc.VirtualSize = memsize;
-  out->section_header[out->pe_header.NumberOfSections - 1].Characteristics = characteristics;
+  out->section_header[out->pe_header.NumberOfSections - 1].PointerToRawData = (uint32_t)section_raw_pointer;
+  out->section_header[out->pe_header.NumberOfSections - 1].SizeOfRawData = (uint32_t)section_memsize;
+  out->section_header[out->pe_header.NumberOfSections - 1].VirtualAddress = (uint32_t)section_rva;
+  out->section_header[out->pe_header.NumberOfSections - 1].Misc.VirtualSize = (uint32_t)memsize;
+  out->section_header[out->pe_header.NumberOfSections - 1].Characteristics = (uint32_t)characteristics;
   if (name != NULL) {
     memcpy(out->section_header[out->pe_header.NumberOfSections - 1].Name, name, MIN(NT_SHORT_NAME_LEN, namesize));
   }

--- a/c/meterpreter/source/extensions/peinjector/libpetool.c
+++ b/c/meterpreter/source/extensions/peinjector/libpetool.c
@@ -141,7 +141,7 @@ bool petool_resize_section(size_t section_index, size_t new_raw_size, size_t new
   bool shrink = false;
   bool raw_change = false;
   unsigned char *newmem = NULL;
-  int i = 0;
+  uint32_t i = 0;
 
   /* Default values (PE COFF Specification) */
   size_t file_alignment = NT_FILE_ALIGNMENT;

--- a/c/meterpreter/workspace/ext_server_peinjector/ext_server_peinjector.vcxproj
+++ b/c/meterpreter/workspace/ext_server_peinjector/ext_server_peinjector.vcxproj
@@ -259,7 +259,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(PlatformSho
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>
       <MapFileName>$(OutDir)\ext_server_peinjector.map</MapFileName>
-      <SubSystem>NotSet</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <OptimizeReferences>
       </OptimizeReferences>
       <EnableCOMDATFolding>


### PR DESCRIPTION
64-bit compilation had a number of warnings / errors. Added Unicode support for file path. Fixed the r7_release build.

These are all needed to produce a fully-working metasploit-payloads gem with peinjector enabled.