### PR TITLE
Send local address information when opening network channels

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/net/net.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/net.c
@@ -1,1 +1,72 @@
 #include "precomp.h"
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+static char * parse_sockaddr(struct sockaddr_storage *addr, uint16_t *port)
+{
+	char *host = NULL;
+
+	host = malloc(INET6_ADDRSTRLEN);
+	if (host) {
+		if (addr->ss_family == AF_INET) {
+			struct sockaddr_in *s = (struct sockaddr_in *)addr;
+			*port = ntohs(s->sin_port);
+			inet_ntop(AF_INET, &s->sin_addr, host, INET6_ADDRSTRLEN);
+		}
+		else if (addr->ss_family == AF_INET6) {
+			struct sockaddr_in6 *s = (struct sockaddr_in6 *)addr;
+			*port = ntohs(s->sin6_port);
+			inet_ntop(AF_INET6, &s->sin6_addr, host, INET6_ADDRSTRLEN);
+		}
+	}
+	return host;
+}
+
+const char * inet_ntop(int af, const void *src, char *dst, socklen_t size) {
+	struct sockaddr_storage addr;
+
+	ZeroMemory(&addr, sizeof(addr));
+	addr.ss_family = af;
+
+	if (af == AF_INET) {
+		((struct sockaddr_in *)&addr)->sin_addr = *(struct in_addr *)src;
+	}
+	else if (af == AF_INET6) {
+		((struct sockaddr_in6 *)&addr)->sin6_addr = *(struct in6_addr *)src;
+	}
+
+	if (!WSAAddressToStringA((struct sockaddr *)&addr, sizeof(addr), NULL, dst, &size)) {
+		dst = NULL;
+	}
+	return dst;
+}
+
+/*!
+* @brief Add the local socket address information to the specified packet.
+* @param sock_ctx Pointer to the socket context to retrieve the address for.
+* @param packet Packet to add the LOCAL_HOST and LOCAL_PORT TLVs to.
+* @retval ERROR_SUCCESS Adding the TLVs was successful.
+*/
+DWORD net_tlv_pack_local_addrinfo(SocketContext *sock_ctx, Packet *packet)
+{
+	struct sockaddr_storage addr;
+	int len = sizeof(addr);
+	char *localhost = NULL;
+	uint16_t localport = 0;
+
+	if (getsockname(sock_ctx->fd, (struct sockaddr *)&addr, &len) == -1) {
+		return ERROR_UNIDENTIFIED_ERROR;
+	}
+
+	localhost = parse_sockaddr(&addr, &localport);
+	if (localhost == NULL) {
+		return ERROR_OUTOFMEMORY;
+	}
+
+	packet_add_tlv_string(packet, TLV_TYPE_LOCAL_HOST, localhost);
+	packet_add_tlv_uint(packet, TLV_TYPE_LOCAL_PORT, localport);
+	free(localhost);
+	localhost = NULL;
+	return ERROR_SUCCESS;
+}

--- a/c/meterpreter/source/extensions/stdapi/server/net/net.h
+++ b/c/meterpreter/source/extensions/stdapi/server/net/net.h
@@ -1,6 +1,9 @@
 #ifndef _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_NET_NET_H
 #define _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_NET_NET_H
 
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
 /*
  * Generic socket context
  */
@@ -62,8 +65,10 @@ DWORD request_net_socket_tcp_shutdown(Remote *remote, Packet *packet);
 /*
  * Channel creation
  */
-DWORD create_tcp_client_channel(Remote *remote, LPCSTR host,USHORT port, Channel **outChannel);
+DWORD create_tcp_client_channel(Remote *remote, LPCSTR host,USHORT port, Channel **outChannel, TcpClientContext **outContext);
 
 VOID free_socket_context(SocketContext *ctx);
+const char * inet_ntop(int af, const void *src, char *dst, socklen_t size);
+DWORD net_tlv_pack_local_addrinfo(SocketContext *sock_ctx, Packet *packet);
 
 #endif

--- a/c/meterpreter/source/extensions/stdapi/server/net/socket/tcp_server.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/socket/tcp_server.c
@@ -301,11 +301,6 @@ DWORD request_net_tcp_server_channel_open(Remote * remote, Packet * packet)
 		ctx->remote = remote;
 
 		localPort = (USHORT)(packet_get_tlv_value_uint(packet, TLV_TYPE_LOCAL_PORT) & 0xFFFF);
-		if (!localPort)
-		{
-			BREAK_WITH_ERROR("[TCP-SERVER] request_net_tcp_server_channel_open. localPort == NULL", ERROR_INVALID_HANDLE);
-		}
-
 		localHost = packet_get_tlv_value_string(packet, TLV_TYPE_LOCAL_HOST);
 
 		ctx->fd = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, 0, 0, 0);
@@ -382,6 +377,7 @@ DWORD request_net_tcp_server_channel_open(Remote * remote, Packet * packet)
 		scheduler_insert_waitable(ctx->notify, ctx, NULL, (WaitableNotifyRoutine)tcp_channel_server_notify, NULL);
 
 		packet_add_tlv_uint(response, TLV_TYPE_CHANNEL_ID, channel_get_id(ctx->channel));
+		net_tlv_pack_local_addrinfo(ctx, response);
 
 		dprintf("[TCP-SERVER] request_net_tcp_server_channel_open. tcp server %s:%d on channel %d", localHost, localPort, channel_get_id(ctx->channel));
 

--- a/c/meterpreter/source/extensions/stdapi/server/net/socket/udp.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/socket/udp.c
@@ -326,6 +326,7 @@ DWORD request_net_udp_channel_open( Remote * remote, Packet * packet )
 		scheduler_insert_waitable( ctx->sock.notify, ctx, NULL, (WaitableNotifyRoutine)udp_channel_notify, NULL );
 
 		packet_add_tlv_uint( response, TLV_TYPE_CHANNEL_ID, channel_get_id(ctx->sock.channel) );
+		net_tlv_pack_local_addrinfo( &ctx->sock, response );
 
 		dprintf( "[UDP] request_net_udp_channel_open. UDP socket on channel %d (The local specified was %s:%d ) (The peer specified was %s:%d)",  channel_get_id( ctx->sock.channel ), inet_ntoa( ctx->localhost ), ctx->localport, inet_ntoa( ctx->peerhost ), ctx->peerport );
 

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -835,6 +835,10 @@ def resolve_host(hostname, family):
     address = address_info['sockaddr'][0]
     return {'family': family, 'address': address, 'packed_address': inet_pton(family, address)}
 
+def tlv_pack_local_addrinfo(sock):
+    local_host, local_port = sock.getsockname()[:2]
+    return tlv_pack(TLV_TYPE_LOCAL_HOST, local_host) + tlv_pack(TLV_TYPE_LOCAL_PORT, local_port)
+
 def windll_RtlGetVersion():
     if not has_windll:
         return None
@@ -896,6 +900,7 @@ def channel_open_stdapi_net_tcp_client(request, response):
         return ERROR_CONNECTION_ERROR, response
     channel_id = meterpreter.add_channel(MeterpreterSocketTCPClient(sock))
     response += tlv_pack(TLV_TYPE_CHANNEL_ID, channel_id)
+    response += tlv_pack_local_addrinfo(sock)
     return ERROR_SUCCESS, response
 
 @register_function
@@ -914,6 +919,7 @@ def channel_open_stdapi_net_tcp_server(request, response):
     server_sock.listen(socket.SOMAXCONN)
     channel_id = meterpreter.add_channel(MeterpreterSocketTCPServer(server_sock))
     response += tlv_pack(TLV_TYPE_CHANNEL_ID, channel_id)
+    response += tlv_pack_local_addrinfo(server_sock)
     return ERROR_SUCCESS, response
 
 @register_function
@@ -926,6 +932,7 @@ def channel_open_stdapi_net_udp_client(request, response):
     peer_address = peer_address_info['sockaddr'] if peer_address_info else None
     channel_id = meterpreter.add_channel(MeterpreterSocketUDPClient(sock, peer_address))
     response += tlv_pack(TLV_TYPE_CHANNEL_ID, channel_id)
+    response += tlv_pack_local_addrinfo(sock)
     return ERROR_SUCCESS, response
 
 @register_function


### PR DESCRIPTION
This PR updates the channel opening behavior for TCP client, server and UDP channels to echo the local socket information back to metasploit in the Windows Native and Python impelmentations. This is notably useful to know what local port the socket is bound to when metasploit specified the value of 0 causing the socket to use an available one selected by the OS.

Changes to the framework to consume this information and offer meaningful testing steps are forthcoming.