### PR TITLE
remove (unused) references to the NDK from README and Makefile

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -5,13 +5,13 @@ PACKAGE=com.metasploit.stage
 all: android
 
 android:
-		mvn package -Dandroid.sdk.path=${ANDROID_HOME} -Dandroid.ndk.path=${ANDROID_NDK_HOME} -Dandroid.release=true -P deploy
+		mvn package -Dandroid.sdk.path=${ANDROID_HOME} -Dandroid.release=true -P deploy
 
 java:
 		mvn package
 
 clean:
-		mvn clean -Dandroid.sdk.path=/ -Dandroid.ndk.path=/
+		mvn clean -Dandroid.sdk.path=/
 
 android-api:
 		${ANDROID}

--- a/java/README.md
+++ b/java/README.md
@@ -1,11 +1,11 @@
 # Building the Java and Android Meterpreter
 
 1. Install Maven and Java, this will depend on your OS
-1. Download the [Android SDK](https://developer.android.com/sdk/index.html), and the [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html)
+1. Download the [Android SDK](https://developer.android.com/sdk/index.html)
 1. Install Android SDK Platforms 3, 10 and 19, and update the "Android SDK Tools" and "Android SDK Platform-tools"
 1. Compile the Android and Java Meterpreter, which deploys to the ../metasploit-frameworks folder
 ```
-mvn package -Dandroid.sdk.path=/path/to/android-sdk -Dandroid.ndk.path=/path/to/android-ndk -Dandroid.release=true -P deploy
+mvn package -Dandroid.sdk.path=/path/to/android-sdk -Dandroid.release=true -P deploy
 ```
 Next time you run `msfconsole`, you should see: `WARNING: Local files may be incompatible with the Metasploit Framework`.
 This means that msfconsole is now using your newly built version of the Java and Android Meterpreter :)
@@ -20,10 +20,9 @@ sdkmanager --licenses
 sdkmanager "platforms;android-3"
 sdkmanager "platforms;android-10"
 sdkmanager "platforms;android-19"
-sdkmanager "ndk-bundle"
 
 #cd metasploit-payloads/java
-mvn package -Dandroid.sdk.path=/usr/local/share/android-sdk -Dandroid.ndk.path=/usr/local/share/android-sdk/ndk-bundle/ -Dandroid.release=true -P deploy
+mvn package -Dandroid.sdk.path=/usr/local/share/android-sdk -Dandroid.release=true -P deploy
 ```
 
 ## Compiling JavaPayload and Java Meterpreter manually


### PR DESCRIPTION
We no longer build using the NDK after https://github.com/rapid7/metasploit-payloads/pull/308