### PR TITLE
Fix #318, Close Process Streams

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -455,6 +455,12 @@ class MeterpreterProcess(MeterpreterChannel):
 
     def close(self):
         self.proc_h.kill()
+        if hasattr(self.proc_h.stdin, 'close'):
+            self.proc_h.stdin.close()
+        if hasattr(self.proc_h.stdout, 'close'):
+            self.proc_h.stdout.close()
+        if hasattr(self.proc_h.stderr, 'close'):
+            self.proc_h.stderr.close()
 
     def is_alive(self):
         return self.proc_h.poll() is None


### PR DESCRIPTION
This *should* fix #318, I hope. Unfortunately I do not have an OS X system to test on so I'm hoping someone can help me out with that.

The proposed solution is to check if stdin, stdout, and stderr each have a `.close()` method when `MeterpreterProcess.close()` is called.

The issue should be reproducible by running `get_users` on an OS X system with a large number of users.

CC @busterb 