### PR TITLE
log error to base stream

### DIFF
--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/ProcessChannel.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/ProcessChannel.java
@@ -74,7 +74,7 @@ public class ProcessChannel extends Channel {
                 stderrThread.join();
                 handleInteract(null);
             } catch (Throwable t) {
-                t.printStackTrace(this.outputStream);
+                t.printStackTrace(meterpreter.getErrorStream());
             }
         }
     }


### PR DESCRIPTION
Changes from #395 interacted with #421 causing `outputStream`
to no longer be a local variable.  Revert to grabbing the error
stream from the base object when logging the error.