### PR TITLE
subtle search(a meterpreter command) patch

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/fs/search.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/search.c
@@ -759,7 +759,7 @@ DWORD search(WDS_INTERFACE * pWDSInterface, wchar_t *directory, SEARCH_OPTIONS *
 DWORD search_all_drives(WDS_INTERFACE *pWDSInterface, SEARCH_OPTIONS *options, Packet *pResponse) //!!! VOID -> DWORD
 {
 	DWORD dwLogicalDrives = GetLogicalDrives();
-	DWORD dwResult = ERROR_ACCESS_DENIED;
+	DWORD dwResult;
 	for (wchar_t index = L'a'; index <= L'z'; index++)
 	{
 		if (dwLogicalDrives & (1 << (index-L'a')))
@@ -839,7 +839,7 @@ DWORD request_fs_search(Remote * pRemote, Packet * pPacket)
 
 	if (!options.rootDirectory)
 	{
-		DWORD dwResult = ERROR_ACCESS_DENIED;
+		DWORD dwResult;
 		dwResult = search_all_drives(&WDSInterface, &options, pResponse);
 		if (dwResult != ERROR_SUCCESS)
 		{
@@ -849,9 +849,6 @@ DWORD request_fs_search(Remote * pRemote, Packet * pPacket)
 		{
 			dwResult = wds3_search(&WDSInterface, L"mapi", NULL, &options, pResponse);
 		}
-		/*search_all_drives(&WDSInterface, &options, pResponse); 
-		wds3_search(&WDSInterface, L"iehistory", NULL, &options, pResponse);
-		wds3_search(&WDSInterface, L"mapi", NULL, &options, pResponse);*/
 	}
 	else
 	{

--- a/c/meterpreter/source/extensions/stdapi/server/fs/search.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/search.c
@@ -318,7 +318,6 @@ HRESULT wds_execute(ICommand * pCommand, Packet * pResponse)
 					directory = L"";
 					fileName  = directory;
 				}
-
 				search_add_result(pResponse, directory, fileName, rowSearchResults.dwSizeValue);
 			}
 
@@ -757,10 +756,10 @@ DWORD search(WDS_INTERFACE * pWDSInterface, wchar_t *directory, SEARCH_OPTIONS *
 	return dwResult;
 }
 
-VOID search_all_drives(WDS_INTERFACE *pWDSInterface, SEARCH_OPTIONS *options, Packet *pResponse)
+DWORD search_all_drives(WDS_INTERFACE *pWDSInterface, SEARCH_OPTIONS *options, Packet *pResponse) //!!! VOID -> DWORD
 {
 	DWORD dwLogicalDrives = GetLogicalDrives();
-
+	DWORD dwResult = ERROR_ACCESS_DENIED;
 	for (wchar_t index = L'a'; index <= L'z'; index++)
 	{
 		if (dwLogicalDrives & (1 << (index-L'a')))
@@ -775,16 +774,17 @@ VOID search_all_drives(WDS_INTERFACE *pWDSInterface, SEARCH_OPTIONS *options, Pa
 			if (dwType == DRIVE_FIXED || dwType == DRIVE_REMOTE)
 			{
 				options->rootDirectory = drive;
-
+				
 				dprintf("[SEARCH] request_fs_search. Searching drive %S (type=%d)...",
 					options->rootDirectory, dwType);
 
-				search(pWDSInterface, NULL, options, pResponse);
+				dwResult = search(pWDSInterface, NULL, options, pResponse);
 			}
 		}
 	}
 
 	options->rootDirectory = NULL;
+	return dwResult;
 }
 
 /*
@@ -839,9 +839,19 @@ DWORD request_fs_search(Remote * pRemote, Packet * pPacket)
 
 	if (!options.rootDirectory)
 	{
-		search_all_drives(&WDSInterface, &options, pResponse);
+		DWORD dwResult = ERROR_ACCESS_DENIED;
+		dwResult = search_all_drives(&WDSInterface, &options, pResponse);
+		if (dwResult != ERROR_SUCCESS)
+		{
+			dwResult = wds3_search(&WDSInterface, L"iehistory", NULL, &options, pResponse);
+		}
+		if (dwResult != ERROR_SUCCESS)
+		{
+			dwResult = wds3_search(&WDSInterface, L"mapi", NULL, &options, pResponse);
+		}
+		/*search_all_drives(&WDSInterface, &options, pResponse); 
 		wds3_search(&WDSInterface, L"iehistory", NULL, &options, pResponse);
-		wds3_search(&WDSInterface, L"mapi", NULL, &options, pResponse);
+		wds3_search(&WDSInterface, L"mapi", NULL, &options, pResponse);*/
 	}
 	else
 	{


### PR DESCRIPTION
A few days ago I did several tests with meterpreters' commands. I found a "search" command bug connected with Windows OS. In general, if a user doesn't specify the starting directory (key -d) then files, located in Desktop, are shown several times. I've patched the source code (search.c), so, from now, it should work fine. Examples before and after patch are shown below. 
Before: 
![image](https://user-images.githubusercontent.com/45002685/48430070-8307f600-e77f-11e8-88d3-52fc264886ca.png)
![image](https://user-images.githubusercontent.com/45002685/48430078-869b7d00-e77f-11e8-96ec-c395b6be7df1.png)
So, C:\Users\IEUser\Desktop\shell3.exe repeats 3 times.
After: 
![image](https://user-images.githubusercontent.com/45002685/48430048-771c3400-e77f-11e8-94c8-9f039d5f6ff1.png)
Extra files were kicked and the amount of files were reduced by 2.