### PR TITLE
Tiny bug fix: wrong nMaxInstances on ImpersonateNamedPipeClient PE

### DIFF
--- a/c/meterpreter/source/extensions/priv/namedpipe.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe.c
@@ -56,7 +56,7 @@ DWORD THREADCALL elevate_namedpipe_thread(THREAD * thread)
 
 		// create the named pipe for the client service to connect to
 		hPipe = CreateNamedPipe(cpPipeName,
-			PIPE_ACCESS_DUPLEX, PIPE_TYPE_MESSAGE|PIPE_WAIT, 2, 0, 0, 0, NULL);
+			PIPE_ACCESS_DUPLEX, PIPE_TYPE_MESSAGE|PIPE_WAIT, 1, 0, 0, 0, NULL);
 
 		if (!hPipe) {
 			BREAK_ON_ERROR("[ELEVATE] elevate_namedpipe_thread. CreateNamedPipe failed");


### PR DESCRIPTION
The nMaxInstances argument refers only to subsequent calls to CreateNamedPipe and not to calls that just open the pipe.
There is no reason to enable anybody else but us to create a pipe with the same name.

There is more info here:
https://csandker.io/2021/01/10/Offensive-Windows-IPC-1-NamedPipes.html#instance-creation-race-condition