### PR TITLE
Change from PEM to DER for crypt TLV negotiation (Python edition)

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1417,11 +1417,16 @@ class PythonMeterpreter(object):
         if (data_tlv['type'] & TLV_META_TYPE_COMPRESSED) == TLV_META_TYPE_COMPRESSED:
             return ERROR_FAILURE, response
 
+        libname = '???'
+        match = re.search(r'^meterpreter\.register_extension\(\'([a-zA-Z0-9]+)\'\)$', str(data_tlv['value']), re.MULTILINE)
+        if match is not None:
+            libname = match.group(1)
+
         self.last_registered_extension = None
         symbols_for_extensions = {'meterpreter':self}
         symbols_for_extensions.update(EXPORTED_SYMBOLS)
         i = code.InteractiveInterpreter(symbols_for_extensions)
-        i.runcode(compile(data_tlv['value'], '', 'exec'))
+        i.runcode(compile(data_tlv['value'], 'ext_server_' + libname + '.py', 'exec'))
         extension_name = self.last_registered_extension
 
         if extension_name:

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -164,7 +164,7 @@ TLV_TYPE_MACHINE_ID            = TLV_META_TYPE_STRING  | 460
 TLV_TYPE_UUID                  = TLV_META_TYPE_RAW     | 461
 TLV_TYPE_SESSION_GUID          = TLV_META_TYPE_RAW     | 462
 
-TLV_TYPE_RSA_PUB_KEY           = TLV_META_TYPE_STRING  | 550
+TLV_TYPE_RSA_PUB_KEY           = TLV_META_TYPE_RAW     | 550
 TLV_TYPE_SYM_KEY_TYPE          = TLV_META_TYPE_UINT    | 551
 TLV_TYPE_SYM_KEY               = TLV_META_TYPE_RAW     | 552
 TLV_TYPE_ENC_SYM_KEY           = TLV_META_TYPE_RAW     | 553
@@ -1403,11 +1403,9 @@ class PythonMeterpreter(object):
         self.transport.aes_key = rand_bytes(32)
         self.transport.aes_enabled = False
         response += tlv_pack(TLV_TYPE_SYM_KEY_TYPE, ENC_AES256)
-        # TODO: adjust this when we've moved from PEM to DER
-        pem = packet_get_tlv(request, TLV_TYPE_RSA_PUB_KEY)['value'].strip()
-        debug_print('[*] PEM is: ' + pem)
-        der = base64.b64decode(bytes(''.join(pem.split("\n")[1:-1]), 'UTF-8'))
-        debug_print('[*] AES Key: ' + hex(met_rsa.b2i(self.transport.aes_key)))
+        der = packet_get_tlv(request, TLV_TYPE_RSA_PUB_KEY)['value'].strip()
+        debug_print('[*] RSA key: ' + str(binascii.b2a_hex(der)))
+        debug_print('[*] AES key: ' + hex(met_rsa.b2i(self.transport.aes_key)))
         enc_key = met_rsa_encrypt(der, self.transport.aes_key)
         debug_print('[*] Encrypted AES key: ' + hex(met_rsa.b2i(enc_key)))
         response += tlv_pack(TLV_TYPE_ENC_SYM_KEY, enc_key)


### PR DESCRIPTION
This makes the following two changes to the Python Meterpreter:
1. Changes RSA keys from PEM to DER format to be compatible with the latest Framework changes (see rapid7/metasploit-framework#13400).
1. Updates `core_loadlib` to extract the extension name from the source code. This allows the `compile()` operation to know the proper name of the extension which will then show up in stack traces. This is a quality of life improvement for Python Meterpreter development as it makes stack traces more readable.

Tested with Python versions: 2.5.6, 2.6.9, 2.7.17, 3.1.5, 3.2.6, 3.4.10, 3.5.9, 3.6.10, 3.7.7, 3.8.2

Example stack trace:
*This is an excerpt from the debug output generated while running the `post/test/file` module, which generates these errors under normal circumstances.*

Note the references to "ext_server_stdapi.py".
```
[-] method stdapi_fs_stat resulted in an error
Traceback (most recent call last):
  File "<string>", line 1605, in create_response
  File "ext_server_stdapi.py", line 1421, in stdapi_fs_stat
  File "ext_server_stdapi.py", line 664, in get_stat_buffer
FileNotFoundError: [Errno 2] No such file or directory: 'c:\\pagefile.sys'
[*] Sending respond packet
[*] running method stdapi_fs_stat
[*] Sending respond packet
[*] running method stdapi_fs_stat
[-] method stdapi_fs_stat resulted in an error
Traceback (most recent call last):
  File "<string>", line 1605, in create_response
  File "ext_server_stdapi.py", line 1421, in stdapi_fs_stat
  File "ext_server_stdapi.py", line 664, in get_stat_buffer
FileNotFoundError: [Errno 2] No such file or directory: '/etc/master.passwd'
```

Testing

- [ ] Use a merged 6.x branch from Metasploit to incorporate the CMD ID changes
- [ ] Generate a Python Meterpreter payload (I tested with the unstaged) and get a session
- [ ] Run the `post/test/file` module to ensure responsiveness