### PR TITLE
fix java/android cmd_exec and shell_command_token

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Channel.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Channel.java
@@ -66,13 +66,13 @@ public class Channel {
      * @param maxLength The maximum number of bytes to read.
      * @return The bytes read, or <code>null</code> if the end of the stream has been reached.
      */
-    public synchronized byte[] read(int maxLength) throws IOException, InterruptedException {
+    public synchronized byte[] read(int maxLength) {
         if (closed)
             return null;
         if (active)
             throw new IllegalStateException("Cannot read; currently interacting with this channel");
-        while (!waiting || (toRead != null && toRead.length == 0))
-            wait();
+        if (!waiting || (toRead != null && toRead.length == 0))
+            return new byte[0];
         if (toRead == null)
             return null;
         byte[] result = new byte[Math.min(toRead.length, maxLength)];

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
@@ -49,6 +49,7 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand("stdapi_sys_config_sysinfo", stdapi_sys_config_sysinfo.class);
         mgr.registerCommand("stdapi_sys_config_localtime", stdapi_sys_config_localtime.class);
         mgr.registerCommand("stdapi_sys_process_execute", stdapi_sys_process_execute.class, V1_2, V1_3);
+        mgr.registerCommand("stdapi_sys_process_close", stdapi_sys_process_close.class);
         mgr.registerCommand("stdapi_sys_process_get_processes", stdapi_sys_process_get_processes.class, V1_2);
         mgr.registerCommand("stdapi_ui_desktop_screenshot", stdapi_ui_desktop_screenshot.class, V1_4);
         mgr.registerCommand("webcam_audio_record", webcam_audio_record.class, V1_4);

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_close.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_close.java
@@ -1,0 +1,15 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.metasploit.meterpreter.*;
+import com.metasploit.meterpreter.command.Command;
+
+public class stdapi_sys_process_close implements Command {
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        long handle = request.getLongValue(TLVType.TLV_TYPE_HANDLE);
+        Channel channel = meterpreter.getChannel((int)handle, false);
+        if (channel instanceof ProcessChannel) {
+            channel.close();
+        }
+        return ERROR_SUCCESS;
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_execute.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_execute.java
@@ -22,6 +22,7 @@ public class stdapi_sys_process_execute implements Command {
 
         cmdbuf.append(cmd);
         if (argsString.length() > 0) {
+            cmdbuf.append(" ");
             cmdbuf.append(argsString);
         }
 


### PR DESCRIPTION
This change fixes a race condition in the cmd_exec tests and https://github.com/rapid7/metasploit-framework/issues/11530
Maybe @schierlm can comment as the logic in Channel.java is pretty complex.

Verification:
```
loadpath test/modules/
use post/test/cmd_exec 
set SESSION -1
run
```