### PR TITLE
Fix a NameError in _core_enumextcmd

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1301,7 +1301,7 @@ class PythonMeterpreter(object):
 
     def _core_enumextcmd(self, request, response):
         id_start = packet_get_tlv(request, TLV_TYPE_UINT)['value']
-        id_end = packet_get_tlv(request, TLV_TYPE_LENGTH)['value'] + start
+        id_end = packet_get_tlv(request, TLV_TYPE_LENGTH)['value'] + id_start
         for func_name in self.extension_functions.keys():
             command_id = cmd_string_to_id(func_name)
             if id_start < command_id and command_id < id_end:
@@ -1370,11 +1370,9 @@ class PythonMeterpreter(object):
         extension_name = self.last_registered_extension
 
         if extension_name:
-            sys.stderr.write(extension_name + "\n")
             check_extension = lambda x: x.startswith(extension_name)
             lib_methods = list(filter(check_extension, list(self.extension_functions.keys())))
             for method in lib_methods:
-                sys.stderr.write(extension_name + " -> " + method + "\n")
                 response += tlv_pack(TLV_TYPE_UINT, cmd_string_to_id(method))
         return ERROR_SUCCESS, response
 


### PR DESCRIPTION
This fixes 2 minor issues with the Python meterpreter:
1. There was a `NameError` in `_core_enumextcmd` due to `start` missing it's `id_` prefix
1. This removes debugging output showing the name mappings

Testing steps

- [ ] Use msfconsole to generate a `python/meterpreter/reverse_tcp` payload
* Optionally set the options to run it in the foreground with debug output
  - [ ] Enable `PythonMeterpreterDebug`
  - [ ] Disable `MeterpreterTryToFork`
- [ ] Run the payload using `python -c`
- [ ] Do not see a stack trace, or command names like `stdapi -> stdapi_sys_config_getenv`

<details>
<summary>Before the patch</summary>

```
[-] method core_negotiate_tlv_encryption was requested but does not exist
[*] running method core_machine_id
[*] running method core_enumextcmd
[-] method core_enumextcmd resulted in an error
Traceback (most recent call last):
  File "<string>", line 1547, in create_response
  File "<string>", line 1304, in _core_enumextcmd
NameError: name 'start' is not defined
[*] running method core_loadlib
stdapi
stdapi -> stdapi_sys_config_getenv
stdapi -> stdapi_sys_config_getuid
stdapi -> stdapi_sys_config_localtime
stdapi -> stdapi_sys_config_sysinfo
stdapi -> stdapi_sys_process_close
stdapi -> stdapi_sys_process_execute
stdapi -> stdapi_sys_process_getpid
stdapi -> stdapi_sys_process_kill
stdapi -> stdapi_sys_process_get_processes
stdapi -> stdapi_fs_chdir
stdapi -> stdapi_fs_delete_dir
stdapi -> stdapi_fs_delete_file
stdapi -> stdapi_fs_file_expand_path
stdapi -> stdapi_fs_file_move
```
</details>

<details>
<summary>After the patch</summary>

```
[-] method core_negotiate_tlv_encryption was requested but does not exist
[*] running method core_machine_id
[*] running method core_enumextcmd
[*] running method core_loadlib
[*] running method stdapi_fs_getwd
[*] running method stdapi_sys_config_getuid
[*] running method stdapi_sys_config_sysinfo
[*] running method core_set_uuid
[*] running method stdapi_net_config_get_interfaces
[-] method stdapi_net_config_get_routes was requested but does not exist
[*] running method core_channel_eof
[-] method core_channel_eof resulted in error: #1
[*] running method core_channel_eof
[-] method core_channel_eof resulted in error: #1
[*] running method core_channel_eof
[-] method core_channel_eof resulted in error: #1
```
</details>