### PR TITLE
[common.lib] Add CMake makefile and fixes for clang compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+**/.vscode

--- a/c/meterpreter/.gitignore
+++ b/c/meterpreter/.gitignore
@@ -52,4 +52,10 @@ docs/*
 
 # ignore CLion files
 .idea/
-CMakeLists.txt
+
+# ignore CMake build artifacts
+**/CMakeCache.txt
+**/CMakeFiles/*
+**/cmake_install.cmake
+**/Makefile
+**/CMakeBuild/*

--- a/c/meterpreter/source/DelayLoadMetSrv/DelayLoadMetSrv.h
+++ b/c/meterpreter/source/DelayLoadMetSrv/DelayLoadMetSrv.h
@@ -30,10 +30,11 @@
 //===============================================================================================//
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <Delayimp.h>
+#include <delayimp.h>
 
+#ifndef __MINGW32__
 #pragma comment (lib,"Delayimp.lib")
-
+#endif 
 // we use this like a macro to set the hook in an server extension that requires it
 #define EnableDelayLoadMetSrv() PfnDliHook __pfnDliNotifyHook2 = delayHook; // set our delay loader hook, see DelayLoadMetSrv.c
 

--- a/c/meterpreter/source/common/arch/win/i386/base_inject.c
+++ b/c/meterpreter/source/common/arch/win/i386/base_inject.c
@@ -2,7 +2,7 @@
 #include "base_inject.h"
 #include "../remote_thread.h"
 #include "./../../../../ReflectiveDLLInjection/inject/src/LoadLibraryR.h"
-#include <Tlhelp32.h>
+#include <tlhelp32.h>
 
 // Simple trick to get the current meterpreters arch
 #ifdef _WIN64

--- a/c/meterpreter/source/common/common.h
+++ b/c/meterpreter/source/common/common.h
@@ -8,6 +8,12 @@
 /*! @brief Set to 0 for "normal", and 1 to "verbose", comment out to disable completely. */
 //#define DEBUGTRACE 0
 
+#ifdef __MINGW32__
+#define ERROR_UNSUPPORTED_COMPRESSION 22
+#define __try
+#define __except(x) if(0)
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>

--- a/c/meterpreter/source/common/packet_encryption.h
+++ b/c/meterpreter/source/common/packet_encryption.h
@@ -1,7 +1,7 @@
 #ifndef _METERPRETER_SOURCE_COMMON_PACKET_ENCRYPTION_H
 #define _METERPRETER_SOURCE_COMMON_PACKET_ENCRYPTION_H
 
-#include <Windows.h>
+#include <windows.h>
 
 #define AES256_BLOCKSIZE 16
 #define ENC_FLAG_NONE   0x0

--- a/c/meterpreter/workspace/ReflectiveDLLInjection/CMakeLists.txt
+++ b/c/meterpreter/workspace/ReflectiveDLLInjection/CMakeLists.txt
@@ -1,0 +1,134 @@
+cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+
+################### Variables. ####################
+# Change if you want modify path or other values. #
+###################################################
+
+set(PROJECT_NAME ReflectiveDLLInjection)
+# Output Variables
+set(OUTPUT_DEBUG ../../output/Debug/)
+set(OUTPUT_RELEASE ../../../output/Release/)
+# Folders files
+
+set(CPP_DIR_1 ../../source/ReflectiveDLLInjection/inject/src)
+set(CPP_DIR_2 ../../source/DelayLoadMetSrv)
+set(CPP_DIR_3 ../../source/ReflectiveDLLInjection/dll/src)
+set(HEADER_DIR_1 ../../source/ReflectiveDLLInjection/common)
+set(HEADER_DIR_2 ../../source/ReflectiveDLLInjection/inject/src)
+set(HEADER_DIR_3 ../../source/DelayLoadMetSrv)
+set(HEADER_DIR_4 ../../source/ReflectiveDLLInjection/dll/src)
+set(HEADER_DIR_5 ../../source/common/)
+############## CMake Project ################
+#        The main options of project        #
+#############################################
+
+project(${PROJECT_NAME} C)
+
+# Define Release by default.
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
+  message(STATUS "Build type not specified: Use Release by default.")
+endif(NOT CMAKE_BUILD_TYPE)
+
+# Definition of Macros
+add_definitions(
+   -D__GNUC__
+   -D_DEBUG 
+   -D_LIB 
+   -DUNICODE
+   -D_UNICODE
+)
+
+############## Artefacts Output #################
+# Defines outputs , depending Debug or Release. #
+#################################################
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
+  set(CMAKE_EXECUTABLE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
+else()
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+  set(CMAKE_EXECUTABLE_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+endif()
+
+################### Dependencies ##################
+# Add Dependencies to project.                    #
+###################################################
+
+option(BUILD_DEPENDS 
+   "Build other CMake project." 
+   OFF 
+)
+
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+# Dependencies : disable BUILD_DEPENDS to link with lib already build.
+if(BUILD_DEPENDS)
+   #add_subdirectory(platform/cmake/backcompat ${CMAKE_BINARY_DIR}/backcompat)
+else()
+   link_directories(../backcompat/Release/)
+endif()
+
+################# Flags ################
+# Defines Flags for Windows and Linux. #
+########################################
+SET(CMAKE_SYSTEM_NAME Windows)
+include(CMakeForceCompiler)
+IF("${GNU_HOST}" STREQUAL "")
+    SET(GNU_HOST x86_64-w64-mingw32)
+ENDIF()
+# Prefix detection only works with compiler id "GNU"
+#CMAKE_FORCE_C_COMPILER(${GNU_HOST}-gcc GNU)
+# CMake doesn't automatically look for prefixed 'windres', do it manually:
+SET(CMAKE_RC_COMPILER ${GNU_HOST}-windres)
+set( _MSC_VER 1910 )
+SET(CMAKE_C_COMPILER clang)
+if(MSVC)
+   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /W3 /Od /EHsc")
+   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /EHsc")
+endif(MSVC)
+if(NOT MSVC)
+set(CMAKE_LIBRARY_ARCHITECTURE x64 CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target x86_64-w64-windows-gnu -I/usr/x86_64-w64-mingw32/include/ -L/usr/lib/gcc/x86_64-w64-mingw32/8.2.0/include/ -L/usr/x86_64-w64-mingw32/lib -Wfatal-errors -fmsc-version=${_MSC_VER} -fms-extensions -fms-compatibility -fdelayed-template-parsing ")
+    
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I/usr/x86_64-w64-mingw32/include/ -std=c++11")
+   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+       set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+   endif()
+endif(NOT MSVC)
+
+################ Files ################
+#   --   Add files to project.   --   #
+#######################################
+
+file(GLOB SRC_FILES
+    ${CPP_DIR_1}/*.c
+    ${CPP_DIR_2}/*.c
+    ${CPP_DIR_3}/*.c
+    ${HEADER_DIR_1}/*.h
+    ${HEADER_DIR_2}/*.h
+    ${HEADER_DIR_3}/*.h
+    ${HEADER_DIR_4}/*.h
+)
+
+include_directories( ${HEADER_DIR_1} )
+include_directories( ${HEADER_DIR_2} )
+include_directories( ${HEADER_DIR_3} )
+include_directories( ${HEADER_DIR_4} )
+include_directories( ${HEADER_DIR_5} )
+
+#include_directories("/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/include/c++/parallel/")
+#include_directories("/usr/include/x86_64-linux-gnu/")
+
+# Add library to build.
+add_library(${PROJECT_NAME} STATIC
+   ${SRC_FILES}
+)
+
+# Link with other dependencies.
+target_link_libraries(${PROJECT_NAME} backcompat )
+if(MSVC)
+   target_link_libraries(${PROJECT_NAME} backcompat.lib )
+endif(MSVC)

--- a/c/meterpreter/workspace/common/CMakeLists.txt
+++ b/c/meterpreter/workspace/common/CMakeLists.txt
@@ -1,0 +1,137 @@
+cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+
+################### Variables. ####################
+# Change if you want modify path or other values. #
+###################################################
+
+set(PROJECT_NAME common)
+# Output Variables
+set(OUTPUT_DEBUG ../../../output/Debug/)
+set(OUTPUT_RELEASE ../../../output/Release/)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_RELEASE})
+# Folders files
+set(CPP_DIR_1 ../../source/common/arch/win)
+set(CPP_DIR_2 ../../source/common)
+set(CPP_DIR_3 ../../source/common/arch/win/i386)
+set(CPP_DIR_4 ../../source/common/zlib)
+set(HEADER_DIR_1 ../../source/common/arch/win)
+set(HEADER_DIR_2 ../../source/common)
+set(HEADER_DIR_3 ../../source/common/arch/win/i386)
+set(HEADER_DIR_4 ../../source/common/zlib)
+set(HEADER_DIR_5 ../../source/ReflectiveDLLInjection/common)
+
+############## CMake Project ################
+#        The main options of project        #
+#############################################
+
+project(${PROJECT_NAME} C)
+
+# Define Release by default.
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
+  message(STATUS "Build type not specified: Use Release by default.")
+endif(NOT CMAKE_BUILD_TYPE)
+
+# Definition of Macros
+add_definitions(
+   -DNDEBUG 
+   -D_WINDOWS 
+   -D_LIB 
+   -DUSE_DLL 
+   -DMETERPRETER_EXPORTS 
+   -D_CRT_SECURE_NO_WARNINGS
+   -D__GNUC__
+)
+
+############## Artefacts Output #################
+# Defines outputs , depending Debug or Release. #
+#################################################
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
+  set(CMAKE_EXECUTABLE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
+else()
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+  set(CMAKE_EXECUTABLE_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+endif()
+
+################### Dependencies ##################
+# Add Dependencies to project.                    #
+###################################################
+
+option(BUILD_DEPENDS 
+   "Build other CMake project." 
+   OFF 
+)
+
+# Dependencies : disable BUILD_DEPENDS to link with lib already build.
+if(BUILD_DEPENDS)
+   add_subdirectory(platform/cmake/backcompat ${CMAKE_BINARY_DIR}/backcompat)
+else()
+   link_directories(../backcompat/Release/)
+endif()
+
+################# Flags ################
+# Defines Flags for Windows and Linux. #
+########################################
+SET(CMAKE_SYSTEM_NAME Windows)
+include(CMakeForceCompiler)
+IF("${GNU_HOST}" STREQUAL "")
+    SET(GNU_HOST x86_64-w64-mingw32)
+ENDIF()
+# Prefix detection only works with compiler id "GNU"
+CMAKE_FORCE_C_COMPILER(${GNU_HOST}-gcc GNU)
+# CMake doesn't automatically look for prefixed 'windres', do it manually:
+SET(CMAKE_RC_COMPILER ${GNU_HOST}-windres)
+
+set( _MSC_VER 1910 )
+SET(CMAKE_C_COMPILER clang)
+
+if(MSVC)
+   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /W3 /EHsc")
+   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /EHsc")
+endif(MSVC)
+if(NOT MSVC)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -target x86_64-w64-windows-gnu -I/usr/x86_64-w64-mingw32/include -L/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/ -L/usr/x86_64-w64-mingw32/lib/ -std=c++11")
+   #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target x86_64-w64-windows-gnu -I/usr/x86_64-w64-mingw32/include -L/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/ -L/usr/x86_64-w64-mingw32/lib/ ")
+   set(CMAKE_LIBRARY_ARCHITECTURE x64 CACHE STRING "" FORCE)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target x86_64-w64-windows-gnu -I/usr/x86_64-w64-mingw32/include/ -L/usr/lib/gcc/x86_64-w64-mingw32/8.2.0/include/ -L/usr/x86_64-w64-mingw32/lib -Wfatal-errors -fmsc-version=${_MSC_VER} -fms-extensions -fms-compatibility -fdelayed-template-parsing ")
+   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+       set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+   endif()
+endif(NOT MSVC)
+
+
+################ Files ################
+#   --   Add files to project.   --   #
+#######################################
+
+file(GLOB SRC_FILES
+    ${CPP_DIR_1}/*.c
+    ${CPP_DIR_2}/*.c
+    ${CPP_DIR_3}/*.c
+    ${CPP_DIR_4}/*.c
+    ${HEADER_DIR_1}/*.h
+    ${HEADER_DIR_2}/*.h
+    ${HEADER_DIR_3}/*.h
+    ${HEADER_DIR_4}/*.h
+)
+
+include_directories( ${HEADER_DIR_1} )
+include_directories( ${HEADER_DIR_2} )
+include_directories( ${HEADER_DIR_3} )
+include_directories( ${HEADER_DIR_4} )
+include_directories( ${HEADER_DIR_5} )
+
+# Add library to build.
+add_library(${PROJECT_NAME} STATIC
+   ${SRC_FILES}
+)
+
+# Link with other dependencies.
+#target_link_libraries(${PROJECT_NAME} backcompat )
+if(MSVC)
+   target_link_libraries(${PROJECT_NAME} backcompat.lib )
+endif(MSVC)


### PR DESCRIPTION
# Description

PR #320 is too big to be reviewed, so I'm splitting it into smaller ones. This PR contains every change related to "common" (workspace/common).

In essence, a CMake makefile is added and allow cross-compilation with clang (tested on ubuntu 18.04 and Archlinux).

# Important

This PR depends on https://github.com/rapid7/ReflectiveDLLInjection/pull/7

# build dependencies

## Archlinux (preferred)

clang
aur/mingw-w64-winpthreads-bin
aur/mingw-w64-headers-bin

## Ubuntu 18.04 
```
# apt-get remove mingw*
wget https://launchpad.net/ubuntu/+archive/primary/+files/mingw-w64-common_6.0.0-3_all.deb
wget https://launchpad.net/ubuntu/+archive/primary/+files/mingw-w64-x86-64-dev_6.0.0-3_all.deb
dpkg -i mingw-w64-common_6.0.0-3_all.deb
dpkg -i mingw-w64-x86-64-dev_6.0.0-3_all.deb
```
# Build instructions

```
git clone https://github.com/plowsec/metasploit-payloads -b clang-compat-common
cd metasploit-payloads
git submodule update --init --recursive
cd c/meterpreter/source/ReflectiveDLLInjection
git fetch origin pull/7/head:pr/7 && git checkout pr/7
```

## build ReflectiveDLLInjection

```
cd ../../workspace/ReflectiveDLLInjection
mkdir CMakeBuild && cd CMakeBuild
cmake .. && make
```

## build common

```
cd ../../common
mkdir CMakeBuild && cd CMakeBuild
cmake .. && make
```
# Note

Once built, you should see two files in metasploit-payloads/c/meterpreter/output/Release:

- libcommon.a
- libReflectiveDLLInjection.a

If not, it means that the build failed. Obviously, I would like to know about it in addition to every information necessary for me to reproduce the failure.

# Testing

Wait for the next PR that allow to build metsrv.dll and then you will be able to test all the features of meterpreter.