### PR TITLE
Add TLV encryption support to Java Meterpreter

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
@@ -69,6 +69,12 @@ public interface TLVType {
     public static final int TLV_TYPE_UUID         = TLVPacket.TLV_META_TYPE_RAW    | 461;
     public static final int TLV_TYPE_SESSION_GUID = TLVPacket.TLV_META_TYPE_RAW    | 462;
 
+    // TLV Encryption
+    public static final int TLV_TYPE_RSA_PUB_KEY  = TLVPacket.TLV_META_TYPE_STRING | 550;
+    public static final int TLV_TYPE_SYM_KEY_TYPE = TLVPacket.TLV_META_TYPE_UINT   | 551;
+    public static final int TLV_TYPE_SYM_KEY      = TLVPacket.TLV_META_TYPE_RAW    | 552;
+    public static final int TLV_TYPE_ENC_SYM_KEY  = TLVPacket.TLV_META_TYPE_RAW    | 553;
+
     // General
     public static final int TLV_TYPE_HANDLE         = TLVPacket.TLV_META_TYPE_QWORD | 600;
     public static final int TLV_TYPE_INHERIT        = TLVPacket.TLV_META_TYPE_BOOL  | 601;

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
@@ -70,7 +70,7 @@ public interface TLVType {
     public static final int TLV_TYPE_SESSION_GUID = TLVPacket.TLV_META_TYPE_RAW    | 462;
 
     // TLV Encryption
-    public static final int TLV_TYPE_RSA_PUB_KEY  = TLVPacket.TLV_META_TYPE_STRING | 550;
+    public static final int TLV_TYPE_RSA_PUB_KEY  = TLVPacket.TLV_META_TYPE_RAW    | 550;
     public static final int TLV_TYPE_SYM_KEY_TYPE = TLVPacket.TLV_META_TYPE_UINT   | 551;
     public static final int TLV_TYPE_SYM_KEY      = TLVPacket.TLV_META_TYPE_RAW    | 552;
     public static final int TLV_TYPE_ENC_SYM_KEY  = TLVPacket.TLV_META_TYPE_RAW    | 553;

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
@@ -19,6 +19,8 @@ public abstract class Transport {
     public static final int ENC_NONE = 0;
     public static final int ENC_AES256 = 1;
 
+    private static final SecureRandom sr = new SecureRandom();
+
     private Transport prev;
     private Transport next;
     private Meterpreter meterpreter;
@@ -134,14 +136,13 @@ public abstract class Transport {
     }
 
     protected byte[] aesEncrypt(byte[] data) throws Exception {
-        SecureRandom sr = new SecureRandom();
         byte[] iv = new byte[16];
         sr.nextBytes(iv);
 
         byte[] encrypted = null;
         IvParameterSpec ivSpec = new IvParameterSpec(iv);
         SecretKeySpec keySpec = new SecretKeySpec(this.aesKey, "AES");
-        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
         synchronized(cipher) {
           cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivSpec);
           encrypted = cipher.doFinal(data);

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
@@ -9,9 +9,15 @@ import java.io.DataOutputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 
+import java.security.SecureRandom;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.Cipher;
+
 public abstract class Transport {
     public static final long MS = 1000L;
     public static final int ENC_NONE = 0;
+    public static final int ENC_AES256 = 1;
 
     private Transport prev;
     private Transport next;
@@ -21,6 +27,8 @@ public abstract class Transport {
     protected long commTimeout;
     protected long retryTotal;
     protected long retryWait;
+    protected byte[] aesKey;
+    protected boolean aesEnabled;
 
     protected abstract boolean tryConnect(Meterpreter met) throws IOException;
 
@@ -34,6 +42,7 @@ public abstract class Transport {
     protected Transport(Meterpreter met, String url) {
         this.meterpreter = met;
         this.url = url;
+        this.aesEnabled = false;
     }
 
     protected void setTimeouts(TransportConfig transportConfig) {
@@ -79,8 +88,6 @@ public abstract class Transport {
         byte[] body = new byte[bodyLen];
         in.readFully(body);
 
-        // TODO: add decryption support here.
-
         // create a complete packet and xor the whole thing. We do this becauase we can't
         // be sure that the content of the body is 4-byte aligned with the xor key, so we
         // do the whole lot to make sure it behaves
@@ -89,8 +96,21 @@ public abstract class Transport {
         this.arrayCopy(body, 0, packet, clonedHeader.length, body.length);
         this.xorBytes(xorKey, packet);
 
-        // Skip the packet TLV header and move straight the first TLV header (by jumping over header.length bytes)
-        ByteArrayInputStream byteStream = new ByteArrayInputStream(packet, clonedHeader.length, body.length);
+        this.arrayCopy(packet, 32, body, 0, body.length);
+        int encFlag = this.readInt(packet, 20);
+        if (encFlag == ENC_AES256 && this.aesKey != null) {
+            try
+            {
+                body = aesDecrypt(body);
+            }
+            catch(Exception e)
+            {
+                // if things go back we're basically screwed.
+                return null;
+            }
+        }
+
+        ByteArrayInputStream byteStream = new ByteArrayInputStream(body, 0, body.length);
         DataInputStream inputStream = new DataInputStream(byteStream);
         TLVPacket tlvPacket = new TLVPacket(inputStream, body.length);
         inputStream.close();
@@ -98,19 +118,76 @@ public abstract class Transport {
         return tlvPacket;
     }
 
+    protected byte[] aesDecrypt(byte[] data) throws Exception {
+        byte[] iv = new byte[16];
+        byte[] encrypted = new byte[data.length - iv.length];
+        this.arrayCopy(data, 0, iv, 0, iv.length);
+        this.arrayCopy(data, iv.length, encrypted, 0, encrypted.length);
+
+        IvParameterSpec ivSpec = new IvParameterSpec(iv);
+        SecretKeySpec keySpec = new SecretKeySpec(this.aesKey, "AES");
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+        synchronized(cipher) {
+          cipher.init(Cipher.DECRYPT_MODE, keySpec, ivSpec);
+          return cipher.doFinal(encrypted);
+        }
+    }
+
+    protected byte[] aesEncrypt(byte[] data) throws Exception {
+        SecureRandom sr = new SecureRandom();
+        byte[] iv = new byte[16];
+        sr.nextBytes(iv);
+
+        byte[] encrypted = null;
+        IvParameterSpec ivSpec = new IvParameterSpec(iv);
+        SecretKeySpec keySpec = new SecretKeySpec(this.aesKey, "AES");
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+        synchronized(cipher) {
+          cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivSpec);
+          encrypted = cipher.doFinal(data);
+        }
+
+        data = new byte[encrypted.length + iv.length];
+        this.arrayCopy(iv, 0, data, 0, iv.length);
+        this.arrayCopy(encrypted, 0, data, iv.length, encrypted.length);
+        return data;
+    }
+
     protected void encodePacketAndWrite(TLVPacket tlvPacket, int type, DataOutputStream out) throws IOException {
         byte[] data = tlvPacket.toByteArray();
+
+        int encType = ENC_NONE;
+        if (this.aesKey != null) {
+            try
+            {
+                if (this.aesEnabled) {
+                    encType = ENC_AES256;
+                    data = aesEncrypt(data);
+                }
+                else
+                {
+                    // enabled it after the response packet goes out
+                    this.aesEnabled = true;
+                }
+            }
+            catch(Exception e)
+            {
+                // if things fail during encryption, should we
+                // just fallback to plain? Or terminate?
+                this.aesEnabled = false;
+                this.aesKey = null;
+            }
+        }
+
         byte[] packet = new byte[32 + data.length];
         randXorKey(packet, 0);
-
-        // TODO: add encryption support here
 
         // Include the session guid in the outgoing message
         byte[] sessionGUID = this.meterpreter.getSessionGUID();
         this.arrayCopy(sessionGUID, 0, packet, 4, sessionGUID.length);
 
         // We don't currently support encryption
-        this.writeInt(packet, 20, ENC_NONE);
+        this.writeInt(packet, 20, encType);
 
         // Write the length/type
         this.writeInt(packet, 24, data.length + 8);
@@ -151,6 +228,11 @@ public abstract class Transport {
         }
     }
 
+    public void setAesEncryptionKey(byte[] aesKey) {
+        this.aesKey = aesKey;
+        this.aesEnabled = false;
+    }
+
     public String getUrl() {
         return this.url;
     }
@@ -181,6 +263,8 @@ public abstract class Transport {
 
     public boolean connect(Meterpreter met) {
         long lastAttempt = System.currentTimeMillis();
+        this.aesKey = null;
+        this.aesEnabled = false;
 
         while (System.currentTimeMillis() < lastAttempt + this.retryTotal) {
             try {

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
@@ -128,7 +128,7 @@ public abstract class Transport {
 
         IvParameterSpec ivSpec = new IvParameterSpec(iv);
         SecretKeySpec keySpec = new SecretKeySpec(this.aesKey, "AES");
-        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
         synchronized(cipher) {
           cipher.init(Cipher.DECRYPT_MODE, keySpec, ivSpec);
           return cipher.doFinal(encrypted);

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
@@ -33,5 +33,6 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand(CommandId.CORE_TRANSPORT_NEXT, core_transport_next.class);
         mgr.registerCommand(CommandId.CORE_TRANSPORT_PREV, core_transport_prev.class);
         mgr.registerCommand(CommandId.CORE_TRANSPORT_REMOVE, core_transport_remove.class);
+        mgr.registerCommand(CommandId.CORE_NEGOTIATE_TLV_ENCRYPTION, core_negotiate_tlv_encryption.class);
     }
 }

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
@@ -27,7 +27,7 @@ public class core_negotiate_tlv_encryption implements Command {
         try
         {
             PublicKey pubKey = getPublicKey(der);
-            Cipher cipher = Cipher.getInstance("RSA");
+            Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
             cipher.init(Cipher.ENCRYPT_MODE, pubKey);
             response.add(TLVType.TLV_TYPE_ENC_SYM_KEY, cipher.doFinal(aesKey));
         }
@@ -42,7 +42,6 @@ public class core_negotiate_tlv_encryption implements Command {
         return ERROR_SUCCESS;
     }
 
-    // This is here for when we move over to using DER instead of PEM
     private PublicKey getPublicKey(byte[] der) {
         try
         {

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
@@ -1,0 +1,68 @@
+package com.metasploit.meterpreter.core;
+
+import javax.xml.bind.DatatypeConverter;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.spec.X509EncodedKeySpec;
+import java.lang.String;
+import javax.crypto.Cipher;
+
+import com.metasploit.meterpreter.Transport;
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.Utils;
+import com.metasploit.meterpreter.command.Command;
+
+public class core_negotiate_tlv_encryption implements Command {
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        String pem = request.getStringValue(TLVType.TLV_TYPE_RSA_PUB_KEY);
+
+        SecureRandom sr = new SecureRandom();
+        byte[] aesKey = new byte[32];
+        sr.nextBytes(aesKey);
+
+        try
+        {
+            PublicKey pubKey = getPublicKey(pem);
+            Cipher cipher = Cipher.getInstance("RSA");
+            cipher.init(Cipher.ENCRYPT_MODE, pubKey);
+            response.add(TLVType.TLV_TYPE_ENC_SYM_KEY, cipher.doFinal(aesKey));
+        }
+        catch(Exception e)
+        {
+            response.add(TLVType.TLV_TYPE_SYM_KEY, aesKey);
+        }
+        response.add(TLVType.TLV_TYPE_SYM_KEY_TYPE, Transport.ENC_AES256);
+
+        meterpreter.getTransports().current().setAesEncryptionKey(aesKey);
+
+        return ERROR_SUCCESS;
+    }
+
+    private PublicKey getPublicKey(String pem) {
+        String[] lines = pem.trim().split("\n", -1);
+        String b64 = "";
+        
+        for (int i = 1; i < lines.length - 1; ++i) {
+            b64 = String.join("", b64, lines[i]);
+        }
+
+        return getPublicKey(DatatypeConverter.parseBase64Binary(b64));
+    }
+
+    // This is here for when we move over to using DER instead of PEM
+    private PublicKey getPublicKey(byte[] der) {
+        try
+        {
+            X509EncodedKeySpec spec = new X509EncodedKeySpec(der);
+            return KeyFactory.getInstance("RSA").generatePublic(spec);
+        }
+        catch(Exception e)
+        {
+            return null;
+        }
+    }
+}

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
@@ -17,16 +17,16 @@ import com.metasploit.meterpreter.command.Command;
 
 public class core_negotiate_tlv_encryption implements Command {
 
-    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
-        String pem = request.getStringValue(TLVType.TLV_TYPE_RSA_PUB_KEY);
+    private static final SecureRandom sr = new SecureRandom();
 
-        SecureRandom sr = new SecureRandom();
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        byte[] der = request.getRawValue(TLVType.TLV_TYPE_RSA_PUB_KEY);
         byte[] aesKey = new byte[32];
         sr.nextBytes(aesKey);
 
         try
         {
-            PublicKey pubKey = getPublicKey(pem);
+            PublicKey pubKey = getPublicKey(der);
             Cipher cipher = Cipher.getInstance("RSA");
             cipher.init(Cipher.ENCRYPT_MODE, pubKey);
             response.add(TLVType.TLV_TYPE_ENC_SYM_KEY, cipher.doFinal(aesKey));
@@ -40,17 +40,6 @@ public class core_negotiate_tlv_encryption implements Command {
         meterpreter.getTransports().current().setAesEncryptionKey(aesKey);
 
         return ERROR_SUCCESS;
-    }
-
-    private PublicKey getPublicKey(String pem) {
-        String[] lines = pem.trim().split("\n", -1);
-        String b64 = "";
-        
-        for (int i = 1; i < lines.length - 1; ++i) {
-            b64 = String.join("", b64, lines[i]);
-        }
-
-        return getPublicKey(DatatypeConverter.parseBase64Binary(b64));
     }
 
     // This is here for when we move over to using DER instead of PEM


### PR DESCRIPTION
# Description

Carrying on from the [Python](https://github.com/rapid7/metasploit-payloads/pull/399) version, this is the start of the work to get things going in Java. And just like with the Python PR, I'm not going to let anyone know that I think Java is just one massive PileOfCrapXmlToStackTraceApplicationProxyFactoryBeanImpl.

![image](https://user-images.githubusercontent.com/28896/81992164-34922b00-9686-11ea-939e-6653367be883.png)

There's DER parsing in there ready to go for when the [PEM to DER](https://github.com/rapid7/metasploit-payloads/pull/397) lands as well.

To be clear, this is technically WIP for build/version reasons, and hence I'm going to request the attention of @timwr to help me get this over the line. He's been doing some testing for me behind the scenes already! But this PR makes the workflow a bit more official. Once we have this done (which I hope we can sort out today), then we're at the point where we can force TLV packet encryption across the board.

I know that the crypto stuff that's in this PR doesn't work every version of Java, so we need to confirm which versions do work, and if implementing this results in a change in the minimum supported version of Java then we need to make sure that's ok.

# Verification

- [x] Build
- [x] Deploy
- [x] Fire up a session
- [x] Confirm that sessions are encrypted!

Plz can haz help @timwr thank you!