### PR TITLE
add android build to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 DATADIR:=../metasploit-framework/data
 METERPDIR:=$(DATADIR)/meterpreter
+ANDROIDSDKDIR:=/usr/local/share/android-sdk
 
 install-all: \
-	install-windows \
+    install-windows \
     install-java \
+    install-android \
     install-php \
     install-python
 
@@ -32,6 +34,11 @@ install-php: $(METERPDIR)
 install-python: $(METERPDIR)
 	@echo "Installing Python payloads"
 	@cp python/meterpreter/*.py $(METERPDIR)
+
+install-android:
+       @echo "Installing Android payloads"
+       @mvn -v >/dev/null 2>&1 || echo "Note: Maven not found, skipping";
+       @mvn -v >/dev/null 2>&1 && (cd java; mvn package -Dandroid.sdk.path=$(ANDROIDSDKDIR) -Dandroid.release=true -P deploy -q);
 
 uninstall:
 	rm -fr $(METERPDIR)


### PR DESCRIPTION
This PR adds a 'install-android' command to the make file.

When handling the last PR, there was confusion and I built the JAVA payload instead, so figured it would be easy to add here.

Added this to 'install-all' which may not be what people want, since they may not have the SDK, open to comments.