### PR TITLE
Fix Issues From metasploit-framework#14617

### DIFF
--- a/gem/lib/metasploit-payloads.rb
+++ b/gem/lib/metasploit-payloads.rb
@@ -84,6 +84,8 @@ module MetasploitPayloads
     end
 
     root_dirs.each do |dir|
+      next unless ::File.directory?(dir)
+
       # Merge in any that don't already exist in the collection.
       meterpreter_enum_ext(dir, binary_suffix).each do |e|
         extensions.push(e) unless extensions.include?(e)

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -397,7 +397,7 @@ def cmd_string_to_id(this_string):
     for that_id, that_string in COMMAND_IDS:
         if this_string == that_string:
             return that_id
-    debug_print('[*] failed to lookup string for command string: ' + this_string)
+    debug_print('[*] failed to lookup id for command string: ' + this_string)
     return None
 
 @export
@@ -1352,6 +1352,8 @@ class PythonMeterpreter(object):
         id_end = packet_get_tlv(request, TLV_TYPE_LENGTH)['value'] + id_start
         for func_name in self.extension_functions.keys():
             command_id = cmd_string_to_id(func_name)
+            if command_id is None:
+                continue
             if id_start < command_id and command_id < id_end:
                 response += tlv_pack(TLV_TYPE_UINT, command_id)
         return ERROR_SUCCESS, response


### PR DESCRIPTION
This fixes two small issues identified while testing rapid7/metasploit-framework#14617.

The first issue is a crash when invoking tab completion for Meterpreter extensions when the `~/.msf4/payloads/meterpreter` directory does not exist. The solution is checking to see that the directory exists before trying to list its contents.

The second issue is in the Python Meterpreter. When the stdapi extension is loaded, it registers some functions to open channels which use the `channel_open` prefix and are used by the `core_channel_open` API. These channel open functions that are registered for consumption by the `core_channel_open` command are not themselves valid commands. This means that once they are registered the `core_enumext` command will fail when resolving them to a numeric command ID. This fixes that by checking if the command name failed to be converted to a numeric ID and if so, skips that entry.

## Testing Bug 1 (Tab Completion)

- [x] To test the tab completion bug, open a Meterpreter session. Any type on any platform should do.
- [x] Make sure that the `~/.msf4/payloads/meterpreter` directory **does not** exist
- [x] At the `meterpreter > ` prompt, type in `load` and then hit TAB
- [x] **Do not see a stack trace**

## Testing Bug 2 (Command Enumeration)

- [x] Open a Python Meterpreter session
- [x] Run the `post/test/meterpreter` test module and see that the "should support 3 or more core commands" check passes
    * Note that this requires the updated test module added in rapid7/metasploit-framework#14617
    * Note that the "should return network routes" test will fail, that's because it's not implemented in Python (see #472)