### PR TITLE
fix rapid7/metasploit-framework#12778

### DIFF
--- a/java/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/java/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -110,7 +110,7 @@ public class Payload {
             return;
         }
         PowerManager.WakeLock wakeLock = null;
-        if ((config.flags & Config.FLAG_WAKELOCK) != 0) {
+        if ((config.flags & Config.FLAG_WAKELOCK) != 0 && context != null) {
             PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
             wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, Payload.class.getSimpleName());
             wakeLock.acquire();


### PR DESCRIPTION
Quick fix for https://github.com/rapid7/metasploit-framework/issues/12778
We should check if the context is `null` before trying to apply the wakelock.