### PR TITLE
lock surefire plugin version

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,6 +18,12 @@
 			<version>3.8.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-surefire-plugin</artifactId>
+			<version>2.22.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
This locks the surefire plugin to a 2.x stream until eval of update to 3.x.