### PR TITLE
Java meterpreter: Allow to list ("ls") relative paths

### DIFF
--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_ls.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_ls.java
@@ -10,8 +10,8 @@ import com.metasploit.meterpreter.command.Command;
 public class stdapi_fs_ls implements Command {
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         stdapi_fs_stat statCommand = (stdapi_fs_stat) meterpreter.getCommandManager().getCommand("stdapi_fs_stat");
-        String path = request.getStringValue(TLVType.TLV_TYPE_DIRECTORY_PATH);
-        String[] entries = new File(path).list();
+        File path = Loader.expand(request.getStringValue(TLVType.TLV_TYPE_DIRECTORY_PATH));
+        String[] entries = path.list();
         for (int i = 0; i < entries.length; i++) {
             if (entries[i].equals(".") || entries[i].equals(".."))
                 continue;


### PR DESCRIPTION
Fix #357
The error was a NPE.

Before: 
(ignore the 15th line that I added to test something, it was a wrong fix)
![image](https://user-images.githubusercontent.com/550823/63800425-5ee06480-c90e-11e9-8b90-edf3a736a15c.png)
When we "cd", the current working directory of the process is not actually changed. So we have to use the `expand` method on all paths to transform them to absolute paths, in the correct "virtual" working directory.
![image](https://user-images.githubusercontent.com/550823/63800481-7ddef680-c90e-11e9-9404-0c1de38d3dc9.png)

All other command implentations do the same:
https://github.com/rapid7/metasploit-payloads/blob/18ed237c1d9ae70030d1b01e64eb67b2c75fa9db/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_file_copy.java#L13-L16

After patch, it continues to work fine for both absolute and relative paths:
```
meterpreter > ls
Listing: /root
==============

Mode              Size    Type  Last modified              Name
----              ----    ----  -------------              ----
40777/rwxrwxrwx   4096    dir   2018-12-13 17:26:11 +0100  .BurpSuite
[...]

meterpreter > cd /tmp
meterpreter > cd meterp
meterpreter > ls
Listing: /tmp/meterp
====================

Mode             Size  Type  Last modified              Name
----             ----  ----  -------------              ----
40776/rwxrwxrw-  4096  dir   2019-08-27 19:47:01 +0200  empty

meterpreter > ls aaaaaa
[-] stdapi_fs_stat: Operation failed: 1
meterpreter > ls .
Listing: .
==========

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
40777/rwxrwxrwx   4096  dir   2019-07-04 14:19:05 +0200  .ICE-unix
40777/rwxrwxrwx   4096  dir   2019-07-04 14:19:02 +0200  .Test-unix
[...]
40776/rwxrwxrw-   4096  dir   2019-08-27 19:47:01 +0200  meterp
[...]

meterpreter > ls ..
Listing: ..
===========

Mode              Size      Type  Last modified              Name
----              ----      ----  -------------              ----
40777/rwxrwxrwx   4096      dir   2018-08-21 12:53:19 +0200  .cache
100666/rw-rw-rw-  0         fil   2018-07-31 10:25:43 +0200  0
40776/rwxrwxrw-   118784    dir   2019-08-20 17:07:44 +0200  bin
40776/rwxrwxrw-   4096      dir   2019-07-10 19:25:47 +0200  boot
[...]

meterpreter > ls /
Listing: /
==========

Mode              Size      Type  Last modified              Name
----              ----      ----  -------------              ----
40777/rwxrwxrwx   4096      dir   2018-08-21 12:53:19 +0200  .cache
100666/rw-rw-rw-  0         fil   2018-07-31 10:25:43 +0200  0
40776/rwxrwxrw-   118784    dir   2019-08-20 17:07:44 +0200  bin
40776/rwxrwxrw-   4096      dir   2019-07-10 19:25:47 +0200  boot
[...]

meterpreter > ls /notfound
[-] stdapi_fs_stat: Operation failed: 1
meterpreter > 

```