### PR TITLE
Update OS names to be more generic in kernel versions 10.0.x

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
@@ -545,7 +545,7 @@ DWORD add_windows_os_version(Packet** packet)
 		{
 			if (v.dwMinorVersion == 0)
 			{
-				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 10" : "Windows 2016";
+				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 10" : "Windows 2016+";
 			}
 		}
 
@@ -556,11 +556,11 @@ DWORD add_windows_os_version(Packet** packet)
 
 		if (wcslen(v.szCSDVersion) > 0)
 		{
-			_snprintf(buffer, sizeof(buffer)-1, "%s (Build %lu, %S).", osName, v.dwBuildNumber, v.szCSDVersion);
+			_snprintf(buffer, sizeof(buffer)-1, "%s (%lu.%lu Build %lu, %S).", osName, v.dwMajorVersion, v.dwMinorVersion, v.dwBuildNumber, v.szCSDVersion);
 		}
 		else
 		{
-			_snprintf(buffer, sizeof(buffer)-1, "%s (Build %lu).", osName, v.dwBuildNumber);
+			_snprintf(buffer, sizeof(buffer)-1, "%s (%lu.%lu Build %lu).", osName, v.dwMajorVersion, v.dwMinorVersion, v.dwBuildNumber);
 		}
 
 		dprintf("[VERSION] Version set to: %s", buffer);

--- a/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
@@ -556,11 +556,11 @@ DWORD add_windows_os_version(Packet** packet)
 
 		if (wcslen(v.szCSDVersion) > 0)
 		{
-			_snprintf(buffer, sizeof(buffer)-1, "%s (%lu.%lu Build %lu, %S).", osName, v.dwMajorVersion, v.dwMinorVersion, v.dwBuildNumber, v.szCSDVersion);
+			_snprintf(buffer, sizeof(buffer)-1, "%s (%u.%u Build %u, %S).", osName, v.dwMajorVersion, v.dwMinorVersion, v.dwBuildNumber, v.szCSDVersion);
 		}
 		else
 		{
-			_snprintf(buffer, sizeof(buffer)-1, "%s (%lu.%lu Build %lu).", osName, v.dwMajorVersion, v.dwMinorVersion, v.dwBuildNumber);
+			_snprintf(buffer, sizeof(buffer)-1, "%s (%u.%u Build %u).", osName, v.dwMajorVersion, v.dwMinorVersion, v.dwBuildNumber);
 		}
 
 		dprintf("[VERSION] Version set to: %s", buffer);


### PR DESCRIPTION
Previously, when Microsoft released a new "named" operating system, it bumped the major/minor kernel version.  Now, it is changing OS names based on the build version (or nothing).  That means we fingerprint Windows 2019, Server 1809, Server 1803, and Server 1709 as Windows 2016, as all are running some flavor of kernel 10.0.x.  Rather than trying to track build numbers (which would not always help, as Windows Server 2019 shares a build number with Windows Server Release 1809) this just makes the OS name for any Kernel version 10.0.x as "Windows Server 2016+" and gives the version and build number.  As Microsoft continues to shrink the update and delivery cycle, the build number will be more important than the OS name.

I tried to play as little as possible in the output, in case some regex out there depended on it.  On a second though, it might be beneficial to preface the version with a 'version' tag, but I don't know how anyone else feels.

Fixes https://github.com/rapid7/metasploit-framework/issues/12112

Windows 7x64 SP1:
```
meterpreter > sysinfo
Computer        : WIN7X64SP1
OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
```

Windows 2016:
```
meterpreter > sysinfo
Computer        : WIN2016X64
OS              : Windows 2016+ (10.0 Build 14393).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
```

Windows 2019:
```
meterpreter > sysinfo
Computer        : WIN2019X64
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows

```

Windows 2012:
```
meterpreter > sysinfo
Computer        : WIN2012X64
OS              : Windows 2012 (6.2 Build 9200).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
```

Windows Server 1709:
```
meterpreter > sysinfo
Computer        : WIN1709X64
OS              : Windows 2016+ (10.0 Build 16299).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
```

Windows Server 1803:
```
meterpreter > sysinfo
Computer        : WIN1709X64
OS              : Windows 2016+ (10.0 Build 16299).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
```

Windows Server 1809:
```
meterpreter > sysinfo
Computer        : WIN1809X64
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows

Windows 10x64 1809:
```
meterpreter > sysinfo
Computer        : WIN10X64_1809
OS              : Windows 10 (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
```
