### PR TITLE
Reducing permissions requested for sys_steal_token

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
@@ -400,7 +400,7 @@ DWORD request_sys_config_steal_token(Remote *remote, Packet *packet)
 			break;
 		}
 
-		if (!OpenProcessToken(hProcessHandle, TOKEN_ALL_ACCESS, &hToken))
+		if (!OpenProcessToken(hProcessHandle, TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY | TOKEN_QUERY, &hToken))
 		{
 			dwResult = GetLastError();
 			dprintf("[STEAL-TOKEN] Failed to open process token for %d (%u)", dwPid, dwResult);
@@ -414,7 +414,7 @@ DWORD request_sys_config_steal_token(Remote *remote, Packet *packet)
 			break;
 		}
 
-		if (!DuplicateTokenEx(hToken, MAXIMUM_ALLOWED, NULL, SecurityIdentification, TokenPrimary, &hDupToken))
+		if (!DuplicateTokenEx(hToken, TOKEN_ADJUST_DEFAULT | TOKEN_ADJUST_SESSIONID | TOKEN_QUERY | TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY, NULL, SecurityIdentification, TokenPrimary, &hDupToken))
 		{
 			dwResult = GetLastError();
 			dprintf("[STEAL-TOKEN] Failed to duplicate a primary token for %d (%u)", dwPid, dwResult);


### PR DESCRIPTION
Reduced permissions from ALL_ACCESS to the minimum access needed for sys_steal_token.

Reduced permissions requested for OpenProcessToken and DuplicateTokenEx.

Additionally, OpenProcess can be reduced to PROCESS_QUERY_LIMITED_INFORMATION for any OS after Windows XP/2003. An OS check could be added here.

I looked into the minimum permissions for these API calls here:
https://posts.specterops.io/understanding-and-defending-against-access-token-theft-finding-alternatives-to-winlogon-exe-80696c8a73b