### PR TITLE
Maven deploy.path is a relative path, not absolute

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -61,10 +61,11 @@ disabled).
 
 If the path to your metasploit framework repository is not
 `../../metasploit-framework`, but for example
-`/opt/metasploit-framework/framework`, set the deploy.path directive like so:
+`/usr/share/metasploit-framework/` (Kali default), set the deploy.path directive like so
+(make sure to include enough "../" as deploy.path is relative and not absolute):
 
 ```
-mvn -D deploy.path=/opt/metasploit-framework/framework -P deploy package
+mvn -D deploy.path=../../../../../../../../../usr/share/metasploit-framework/ -P deploy package
 ```
 
 When you are editing this or any other Meterpreter, you will want to make sure


### PR DESCRIPTION
Having many "../" in the example is not very elegant, but I think this change is less risky than editing the pom.xml of all modules :)

Proof that deploy.path is relative:
https://github.com/rapid7/metasploit-payloads/blob/56d784c525934363c1fd5a1e97773c6300829db6/java/javapayload/pom.xml#L38

I tested it on Kali, and the Java payloads were copied to the right destination folder.

Before the patch:
```console
# mvn -DskipTests -Ddeploy.path=/usr/share/metasploit-framework clean -P deploy package
[...]
[INFO] --- maven-antrun-plugin:1.7:run (default) @ Metasploit-JavaPayload ---
[INFO] Executing tasks

main:
     [copy] Copying 14 files to /root/tools/metasploit-payloads/java/usr/share/metasploit-framework/data/java
[...]
# ls /usr/share/metasploit-framework/data/java/
ls: cannot access '/usr/share/metasploit-framework/data/java/': No such file or directory
```

With the patch:
```console
# mvn -DskipTests -Ddeploy.path=../../../../../../../../../usr/share/metasploit-framework/ clean -P deploy package
[...]
[INFO] --- maven-antrun-plugin:1.7:run (default) @ Metasploit-JavaPayload ---
[INFO] Executing tasks

main:
     [copy] Copying 14 files to /root/tools/metasploit-payloads/java/javapayload/../../../../../../../../../../usr/share/metasploit-framework/data/java
[...]
# ls /usr/share/metasploit-framework/data/java/
com  javapayload  metasploit
```