### PR TITLE
[metsrv] Add CMake makefile and fixes for clang compatibility.

### DIFF
--- a/c/meterpreter/source/server/remote_dispatch_common.c
+++ b/c/meterpreter/source/server/remote_dispatch_common.c
@@ -1,5 +1,5 @@
 #include "metsrv.h"
-#include "win\server_pivot.h"
+#include "win/server_pivot.h"
 
 // see ReflectiveLoader.c...
 extern HINSTANCE hAppInstance;

--- a/c/meterpreter/source/server/server_setup_win.c
+++ b/c/meterpreter/source/server/server_setup_win.c
@@ -504,7 +504,7 @@ DWORD server_setup(MetsrvConfig* config)
 
 		remote_deallocate(remote);
 	}
-	__except (exceptionfilter(GetExceptionCode(), GetExceptionInformation()))
+	__except(0)
 	{
 		dprintf("[SERVER] *** exception triggered!");
 

--- a/c/meterpreter/source/server/server_setup_win.c
+++ b/c/meterpreter/source/server/server_setup_win.c
@@ -504,7 +504,11 @@ DWORD server_setup(MetsrvConfig* config)
 
 		remote_deallocate(remote);
 	}
-	__except(0)
+	#ifndef __MINGW32__
+	__except (exceptionfilter(GetExceptionCode(), GetExceptionInformation()))
+	#else
+	__except (0)
+	#endif
 	{
 		dprintf("[SERVER] *** exception triggered!");
 

--- a/c/meterpreter/source/server/win/libloader.c
+++ b/c/meterpreter/source/server/win/libloader.c
@@ -135,8 +135,9 @@ typedef struct _SHELLCODE_CTX {
 
 SHELLCODE_CTX *ctx = NULL;
 
+#ifndef __MINGW32__
 #pragma comment(lib, "ws2_32.lib")
-
+#endif
 #pragma warning(disable: 4068)
 
 /*

--- a/c/meterpreter/source/server/win/metsrv_test.c
+++ b/c/meterpreter/source/server/win/metsrv_test.c
@@ -33,8 +33,13 @@ int main(int argc, char **argv)
 
 		lib = LoadLibrary(argv[1]);
 
-		if ((!lib) ||
-		    (!((LPVOID)init = (LPVOID)GetProcAddress(lib, "Init"))))
+		if (!lib) 
+		{
+			fprintf(stderr, "could not load metsrv.dll, %lu\n", GetLastError());
+			break;
+		}
+		init = (LPVOID)GetProcAddress(lib, "Init");
+		if (!init) 
 		{
 			fprintf(stderr, "could not load metsrv.dll, %lu\n", GetLastError());
 			break;

--- a/c/meterpreter/source/server/win/server_pivot_named_pipe.c
+++ b/c/meterpreter/source/server/win/server_pivot_named_pipe.c
@@ -3,8 +3,8 @@
 #include "server_pivot_named_pipe.h"
 #include "../../common/packet_encryption.h"
 
-#include <AccCtrl.h>
-#include <AclApi.h>
+#include <accctrl.h>
+#include <aclapi.h>
 
 #define PIPE_NAME_SIZE 256
 #define PIPE_BUFFER_SIZE 0x10000

--- a/c/meterpreter/source/server/win/server_transport_tcp.c
+++ b/c/meterpreter/source/server/win/server_transport_tcp.c
@@ -20,7 +20,7 @@ typedef struct _TCPMIGRATECONTEXT
 #ifndef IPPROTO_IPV6
 #define IPPROTO_IPV6 41
 #endif
-#ifndef in6addr_any && !defined __MINGW32__
+#if !defined in6addr_any && !defined __MINGW32__
 extern IN6_ADDR in6addr_any;
 #endif
 

--- a/c/meterpreter/source/server/win/server_transport_tcp.c
+++ b/c/meterpreter/source/server/win/server_transport_tcp.c
@@ -20,8 +20,8 @@ typedef struct _TCPMIGRATECONTEXT
 #ifndef IPPROTO_IPV6
 #define IPPROTO_IPV6 41
 #endif
-#ifndef in6addr_any
-
+#ifndef in6addr_any && !defined __MINGW32__
+extern IN6_ADDR in6addr_any;
 #endif
 
 /*!

--- a/c/meterpreter/source/server/win/server_transport_tcp.c
+++ b/c/meterpreter/source/server/win/server_transport_tcp.c
@@ -21,7 +21,7 @@ typedef struct _TCPMIGRATECONTEXT
 #define IPPROTO_IPV6 41
 #endif
 #ifndef in6addr_any
-extern IN6_ADDR in6addr_any;
+
 #endif
 
 /*!

--- a/c/meterpreter/workspace/metsrv/CMakeLists.txt
+++ b/c/meterpreter/workspace/metsrv/CMakeLists.txt
@@ -1,0 +1,144 @@
+cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+
+################### Variables. ####################
+# Change if you want modify path or other values. #
+###################################################
+
+set(PROJECT_NAME metsrv)
+# Output Variables
+set(OUTPUT_DEBUG ../../output/Debug/)
+set(OUTPUT_RELEASE ../../../output/Release/)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_RELEASE})
+
+# Folders files
+set(CPP_DIR_1 ../../source/server/win)
+set(CPP_DIR_2 ../../source/server)
+set(HEADER_DIR_1 ../../source/server)
+set(HEADER_DIR_2 ../../source/server/win)
+set(HEADER_DIR_3 ../../source/common/)
+set(HEADER_DIR_4 ../../source/ReflectiveDLLInjection/common)
+
+############## CMake Project ################
+#        The main options of project        #
+#############################################
+
+project(${PROJECT_NAME} C)
+
+# Define Release by default.
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
+  message(STATUS "Build type not specified: Use Release by default.")
+endif(NOT CMAKE_BUILD_TYPE)
+
+# Definition of Macros
+add_definitions(
+   -D__GNUC__
+   -DNDEBUG 
+   -DUNICODE
+   -D_UNICODE
+)
+
+############## Artefacts Output #################
+# Defines outputs , depending Debug or Release. #
+#################################################
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
+  set(CMAKE_EXECUTABLE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
+else()
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+  set(CMAKE_EXECUTABLE_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+endif()
+
+################### Dependencies ##################
+# Add Dependencies to project.                    #
+###################################################
+
+option(BUILD_DEPENDS 
+   "Build other CMake project." 
+   OFF 
+)
+
+# Dependencies : disable BUILD_DEPENDS to link with lib already build.
+if(BUILD_DEPENDS)
+   add_subdirectory(platform/cmake/backcompat ${CMAKE_BINARY_DIR}/backcompat)
+   add_subdirectory(platform/cmake/common ${CMAKE_BINARY_DIR}/common)
+   add_subdirectory(platform/cmake/ReflectiveDLLInjection ${CMAKE_BINARY_DIR}/ReflectiveDLLInjection)
+else()
+   link_directories(${OUTPUT_RELEASE})
+   link_directories(../../output/Release)
+   link_directories(/usr/x86_64-w64-mingw32/lib/)
+endif()
+
+################# Flags ################
+# Defines Flags for Windows and Linux. #
+########################################
+SET(CMAKE_SYSTEM_NAME Windows)
+include(CMakeForceCompiler)
+IF("${GNU_HOST}" STREQUAL "")
+    SET(GNU_HOST x86_64-w64-mingw32)
+ENDIF()
+# Prefix detection only works with compiler id "GNU"
+#CMAKE_FORCE_C_COMPILER(clang GNU)
+# CMake doesn't automatically look for prefixed 'windres', do it manually:
+SET(CMAKE_RC_COMPILER ${GNU_HOST}-windres)
+
+set( _MSC_VER 1910 )
+SET(CMAKE_C_COMPILER clang)
+
+if(MSVC)
+   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /W3 /EHsc")
+   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /EHsc")
+endif(MSVC)
+if(NOT MSVC)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -target x86_64-w64-windows-gnu -I/usr/x86_64-w64-mingw32/include -L/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/ -L/usr/x86_64-w64-mingw32/lib/ -std=c++11")
+   #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target x86_64-w64-windows-gnu -I/usr/x86_64-w64-mingw32/include -L/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/ -L/usr/x86_64-w64-mingw32/lib/ ")
+   set(CMAKE_LIBRARY_ARCHITECTURE x64 CACHE STRING "" FORCE)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target x86_64-w64-windows-gnu -I/usr/x86_64-w64-mingw32/include/ -L/usr/lib/gcc/x86_64-w64-mingw32/8.2.0/include/ -L/usr/x86_64-w64-mingw32/lib -Wfatal-errors -fmsc-version=${_MSC_VER} -fms-extensions -fms-compatibility -fdelayed-template-parsing ")
+   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+       set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+   endif()
+endif(NOT MSVC)
+
+################ Files ################
+#   --   Add files to project.   --   #
+#######################################
+
+file(GLOB SRC_FILES
+    ${CPP_DIR_1}/*.c
+    ${CPP_DIR_2}/*.c
+    ${HEADER_DIR_1}/*.h
+    ${HEADER_DIR_2}/*.h
+)
+
+include_directories( ${HEADER_DIR_1} )
+include_directories( ${HEADER_DIR_2} )
+include_directories( ${HEADER_DIR_3} )
+include_directories( ${HEADER_DIR_4} )
+
+# Add library to build.
+#add_library(objlib OBJECT ${SRC_FILES})
+
+
+set( CMAKE_C_COMPILE_OPTIONS_PIC "" ) 
+
+
+#add_library(${PROJECT_NAME}-dll SHARED $<TARGET_OBJECTS:objlib>)
+#add_library(${PROJECT_NAME} STATIC $<TARGET_OBJECTS:objlib>)
+
+
+add_library(${PROJECT_NAME} SHARED
+   ${SRC_FILES}
+)
+
+
+link_directories(/usr/x86_64-w64-mingw32/lib/)
+
+# Link with other dependencies.
+target_link_libraries(${PROJECT_NAME} common ReflectiveDLLInjection ws2_32 ole32 odbc32 odbccp32 crypt32 wininet winhttp )
+
+if(MSVC)
+   target_link_libraries(${PROJECT_NAME} ws2_32.lib odbc32.lib odbccp32.lib crypt32.lib wininet.lib winhttp.lib )
+endif(MSVC)

--- a/c/meterpreter/workspace/metsrv/CMakeLists.txt
+++ b/c/meterpreter/workspace/metsrv/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
 # Change if you want modify path or other values. #
 ###################################################
 
-set(PROJECT_NAME metsrv)
+set(PROJECT_NAME metsrv.x64)
 # Output Variables
 set(OUTPUT_DEBUG ../../output/Debug/)
 set(OUTPUT_RELEASE ../../../output/Release/)
@@ -133,6 +133,8 @@ add_library(${PROJECT_NAME} SHARED
    ${SRC_FILES}
 )
 
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
+set(CMAKE_SHARED_LIBRARY_SUFFIX ".dll")
 
 link_directories(/usr/x86_64-w64-mingw32/lib/)
 


### PR DESCRIPTION
# Description

PR #320 is too big to be reviewed, so I'm splitting it into smaller ones. This PR contains every change related to "_metsrv_" (_workspace/metsrv_).

In essence, a CMake makefile is added and allow cross-compilation with clang (tested on ubuntu 18.04 and Archlinux).

# Important

This PR depends on:

- https://github.com/rapid7/ReflectiveDLLInjection/pull/7
- https://github.com/rapid7/metasploit-payloads/pull/340

Instructions to take care of these dependencies are included in the part "Build instructions".

# build dependencies

## Archlinux (preferred)

clang
aur/mingw-w64-winpthreads-bin
aur/mingw-w64-headers-bin

## Ubuntu 18.04 
```
# apt-get remove mingw*
wget https://launchpad.net/ubuntu/+archive/primary/+files/mingw-w64-common_6.0.0-3_all.deb
wget https://launchpad.net/ubuntu/+archive/primary/+files/mingw-w64-x86-64-dev_6.0.0-3_all.deb
dpkg -i mingw-w64-common_6.0.0-3_all.deb
dpkg -i mingw-w64-x86-64-dev_6.0.0-3_all.deb
```
# Build instructions

```
git clone https://github.com/plowsec/metasploit-payloads -b clang-compat-metsrv
cd metasploit-payloads
git submodule update --init --recursive
git merge origin/clang-compat-common
cd c/meterpreter/source/ReflectiveDLLInjection
git fetch origin pull/7/head:pr/7 && git checkout pr/7
```
This takes care of the following:

* Cloning my fork of _metasploit-payloads_ and checking out the branch _clang-compat-metsrv_ 
* Update the submodules _ReflectiveDLLInjection_ and _mimikatz_
* Merge the PR #340 (which is the "common" subproject).
* Merge the PR https://github.com/rapid7/ReflectiveDLLInjection/pull/7

## build ReflectiveDLLInjection

```
cd ../../workspace/ReflectiveDLLInjection
mkdir CMakeBuild && cd CMakeBuild
cmake .. && make VERBOSE=1 -j 4
```

## build common

```
cd ../../common
mkdir CMakeBuild && cd CMakeBuild
cmake .. && make VERBOSE=1 -j 4
```
## build metsrv

```
cd ../../metsrv
mkdir CMakeBuild && cd CMakeBuild
cmake .. && make VERBOSE=1 -j 4
```

# Testing

Copy _metsrv.x64.dll_ (located in `metasploit-payloads/c/meterpreter/output/Release`) in your metasploit installation folder.

In my setup it's in `/opt/metasploit/vendor/bundle/ruby/2.6.0/gems/metasploit-payloads-1.3.68/data/meterpreter/`).

**You may want to backup the original metsrv.x64.dll ;)**

If _msfconsole_ is already launched, type "reload_all", otherwise launch it, setup a handler and spawn a _meterpreter_ session on a 64-bit Windows, with a 64-bit _staged_ payload:

```
handler -H your_local_ip -P 8443 -p windows/x64/meterpreter/reverse_https
```



