### PR TITLE
Update makefile to match new output folder and naming convention.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,18 +10,17 @@ install-all: \
 	install-python
 
 install-windows:
-	@echo "Installing Windows payloads"
-
-        ifneq ("$(wildcard c/meterpreter/output/*.x86.dll)","")
-	        @cp c/meterpreter/output/*.x86.dll $(METERPDIR) 
-        else
-	        @echo "Note: Windows 32-bit not built, skipping"
-        endif
-        ifneq ("$(wildcard c/meterpreter/output/*.x64.dll)","")
-	        @cp c/meterpreter/output/*.x64.dll $(METERPDIR) 
-        else
-	        @echo "Note: Windows 64-bit not built, skipping"
-        endif
+		@echo "Installing Windows payloads"
+    ifneq ("$(wildcard c/meterpreter/output/*.x86.dll)","")
+			@cp c/meterpreter/output/*.x86.dll $(METERPDIR) 
+    else
+			@echo "Note: Windows 32-bit not built, skipping"
+    endif
+    ifneq ("$(wildcard c/meterpreter/output/*.x64.dll)","")
+			@cp c/meterpreter/output/*.x64.dll $(METERPDIR) 
+    else
+			@echo "Note: Windows 64-bit not built, skipping"
+    endif
 
 install-java:
 	@echo "Installing Java payloads"

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,17 @@ install-all: \
 
 install-windows:
 	@echo "Installing Windows payloads"
-	@if [ -d c/meterpreter/output/x86 ]; then \
-		cp -a c/meterpreter/output/x86/*.dll $(METERPDIR); \
-	else \
-		echo "Note: Windows 32-bit not built, skipping"; \
-	fi
-	@if [ -d c/meterpreter/output/x64 ]; then \
-		cp -a c/meterpreter/output/x64/*.dll $(METERPDIR); \
-	else \
-		echo "Note: Windows 64-bit not built, skipping"; \
-	fi
+
+        ifneq ("$(wildcard c/meterpreter/output/*.x86.dll)","")
+	        @cp c/meterpreter/output/*.x86.dll $(METERPDIR) 
+        else
+	        @echo "Note: Windows 32-bit not built, skipping"
+        endif
+        ifneq ("$(wildcard c/meterpreter/output/*.x64.dll)","")
+	        @cp c/meterpreter/output/*.x64.dll $(METERPDIR) 
+        else
+	        @echo "Note: Windows 64-bit not built, skipping"
+        endif
 
 install-java:
 	@echo "Installing Java payloads"


### PR DESCRIPTION
This is a super easy patch up fix to the main payload makefile to support the new output folder location and naming conventions that we started using in msf6 (I guess?)


Testing:
- [x] Ensure you do not have binaries built from a previous compilation (Delete the dlls in `/c/meterpreter/output/`
- [x] Run Make install-windows and verify it says you don't have the binaries.
- [x] Build the windows binaries.
- [x] Run make install-windows again, and verify the binaries are moved to the correct location.