### PR TITLE
Let PHP Meterpreter renegotiate CryptTLV

### DIFF
--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -485,6 +485,7 @@ function core_negotiate_tlv_encryption($req, &$pkt) {
     if (supports_aes()) {
         my_print("AES functionality is supported");
         packet_add_tlv($pkt, create_tlv(TLV_TYPE_SYM_KEY_TYPE, ENC_AES256));
+        $GLOBALS['AES_ENABLED'] = false;
         $GLOBALS['AES_KEY'] = rand_bytes(32);
         if (function_exists('openssl_pkey_get_public') && function_exists('openssl_public_encrypt')) {
             my_print("Encryption via public key is supported");


### PR DESCRIPTION
When negotiating the CryptTLV symmetric key, we always need to clear the `AES_ENABLED` flag so we don't try to encrypt the new symmetric key with itself.

Verification
========

- [ ] Pull down https://github.com/rapid7/metasploit-framework/pull/11965
- [ ] Set up a multi/handler for php meterpreter
- [ ] Create the session
- [ ] `sessions -v` should show the session as encrypted
- [ ] `sessions -i -1`
- [ ] Verify `pwd` works
- [ ] Verify `secure` works as per https://github.com/rapid7/metasploit-framework/pull/11965
- [ ] Verify `pwd` works again
- [ ] `background` and verify `sessions -v` shows the session as still encrypted