### PR TITLE
rename public build container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # To build the dev environment.
-# docker build -t rapid7/build:meterpreter .
+# docker build -t rapid7/msf-ubuntu-x64-meterpreter:latest .
 
 FROM ubuntu:14.04.5
 MAINTAINER Brent Cook <bcook@rapid7.com> (@busterbcook)


### PR DESCRIPTION
Latest container has been published to [dockerhub](https://hub.docker.com/repository/docker/rapid7/msf-ubuntu-x64-meterpreter).

Tagged as `2020_06` & `latest`
