### PR TITLE
Support AES-128-CBC For Java's TLV Crypt

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
@@ -18,6 +18,7 @@ public abstract class Transport {
     public static final long MS = 1000L;
     public static final int ENC_NONE = 0;
     public static final int ENC_AES256 = 1;
+    public static final int ENC_AES128 = 2;
 
     private static final SecureRandom sr = new SecureRandom();
 
@@ -100,7 +101,7 @@ public abstract class Transport {
 
         this.arrayCopy(packet, 32, body, 0, body.length);
         int encFlag = this.readInt(packet, 20);
-        if (encFlag == ENC_AES256 && this.aesKey != null) {
+        if (encFlag == ENC_AES128 && this.aesKey != null) {
             try
             {
                 body = aesDecrypt(body);
@@ -162,7 +163,7 @@ public abstract class Transport {
             try
             {
                 if (this.aesEnabled) {
-                    encType = ENC_AES256;
+                    encType = ENC_AES128;
                     data = aesEncrypt(data);
                 }
                 else

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Transport.java
@@ -101,7 +101,7 @@ public abstract class Transport {
 
         this.arrayCopy(packet, 32, body, 0, body.length);
         int encFlag = this.readInt(packet, 20);
-        if (encFlag == ENC_AES128 && this.aesKey != null) {
+        if (encFlag != ENC_NONE && this.aesKey != null) {
             try
             {
                 body = aesDecrypt(body);
@@ -162,8 +162,8 @@ public abstract class Transport {
         if (this.aesKey != null) {
             try
             {
-                if (this.aesEnabled) {
-                    encType = ENC_AES128;
+                if (this.aesEnabled && this.aesKey != null) {
+                    encType = (this.aesKey.length == 32 ? ENC_AES256 : ENC_AES128);
                     data = aesEncrypt(data);
                 }
                 else

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
@@ -21,7 +21,7 @@ public class core_negotiate_tlv_encryption implements Command {
 
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         byte[] der = request.getRawValue(TLVType.TLV_TYPE_RSA_PUB_KEY);
-        byte[] aesKey = new byte[32];
+        byte[] aesKey = new byte[16];
         sr.nextBytes(aesKey);
 
         try
@@ -35,7 +35,7 @@ public class core_negotiate_tlv_encryption implements Command {
         {
             response.add(TLVType.TLV_TYPE_SYM_KEY, aesKey);
         }
-        response.add(TLVType.TLV_TYPE_SYM_KEY_TYPE, Transport.ENC_AES256);
+        response.add(TLVType.TLV_TYPE_SYM_KEY_TYPE, Transport.ENC_AES128);
 
         meterpreter.getTransports().current().setAesEncryptionKey(aesKey);
 

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_negotiate_tlv_encryption.java
@@ -21,7 +21,8 @@ public class core_negotiate_tlv_encryption implements Command {
 
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         byte[] der = request.getRawValue(TLVType.TLV_TYPE_RSA_PUB_KEY);
-        byte[] aesKey = new byte[16];
+        int encType = (Cipher.getMaxAllowedKeyLength("AES") >= 256 ? Transport.ENC_AES256 : Transport.ENC_AES128);
+        byte[] aesKey = new byte[encType == Transport.ENC_AES256 ? 32 : 16];
         sr.nextBytes(aesKey);
 
         try
@@ -35,7 +36,7 @@ public class core_negotiate_tlv_encryption implements Command {
         {
             response.add(TLVType.TLV_TYPE_SYM_KEY, aesKey);
         }
-        response.add(TLVType.TLV_TYPE_SYM_KEY_TYPE, Transport.ENC_AES128);
+        response.add(TLVType.TLV_TYPE_SYM_KEY_TYPE, encType);
 
         meterpreter.getTransports().current().setAesEncryptionKey(aesKey);
 


### PR DESCRIPTION
This will be followed shortly by a framework side pull request.

This adds support to the Java Meterpreter to use fail back to AES-128 when AES-256 is unavailable. This is intended to provide maximum compatibility with other Java versions, particularly ones where strong crypto is unavailable.

This fixes a bug where on older Java versions, the Meterpreter session would not properly establish itself due to strong crypto being unavailable.

## Testing Steps

- [ ] Build the thing, I'd be happy to help with this and or provide a built gem upon request
- [ ] Install the gem or extract the relevant JAR files to `~/.msf4/payload/meterpreter`
- [ ] Load `msfconsole` and generate a Java meterpreter with `use payload/java/meterpreter/reverse_tcp`
- [ ] Test the payload works...
    - [ ] With a newer version of Java like 1.8.0_251 and negotiates AES-256
    - [ ] With an older version of Java like [1.8.0_131](https://www.filepuma.com/download/java_runtime_environment_32bit_8.0.1310.11-14917/) and negotiates AES-128