### PR TITLE
Allow Enumerating Core Command IDs In Windows

### DIFF
--- a/c/meterpreter/source/metsrv/base.c
+++ b/c/meterpreter/source/metsrv/base.c
@@ -106,20 +106,26 @@ Command* extensionCommands = NULL;
 
 /*!
  * @brief Register dispatch routines provided by the meterpreter core.
+ * @return Returns the first command of the array of commands that was registered.
  */
-Command* register_base_dispatch_routines(void) {
+Command* register_base_dispatch_routines(void)
+{
 	Command* pFirstCommand = NULL;
 	command_register_all(baseCommands);
 
 	pFirstCommand = extensionCommands;
 	while (pFirstCommand && pFirstCommand->command_id != baseCommands[0].command_id) {
-		dprintf("[COMMAND LIST] Command: %p command id %u != %u", pFirstCommand, pFirstCommand->command_id, baseCommands[0].command_id);
 		pFirstCommand = pFirstCommand->next;
 	}
-	if (pFirstCommand) {
-		dprintf("Found first command: %p (id: %u)", pFirstCommand, pFirstCommand->command_id);
-	}
 	return pFirstCommand;
+}
+
+/*!
+ * @brief Deregister dispatch routines provided by the meterpreter core.
+ */
+void deregister_base_dispatch_routines(void)
+{
+	command_deregister_all(baseCommands);
 }
 
 /*!

--- a/c/meterpreter/source/metsrv/base.h
+++ b/c/meterpreter/source/metsrv/base.h
@@ -13,6 +13,8 @@ DWORD command_register(Command *command);
 DWORD command_deregister(Command *command);
 VOID command_join_threads( VOID );
 BOOL command_handle( Remote *remote, Packet *packet );
+
 Command* register_base_dispatch_routines(void);
+void deregister_base_dispatch_routines(void);
 
 #endif

--- a/c/meterpreter/source/metsrv/base.h
+++ b/c/meterpreter/source/metsrv/base.h
@@ -13,5 +13,6 @@ DWORD command_register(Command *command);
 DWORD command_deregister(Command *command);
 VOID command_join_threads( VOID );
 BOOL command_handle( Remote *remote, Packet *packet );
+Command* register_base_dispatch_routines(void);
 
 #endif

--- a/c/meterpreter/source/metsrv/remote_dispatch.c
+++ b/c/meterpreter/source/metsrv/remote_dispatch.c
@@ -148,6 +148,17 @@ DWORD request_core_enumextcmd(Remote* remote, Packet* packet)
 }
 
 /*
+ * Deinitialize the core pseudo extension
+ */
+static DWORD deinit_server_extension(Remote* remote)
+{
+	command_deregister_all(customCommands);
+	deregister_base_dispatch_routines();
+
+	return ERROR_SUCCESS;
+}
+
+/*
  * Registers custom command handlers
  */
 VOID register_dispatch_routines()
@@ -160,10 +171,11 @@ VOID register_dispatch_routines()
 	PEXTENSION pExtension = (PEXTENSION)malloc(sizeof(EXTENSION));
 	if (pExtension) {
 		memset(pExtension, 0, sizeof(EXTENSION));
+		pExtension->deinit = deinit_server_extension;
 		pExtension->end = pFirstCommand;
 		pExtension->start = extensionCommands;
 		list_push(gExtensionList, pExtension);
-		dprintf("[EXTENSTION] Registered core pseudo extension %p", pExtension);
+		dprintf("[CORE] Registered the core pseudo extension %p", pExtension);
 	}
 }
 
@@ -187,8 +199,6 @@ VOID deregister_dispatch_routines(Remote * remote)
 
 		free(extension);
 	}
-
-	command_deregister_all(customCommands);
 
 	list_destroy(gExtensionList);
 }

--- a/c/meterpreter/source/metsrv/remote_dispatch.c
+++ b/c/meterpreter/source/metsrv/remote_dispatch.c
@@ -94,9 +94,10 @@ BOOL ext_cmd_callback(LPVOID pState, LPVOID pData)
 		PEXTENSION pExt = (PEXTENSION)pData;
 		for (command = pExt->start; command != pExt->end; command = command->next)
 		{
+			dprintf("[LISTEXTCMD] Processing extension: %p", pExt);
 			if (pEnum->command_id_start < command->command_id && command->command_id < pEnum->command_id_end)
 			{
-				dprintf("[DISPATCH] Adding command ID %u", command->command_id);
+				dprintf("[LISTEXTCMD] Adding command ID %u", command->command_id);
 				packet_add_tlv_uint(pEnum->pResponse, TLV_TYPE_UINT, command->command_id);
 			}
 		}
@@ -153,7 +154,17 @@ VOID register_dispatch_routines()
 {
 	gExtensionList = list_create();
 
+	Command* pFirstCommand = register_base_dispatch_routines();
 	command_register_all(customCommands);
+
+	PEXTENSION pExtension = (PEXTENSION)malloc(sizeof(EXTENSION));
+	if (pExtension) {
+		memset(pExtension, 0, sizeof(EXTENSION));
+		pExtension->end = pFirstCommand;
+		pExtension->start = extensionCommands;
+		list_push(gExtensionList, pExtension);
+		dprintf("[EXTENSTION] Registered core pseudo extension %p", pExtension);
+	}
 }
 
 /*

--- a/c/meterpreter/source/metsrv/server_setup.c
+++ b/c/meterpreter/source/metsrv/server_setup.c
@@ -375,7 +375,7 @@ DWORD server_setup(MetsrvConfig* config)
 
 			dprintf("[SERVER] Registering dispatch routines...");
 			register_dispatch_routines();
-
+			
 			// this has to be done after dispatch routine are registered
 			LPBYTE configEnd = load_stageless_extensions(remote, (MetsrvExtension*)((LPBYTE)config->transports + transportSize));
 


### PR DESCRIPTION
This adjusts how the Windows Meterpreter handles the core command IDs. It changes them to be treated as an extension, registering them in the same way, using a `EXTENSION` struct, registering a `deinit` callback etc. This is necessary to allow the `enumextcmd` command to enumerate the supported core commands in the same was as extension commands are enumerated. This allows Metasploit to know what core commands are available and thus handle different Meterpreter implementations with different core capabilities in a more consistent and user-friendly manner. A framework side PR for this will be opened shortly.

I tested the other Meterpreter implementations and the Java, PHP and Python implementations all already allow the core commands to be enumerated through `enumextcmd` so the Windows one is the only one that requires an update. Mettle works already as well so there's nothing to do there.

Since the core commands are now registered as extension commands, there is no longer two lists that need to be searched when attempting to resolve a command ID. You'll see quite a bit of code refactored in `base.c` to remove unnecessary logic now that a single command list is used. There are two lists of core commands, one in `base.c` and one in `remote_dispatch.c`. This means I had to add new functions in `base.c` to register those commands without exposing them.

I tested this on both the 32-bit and 64-bit staged and unstaged combinations along with Metasploits `post/test/meterpreter` module to ensure things are still functioning correctly.