### PR TITLE
Fix stageless config block memory protection

### DIFF
--- a/c/meterpreter/source/common/remote.c
+++ b/c/meterpreter/source/common/remote.c
@@ -73,6 +73,11 @@ VOID remote_deallocate(Remote * remote)
 		lock_destroy(remote->lock);
 	}
 
+	if (remote->orig_config)
+	{
+		free(remote->orig_config);
+	}
+
 	// Wipe our structure from memory
 	memset(remote, 0, sizeof(Remote));
 

--- a/c/meterpreter/source/server/win/remote_dispatch.c
+++ b/c/meterpreter/source/server/win/remote_dispatch.c
@@ -296,7 +296,7 @@ DWORD request_core_set_session_guid(Remote* remote, Packet* packet)
 
 	if (sessionGuid != NULL)
 	{
-		memcpy(&remote->orig_config->session.session_guid, sessionGuid, sizeof(GUID));
+		memcpy(remote->orig_config->session.session_guid, sessionGuid, sizeof(GUID));
 	}
 	else
 	{


### PR DESCRIPTION
HAI GUYZ! Long time no see ❤️ 

## Description

I found an edge case where stageless payloads did not work when they were embedded in .NET applications. The reason for this is because the configuration block is stored alongside the code in stageless payloads and hence is loaded into memory as part of the section when it's mapped.
This section, in native world, remains RWX, and hence we don't have a problem reading from and writing to it. We write to it for various reasons, such as when the session guid changes.

In .NET land, this section is mapped as RX instead of RWX. This means that when we try to write to it, the program segfaults due to an access violation.

This code modifies the loading of the configuration so that instead of maintaining a pointer to the original configuration, it instead creates a copy of it on the heap. I preferred this fix over marking the memory as RWX, which obviously stands out a bit more.

## Verification

The easiest way to validate that this is currently broken is to use [this shellcode launcher](https://github.com/Arno0x/CSharpScripts/blob/master/shellcodeLauncher.cs). When you build the project make sure you either build directly for x64 or x86, or that you use corflags.exe to modify the binary. The point is to make sure that whatever payload you generate, you match the architecture of the payload to the .NET binary. This should be tested for both architectures.

When you've got a functional stub, validate that it's broken:
- [x] Generate a stageless payload (eg. `meterpreter_reverse_tcp`), embed it into the launcher, and build it.
- [x] Create a listener
- [x] Run the payload ... it should crash almost immediately.

Apply the fix, then:
- [x] Generate a stageless payload (eg. `meterpreter_reverse_tcp`), embed it into the launcher, and build it.
- [x] Create a listener
- [x] Run the payload ... it should NOT crash. At all.

Also: