### PR TITLE
fix rapid7/metasploit-framework#12580

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Channel.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Channel.java
@@ -15,8 +15,8 @@ public class Channel {
     private final OutputStream out;
     private final int id;
     protected final Meterpreter meterpreter;
-    private boolean active = false, closed = false, waiting = false;
-    private byte[] toRead;
+    protected boolean active = false, closed = false, waiting = false;
+    protected byte[] toRead;
 
     /**
      * Create a new "generic" channel.
@@ -66,13 +66,13 @@ public class Channel {
      * @param maxLength The maximum number of bytes to read.
      * @return The bytes read, or <code>null</code> if the end of the stream has been reached.
      */
-    public synchronized byte[] read(int maxLength) {
+    public synchronized byte[] read(int maxLength) throws IOException, InterruptedException {
         if (closed)
             return null;
         if (active)
             throw new IllegalStateException("Cannot read; currently interacting with this channel");
-        if (!waiting || (toRead != null && toRead.length == 0))
-            return new byte[0];
+        while (!waiting || (toRead != null && toRead.length == 0))
+            wait();
         if (toRead == null)
             return null;
         byte[] result = new byte[Math.min(toRead.length, maxLength)];

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/ProcessChannel.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/ProcessChannel.java
@@ -28,11 +28,12 @@ public class ProcessChannel extends Channel {
 
     /**
      * Read at least one byte, and up to maxLength bytes from this stream.
+     * An empty string (0 length data) is returned if no data is available.
      *
      * @param maxLength The maximum number of bytes to read.
      * @return The bytes read, or <code>null</code> if the end of the stream has been reached.
      */
-    public synchronized byte[] read(int maxLength) {
+    public synchronized byte[] read(int maxLength) throws IOException, InterruptedException {
         if (closed)
             return null;
         if (active)
@@ -41,13 +42,7 @@ public class ProcessChannel extends Channel {
             return new byte[0];
         if (toRead == null)
             return null;
-        byte[] result = new byte[Math.min(toRead.length, maxLength)];
-        System.arraycopy(toRead, 0, result, 0, result.length);
-        byte[] rest = new byte[toRead.length - result.length];
-        System.arraycopy(toRead, result.length, rest, 0, rest.length);
-        toRead = rest;
-        notifyAll();
-        return result;
+        return super.read(maxLength);
     }
 
     public void close() throws IOException {


### PR DESCRIPTION
This change fixes https://github.com/rapid7/metasploit-framework/issues/12580
The bug was previously introduced by https://github.com/rapid7/metasploit-payloads/pull/334

Currently there is a race condition in that if fs.read is called before the InteractThread has started, the read will return '' (an empty string). This is acceptable on a ProcessChannel (where data can be added at any time), but is incorrect on a file channel (as shown by the test failure).

The fix simply reverts the change on the normal Channel class, and instead only applies it to the ProcessChannel class.

Ping @schierlm @bwatters-r7 

## Verification

Get a java reverse tcp (or bind tcp) session:
```
msfconsole -qx "use exploit/multi/handler; set payload java/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"

setg SESSION -1

loadpath test/modules/
use post/test/cmd_exec 
run

use post/test/meterpreter 
run
```
- [ ] Verify all tests pass
