### PR TITLE
Typecast values to prevent incompatibilities in packing them

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -665,15 +665,9 @@ def get_stat_buffer(path):
     rdev = 0
     if hasattr(si, 'st_rdev'):
         rdev = si.st_rdev
-    blksize = 0
-    if hasattr(si, 'st_blksize'):
-        blksize = si.st_blksize
-    blocks = 0
-    if hasattr(si, 'st_blocks'):
-        blocks = si.st_blocks
-    st_buf = struct.pack('<III', si.st_dev, si.st_mode, si.st_nlink)
-    st_buf += struct.pack('<IIIQ', si.st_uid, si.st_gid, rdev, si.st_ino)
-    st_buf += struct.pack('<QQQQ', si.st_size, si.st_atime, si.st_mtime, si.st_ctime)
+    st_buf = struct.pack('<III', int(si.st_dev), int(si.st_mode), int(si.st_nlink))
+    st_buf += struct.pack('<IIIQ', int(si.st_uid), int(si.st_gid), int(rdev), long(si.st_ino))
+    st_buf += struct.pack('<QQQQ', long(si.st_size), long(si.st_atime), long(si.st_mtime), long(si.st_ctime))
     return st_buf
 
 def get_token_user(handle):

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -337,7 +337,7 @@ def packet_enum_tlvs(pkt, tlv_type=None):
                 pass
             yield {'type': tlv[1], 'length': tlv[0], 'value': val}
         offset += tlv[0]
-    raise StopIteration()
+    return
 
 @export
 def packet_get_tlv(pkt, tlv_type):


### PR DESCRIPTION
The automated testing system failed after the ls update from https://github.com/rapid7/metasploit-payloads/pull/322

This only failed on some versions of Python.  After some digging, I think this is because there are inconsistencies in the `os.stat` object members based on python version.  On python 2.7.15x86, the `st_size` value is a long, but on version 3.4.4x64, the `st_size` is an int.  Casting all the data to the expected values (given those values are large enough for no truncating to take place) seems to be the best way to prevent problems from cropping up in the future.

I also removed the block size bits that were no longer sent.  I think the sending was removed because no one was receiving them.

FWIW, I found this regression using python 3.4.4 on Windows 10x64 release 1511.

# Bad
![image](https://user-images.githubusercontent.com/17987018/52579384-a9bfe200-2deb-11e9-91cd-074723c45e54.png)

# Good
![image](https://user-images.githubusercontent.com/17987018/52579424-bb08ee80-2deb-11e9-83b9-68ca898d5dbf.png)

