### PR TITLE
Add TLV encryption support to Python Meterpreter

### DIFF
--- a/gem/lib/metasploit-payloads/version.rb
+++ b/gem/lib/metasploit-payloads/version.rb
@@ -1,6 +1,6 @@
 # -*- coding:binary -*-
 module MetasploitPayloads
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 
   def self.version
     VERSION


### PR DESCRIPTION
This is the PR that goes along with the [Metasploit PR](https://github.com/rapid7/metasploit-framework/pull/13432) that supports the changes in Python Meterp. Please refer to that PR for all the details.