### PR TITLE
Fix endless loop bug

### DIFF
--- a/c/meterpreter/source/metsrv/server_transport_tcp.c
+++ b/c/meterpreter/source/metsrv/server_transport_tcp.c
@@ -308,7 +308,7 @@ static DWORD packet_receive(Remote *remote, Packet **packet)
 	DWORD headerBytes = 0, payloadBytesLeft = 0, res;
 	Packet *localPacket = NULL;
 	PacketHeader header = { 0 };
-	DWORD bytesRead;
+	int bytesRead;
 	BOOL inHeader = TRUE;
 	PUCHAR packetBuffer = NULL;
 	ULONG payloadLength;


### PR DESCRIPTION
Main thread will be stuck in loop if recv returns SOCKET_ERROR (-1) due
to int to DWORD casting