### PR TITLE
Use the proper bytes type when building search response TLVs

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1383,14 +1383,14 @@ def stdapi_fs_search(request, response):
     if recurse:
         for root, dirs, files in os.walk(search_root):
             for f in filter(lambda f: fnmatch.fnmatch(f, glob), files):
-                file_tlv  = ''
+                file_tlv  = bytes()
                 file_tlv += tlv_pack(TLV_TYPE_FILE_PATH, root)
                 file_tlv += tlv_pack(TLV_TYPE_FILE_NAME, f)
                 file_tlv += tlv_pack(TLV_TYPE_FILE_SIZE, os.stat(os.path.join(root, f)).st_size)
                 response += tlv_pack(TLV_TYPE_SEARCH_RESULTS, file_tlv)
     else:
         for f in filter(lambda f: fnmatch.fnmatch(f, glob), os.listdir(search_root)):
-            file_tlv  = ''
+            file_tlv  = bytes()
             file_tlv += tlv_pack(TLV_TYPE_FILE_PATH, search_root)
             file_tlv += tlv_pack(TLV_TYPE_FILE_NAME, f)
             file_tlv += tlv_pack(TLV_TYPE_FILE_SIZE, os.stat(os.path.join(search_root, f)).st_size)


### PR DESCRIPTION
The Python meterpreter needs to explicitly specified `bytes()` when building TLV response groups. This is already the case when enumerating processes and network interfaces, however the filesystem search functionality does not do this. The result is on Python 3.x versions, the search command is broken due to the inability to append bytes and string types.

Before the patch:
```
meterpreter > search -f *.pdf
[-] 1013: Operation failed: Python exception: TypeError
```

After the patch:
```
meterpreter > search -f *.pdf
Found 3 results...
    ./data/exploits/CVE-2018-9948/template.pdf (3115 bytes)
    ./data/exploits/CVE-2010-1240/template.pdf (618 bytes)
    ./documentation/developers_guide.pdf (458889 bytes)
```

## Testing

I used a test harness and PyEnv to test all supported versions of Python (2.5-2.7 & 3.1-3.8).

- [x] Load msfconsole and `use payload/python/meterpreter/reverse_tcp`
- [x] Set the `LHOST` option as appropriate and generate the payload using `generate -f raw -o /path/to/meterpreter.py`
- [x]  Start the handler with `to_handler`
- [x] From the working directory of the metasploit-framework, run the payload stage **in Python 3.x** to get a session
    * The working directory is just so the results are deterministic
- [x] From the `meterpreter >` prompt run `search -f *.pdf` and see results instead of a Python exception