### PR TITLE
fix wildcard usage in java meterpreter

### DIFF
--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_ls.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_ls.java
@@ -8,9 +8,18 @@ import com.metasploit.meterpreter.TLVType;
 import com.metasploit.meterpreter.command.Command;
 
 public class stdapi_fs_ls implements Command {
+
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         stdapi_fs_stat statCommand = (stdapi_fs_stat) meterpreter.getCommandManager().getCommand("stdapi_fs_stat");
-        File path = Loader.expand(request.getStringValue(TLVType.TLV_TYPE_DIRECTORY_PATH));
+        String pathString = request.getStringValue(TLVType.TLV_TYPE_DIRECTORY_PATH);
+        if (pathString.equals("*")) {
+            pathString = ".";
+        } else if (pathString.contains("*")) {
+            if (pathString.endsWith(File.separator + "*")) {
+                pathString = pathString.substring(0, pathString.length() - 1);
+            }
+        }
+        File path = Loader.expand(pathString);
         String[] entries = path.list();
         for (int i = 0; i < entries.length; i++) {
             if (entries[i].equals(".") || entries[i].equals(".."))

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_ls.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_ls.java
@@ -1,7 +1,6 @@
 package com.metasploit.meterpreter.stdapi;
 
 import java.io.File;
-import java.util.List;
 
 import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.TLVPacket;
@@ -13,26 +12,12 @@ public class stdapi_fs_ls implements Command {
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         stdapi_fs_stat statCommand = (stdapi_fs_stat) meterpreter.getCommandManager().getCommand("stdapi_fs_stat");
         String pathString = request.getStringValue(TLVType.TLV_TYPE_DIRECTORY_PATH);
-        File path = Loader.expand(pathString);
-        if (pathString.contains("*")) {
-            String root = path.getParent();
-            String match = path.getName();
-            List entries = stdapi_fs_search.findFiles(root, match, false);
-            for (int i = 0; i < entries.size(); i++) {
-                String entry = entries.get(i).toString();
-                if (entry.equals(".") || entry.equals(".."))
-                    continue;
-                File f = new File(entry);
-                String pathEntry = entry;
-                if (pathEntry.startsWith(root)) {
-                    pathEntry = pathEntry.substring(root.length() + 1);
-                }
-                response.addOverflow(TLVType.TLV_TYPE_FILE_NAME, pathEntry);
-                response.addOverflow(TLVType.TLV_TYPE_FILE_PATH, pathEntry);
-                response.addOverflow(TLVType.TLV_TYPE_STAT_BUF, statCommand.stat(f));
-            }
-            return ERROR_SUCCESS;
+        if (pathString.equals("*")) {
+            pathString = ".";
+        } else if (pathString.endsWith(File.separator + "*")) {
+            pathString = pathString.substring(0, pathString.length() - 1);
         }
+        File path = Loader.expand(pathString);
         String[] entries = path.list();
         for (int i = 0; i < entries.length; i++) {
             if (entries[i].equals(".") || entries[i].equals(".."))

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_ls.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_ls.java
@@ -1,6 +1,7 @@
 package com.metasploit.meterpreter.stdapi;
 
 import java.io.File;
+import java.util.List;
 
 import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.TLVPacket;
@@ -12,12 +13,26 @@ public class stdapi_fs_ls implements Command {
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         stdapi_fs_stat statCommand = (stdapi_fs_stat) meterpreter.getCommandManager().getCommand("stdapi_fs_stat");
         String pathString = request.getStringValue(TLVType.TLV_TYPE_DIRECTORY_PATH);
-        if (pathString.equals("*")) {
-            pathString = ".";
-        } else if (pathString.endsWith(File.separator + "*")) {
-            pathString = pathString.substring(0, pathString.length() - 1);
-        }
         File path = Loader.expand(pathString);
+        if (pathString.contains("*")) {
+            String root = path.getParent();
+            String match = path.getName();
+            List entries = stdapi_fs_search.findFiles(root, match, false);
+            for (int i = 0; i < entries.size(); i++) {
+                String entry = entries.get(i).toString();
+                if (entry.equals(".") || entry.equals(".."))
+                    continue;
+                File f = new File(entry);
+                String pathEntry = entry;
+                if (pathEntry.startsWith(root)) {
+                    pathEntry = pathEntry.substring(root.length() + 1);
+                }
+                response.addOverflow(TLVType.TLV_TYPE_FILE_NAME, f.getName());
+                response.addOverflow(TLVType.TLV_TYPE_FILE_PATH, pathEntry);
+                response.addOverflow(TLVType.TLV_TYPE_STAT_BUF, statCommand.stat(f));
+            }
+            return ERROR_SUCCESS;
+        }
         String[] entries = path.list();
         for (int i = 0; i < entries.length; i++) {
             if (entries[i].equals(".") || entries[i].equals(".."))

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_ls.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_ls.java
@@ -1,6 +1,7 @@
 package com.metasploit.meterpreter.stdapi;
 
 import java.io.File;
+import java.util.List;
 
 import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.TLVPacket;
@@ -12,14 +13,26 @@ public class stdapi_fs_ls implements Command {
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         stdapi_fs_stat statCommand = (stdapi_fs_stat) meterpreter.getCommandManager().getCommand("stdapi_fs_stat");
         String pathString = request.getStringValue(TLVType.TLV_TYPE_DIRECTORY_PATH);
-        if (pathString.equals("*")) {
-            pathString = ".";
-        } else if (pathString.contains("*")) {
-            if (pathString.endsWith(File.separator + "*")) {
-                pathString = pathString.substring(0, pathString.length() - 1);
-            }
-        }
         File path = Loader.expand(pathString);
+        if (pathString.contains("*")) {
+            String root = path.getParent();
+            String match = path.getName();
+            List entries = stdapi_fs_search.findFiles(root, match, false);
+            for (int i = 0; i < entries.size(); i++) {
+                String entry = entries.get(i).toString();
+                if (entry.equals(".") || entry.equals(".."))
+                    continue;
+                File f = new File(entry);
+                String pathEntry = entry;
+                if (pathEntry.startsWith(root)) {
+                    pathEntry = pathEntry.substring(root.length() + 1);
+                }
+                response.addOverflow(TLVType.TLV_TYPE_FILE_NAME, pathEntry);
+                response.addOverflow(TLVType.TLV_TYPE_FILE_PATH, pathEntry);
+                response.addOverflow(TLVType.TLV_TYPE_STAT_BUF, statCommand.stat(f));
+            }
+            return ERROR_SUCCESS;
+        }
         String[] entries = path.list();
         for (int i = 0; i < entries.length; i++) {
             if (entries[i].equals(".") || entries[i].equals(".."))

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_search.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_search.java
@@ -52,7 +52,7 @@ public class stdapi_fs_search implements Command {
         }
     }
 
-    private List findFiles(String path, String mask, boolean recurse) {
+    public static List findFiles(String path, String mask, boolean recurse) {
         try {
             File pathfile = Loader.expand(path);
             if (!pathfile.exists() || !pathfile.isDirectory()) {

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_search.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_search.java
@@ -52,7 +52,7 @@ public class stdapi_fs_search implements Command {
         }
     }
 
-    public static List findFiles(String path, String mask, boolean recurse) {
+    private List findFiles(String path, String mask, boolean recurse) {
         try {
             File pathfile = Loader.expand(path);
             if (!pathfile.exists() || !pathfile.isDirectory()) {


### PR DESCRIPTION
This should fix the usage of wildcards (*) in java meterpreter ls (and download). 
It fixes some common cases, e.g:

Before
```
meterpreter > cd /home/user/Desktop
meterpreter > ls
Listing: /home/user/Desktop
===========================

Mode             Size  Type  Last modified              Name
----             ----  ----  -------------              ----
40776/rwxrwxrw-  4096  dir   2020-03-06 11:18:09 +0800  folder

meterpreter > ls *
[-] stdapi_fs_ls: Operation failed: 1
meterpreter > download *
[-] stdapi_fs_ls: Operation failed: 1
meterpreter > ls folder/*
[-] stdapi_fs_ls: Operation failed: 1
meterpreter >
```
After fix:
```
meterpreter > cd /home/user/Desktop
meterpreter > ls *
Listing: *
==========

Mode             Size  Type  Last modified              Name
----             ----  ----  -------------              ----
40776/rwxrwxrw-  4096  dir   2020-03-06 11:18:09 +0800  folder

meterpreter > download *
[*] mirroring  : ./folder -> ./folder
[*] downloading: ./folder/lolol -> ./folder/lolol
[*] skipped    : ./folder/lolol -> ./folder/lolol
[*] mirrored   : ./folder -> ./folder
meterpreter > ls folder/*
Listing: folder/*
=================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100666/rw-rw-rw-  0     fil   2020-03-06 11:18:09 +0800  lolol

meterpreter > download folder/*
[*] downloading: folder/lolol -> ./lolol
[*] download   : folder/lolol -> ./lolol
meterpreter >
```


This matches the implementation of non-java meterpreters. I'm happy to add some tests on the framework side to confirm this and lock down the behaviour.
Tab completion should also work now.

Ping @schierlm 