### PR TITLE
Fix issue about REG_MULTI_SZ.

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
@@ -463,6 +463,7 @@ static void set_value(Remote *remote, Packet *packet, HKEY hkey)
 		switch (valueType) {
 			case REG_SZ:
 			case REG_EXPAND_SZ:
+			case REG_MULTI_SZ:
 				buf = utf8_to_wchar(valueData.buffer);
 				len = (wcslen(buf) + 1) * sizeof(wchar_t);
 				break;


### PR DESCRIPTION
Fix https://github.com/rapid7/metasploit-framework/issues/10859 

The `REG_MULTI_SZ` type is the same as `REG_EXPAND_SZ` and `REG_SZ`, should be converted by `utf8_to_wchar`

## Before fix

```
meterpreter > reg setval -k HKCU\\Software\\Mozilla\\Firefox -t REG_MULTI_SZ -v "asddsad" -d 'string\0string2\0'
Successfully set asdd of REG_MULTI_SZ.
```

On victim side we got this:
![image](https://user-images.githubusercontent.com/22535454/47985709-7b0fdc80-e115-11e8-835a-9dd5edbcea32.png)

### After fix

```
meterpreter > reg setval -k HKCU\\Software\\Mozilla\\Firefox -t REG_MULTI_SZ -v "testforit" -d 'string\0string2\0sadd\0asdsaasdsa\0\0asdsasadasqweq'
Successfully set testforit of REG_MULTI_SZ.
```

On victim side we got this:

![image](https://user-images.githubusercontent.com/22535454/48887730-503ebb80-ee6b-11e8-9e57-57ac899eada0.png)

