### PR TITLE
Add route inspection support to the Python Meterpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.idea
 *.swp
 *.suo
 .vs

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -105,27 +105,26 @@ if has_ctypes:
             ("iSockaddrLength", ctypes.c_int)]
 
     class sockaddr_in(ctypes.Structure):
-        _fields_ = [('sin_family', ctypes.c_short),
-            ('sin_port', ctypes.c_ushort),
-            ('sin_addr', ctypes.c_byte * 4),
-            ('sin_zero', ctypes.c_char * 8)
+        _fields_ = [("sin_family", ctypes.c_short),
+            ("sin_port", ctypes.c_ushort),
+            ("sin_addr", ctypes.c_byte * 4),
+            ("sin_zero", ctypes.c_char * 8)
         ]
     SOCKADDR_IN = sockaddr_in
 
     class sockaddr_in6(ctypes.Structure):
-        _fields_ = [('sin6_family', ctypes.c_short),
-            ('sin6_port', ctypes.c_ushort),
-            ('sin6_flowinfo', ctypes.c_ulong),
-            ('sin6_addr', ctypes.c_byte * 16),
-            ('sin6_scope_id', ctypes.c_ulong)
+        _fields_ = [("sin6_family", ctypes.c_short),
+            ("sin6_port", ctypes.c_ushort),
+            ("sin6_flowinfo", ctypes.c_ulong),
+            ("sin6_addr", ctypes.c_byte * 16),
+            ("sin6_scope_id", ctypes.c_ulong)
         ]
     SOCKADDR_IN6 = sockaddr_in6
 
     class SOCKADDR_INET(ctypes.Union):
-        _fields_ = [
-            ('Ipv4', SOCKADDR_IN),
-            ('Ipv6', SOCKADDR_IN6),
-            ('si_family', ctypes.c_short)
+        _fields_ = [("Ipv4", SOCKADDR_IN),
+            ("Ipv6", SOCKADDR_IN6),
+            ("si_family", ctypes.c_short)
         ]
 
     class IP_ADAPTER_UNICAST_ADDRESS(ctypes.Structure):
@@ -205,102 +204,65 @@ if has_ctypes:
         _fields_ = [("cbSize", ctypes.c_uint32),
             ("dwTime", ctypes.c_uint32)]
 
-    class MIB_IFROW(ctypes.Structure):
-        _fields_ = [("wszName", (ctypes.c_wchar * 256)),
-            ("dwIndex", ctypes.c_uint32),
-            ("dwType", ctypes.c_uint32),
-            ("dwMtu", ctypes.c_uint32),
-            ("dwSpeed", ctypes.c_uint32),
-            ("dwPhysAddrLen", ctypes.c_uint32),
-            ("bPhysAddr", (ctypes.c_uint8 * 8)),
-            ("dwAdminStatus", ctypes.c_uint32),
-            ("dwOperStaus", ctypes.c_uint32),
-            ("dwLastChange", ctypes.c_uint32),
-            ("dwInOctets", ctypes.c_uint32),
-            ("dwInUcastPkts", ctypes.c_uint32),
-            ("dwInNUcastPkts", ctypes.c_uint32),
-            ("dwInDiscards", ctypes.c_uint32),
-            ("dwInErrors", ctypes.c_uint32),
-            ("dwInUnknownProtos", ctypes.c_uint32),
-            ("dwOutOctets", ctypes.c_uint32),
-            ("dwOutUcastPkts", ctypes.c_uint32),
-            ("dwOutNUcastPkts", ctypes.c_uint32),
-            ("dwOutDiscards", ctypes.c_uint32),
-            ("dwOutErrors", ctypes.c_uint32),
-            ("dwOutQLen", ctypes.c_uint32),
-            ("dwDescrLen", ctypes.c_uint32),
-            ("bDescr", (ctypes.c_char * 256))]
-
-    class MIB_IPADDRROW(ctypes.Structure):
-        _fields_ = [("dwAddr", ctypes.c_uint32),
-            ("dwIndex", ctypes.c_uint32),
-            ("dwMask", ctypes.c_uint32),
-            ("dwBCastAddr", ctypes.c_uint32),
-            ("dwReasmSize", ctypes.c_uint32),
-            ("unused1", ctypes.c_uint16),
-            ("wType", ctypes.c_uint16)]
-
     class MIB_IPINTERFACE_ROW(ctypes.Structure):
-        _fields_ = [
-            ('Family', ctypes.c_uint16),
-            ('InterfaceLuid', ctypes.c_uint64),
-            ('InterfaceIndex', ctypes.c_uint32),
-            ('MaxReassemblySize', ctypes.c_uint32),
-            ('InterfaceIdentifier', ctypes.c_uint64),
-            ('MinRouterAdvertisementInterval', ctypes.c_uint32),
-            ('MaxRouterAdvertisementInterval', ctypes.c_uint32),
-            ('AdvertisingEnabled', ctypes.c_uint8),
-            ('ForwardingEnabled', ctypes.c_uint8),
-            ('WeakHostSend', ctypes.c_uint8),
-            ('WeakHostReceive', ctypes.c_uint8),
-            ('UseAutomaticMetric', ctypes.c_uint8),
-            ('UseNeighborUnreachabilityDetection', ctypes.c_uint8),
-            ('ManagedAddressConfigurationSupported', ctypes.c_uint8),
-            ('OtherStatefulConfigurationSupported', ctypes.c_uint8),
-            ('AdvertiseDefaultRoute', ctypes.c_uint8),
-            ('RouterDiscoveryBehavior', ctypes.c_uint32),
-            ('DadTransmits', ctypes.c_uint32),
-            ('BaseReachableTime', ctypes.c_uint32),
-            ('RetransmitTime', ctypes.c_uint32),
-            ('PathMtuDiscoveryTimeout', ctypes.c_uint32),
-            ('LinkLocalAddressBehavior', ctypes.c_uint32),
-            ('LinkLocalAddressTimeout', ctypes.c_uint32),
-            ('ZoneIndices', ctypes.c_uint32 * 16),
-            ('SitePrefixLength', ctypes.c_uint32),
-            ('Metric', ctypes.c_uint32),
-            ('NlMtu', ctypes.c_uint32),
-            ('Connected', ctypes.c_uint8),
-            ('SupportsWakeUpPatterns', ctypes.c_uint8),
-            ('SupportsNeighborDiscovery', ctypes.c_uint8),
-            ('SupportsRouterDiscovery', ctypes.c_uint8),
-            ('ReachableTime', ctypes.c_uint32),
-            ('TransmitOffload', ctypes.c_uint8),
-            ('ReceiveOffload', ctypes.c_uint8),
-            ('DisableDefaultRoutes', ctypes.c_uint8),
+        _fields_ = [("Family", ctypes.c_uint16),
+            ("InterfaceLuid", ctypes.c_uint64),
+            ("InterfaceIndex", ctypes.c_uint32),
+            ("MaxReassemblySize", ctypes.c_uint32),
+            ("InterfaceIdentifier", ctypes.c_uint64),
+            ("MinRouterAdvertisementInterval", ctypes.c_uint32),
+            ("MaxRouterAdvertisementInterval", ctypes.c_uint32),
+            ("AdvertisingEnabled", ctypes.c_uint8),
+            ("ForwardingEnabled", ctypes.c_uint8),
+            ("WeakHostSend", ctypes.c_uint8),
+            ("WeakHostReceive", ctypes.c_uint8),
+            ("UseAutomaticMetric", ctypes.c_uint8),
+            ("UseNeighborUnreachabilityDetection", ctypes.c_uint8),
+            ("ManagedAddressConfigurationSupported", ctypes.c_uint8),
+            ("OtherStatefulConfigurationSupported", ctypes.c_uint8),
+            ("AdvertiseDefaultRoute", ctypes.c_uint8),
+            ("RouterDiscoveryBehavior", ctypes.c_uint32),
+            ("DadTransmits", ctypes.c_uint32),
+            ("BaseReachableTime", ctypes.c_uint32),
+            ("RetransmitTime", ctypes.c_uint32),
+            ("PathMtuDiscoveryTimeout", ctypes.c_uint32),
+            ("LinkLocalAddressBehavior", ctypes.c_uint32),
+            ("LinkLocalAddressTimeout", ctypes.c_uint32),
+            ("ZoneIndices", ctypes.c_uint32 * 16),
+            ("SitePrefixLength", ctypes.c_uint32),
+            ("Metric", ctypes.c_uint32),
+            ("NlMtu", ctypes.c_uint32),
+            ("Connected", ctypes.c_uint8),
+            ("SupportsWakeUpPatterns", ctypes.c_uint8),
+            ("SupportsNeighborDiscovery", ctypes.c_uint8),
+            ("SupportsRouterDiscovery", ctypes.c_uint8),
+            ("ReachableTime", ctypes.c_uint32),
+            ("TransmitOffload", ctypes.c_uint8),
+            ("ReceiveOffload", ctypes.c_uint8),
+            ("DisableDefaultRoutes", ctypes.c_uint8),
         ]
+
     class IP_ADDRESS_PREFIX(ctypes.Structure):
-        _fields_ = [
-            ('Prefix', SOCKADDR_INET),
-            ('PrefixLength', ctypes.c_uint8)
+        _fields_ = [("Prefix", SOCKADDR_INET),
+            ("PrefixLength", ctypes.c_uint8)
         ]
 
     class MIB_IPFORWARD_ROW2(ctypes.Structure):
-        _fields_ = [
-            ('InterfaceLuid', ctypes.c_uint64),
-            ('InterfaceIndex', ctypes.c_uint32),
-            ('DestinationPrefix', IP_ADDRESS_PREFIX),
-            ('NextHop', SOCKADDR_INET),
-            ('SitePrefixLength', ctypes.c_uint8),
-            ('ValidLifetime', ctypes.c_uint32),
-            ('PreferredLifetime', ctypes.c_uint32),
-            ('Metric', ctypes.c_uint32),
-            ('Protocol', ctypes.c_uint32),
-            ('Loopback', ctypes.c_byte),
-            ('AutoconfigureAddress', ctypes.c_byte),
-            ('Publish', ctypes.c_byte),
-            ('Immortal', ctypes.c_byte),
-            ('Age', ctypes.c_uint32),
-            ('Origin', ctypes.c_uint32),
+        _fields_ = [("InterfaceLuid", ctypes.c_uint64),
+            ("InterfaceIndex", ctypes.c_uint32),
+            ("DestinationPrefix", IP_ADDRESS_PREFIX),
+            ("NextHop", SOCKADDR_INET),
+            ("SitePrefixLength", ctypes.c_uint8),
+            ("ValidLifetime", ctypes.c_uint32),
+            ("PreferredLifetime", ctypes.c_uint32),
+            ("Metric", ctypes.c_uint32),
+            ("Protocol", ctypes.c_uint32),
+            ("Loopback", ctypes.c_byte),
+            ("AutoconfigureAddress", ctypes.c_byte),
+            ("Publish", ctypes.c_byte),
+            ("Immortal", ctypes.c_byte),
+            ("Age", ctypes.c_uint32),
+            ("Origin", ctypes.c_uint32),
         ]
     PMIB_IPFORWARD_ROW2 = ctypes.POINTER(MIB_IPFORWARD_ROW2)
 
@@ -1738,8 +1700,6 @@ def stdapi_net_config_get_interfaces_via_osx_ifconfig():
 
 def stdapi_net_config_get_interfaces_via_windll():
     iphlpapi = ctypes.windll.iphlpapi
-    if not hasattr(iphlpapi, 'GetAdaptersAddresses'):  # added in XP / Server 2003
-        return stdapi_net_config_get_interfaces_via_windll_mib()
     Flags = (GAA_FLAG_INCLUDE_PREFIX | GAA_FLAG_SKIP_DNS_SERVER | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_ANYCAST)
     AdapterAddresses = ctypes.c_void_p()
     SizePointer = ctypes.c_ulong()
@@ -1787,35 +1747,6 @@ def stdapi_net_config_get_interfaces_via_windll():
             else:
                 iface_addresses.append((socket.AF_INET6, ctypes.string_at(ctypes.byref(address.sa_data), 22)[6:], prefix))
             iface_info['addrs'] = iface_addresses
-        interfaces.append(iface_info)
-    return interfaces
-
-def stdapi_net_config_get_interfaces_via_windll_mib():
-    iphlpapi = ctypes.windll.iphlpapi
-    table = (ctypes.c_uint8 * (ctypes.sizeof(MIB_IPADDRROW) * 33))()
-    pdwSize = ctypes.c_ulong()
-    pdwSize.value = ctypes.sizeof(table)
-    if (iphlpapi.GetIpAddrTable(ctypes.byref(table), ctypes.byref(pdwSize), True) != 0):
-        return None
-    interfaces = []
-    table_data = ctypes.string_at(table, pdwSize.value)
-    entries = struct.unpack('I', table_data[:4])[0]
-    table_data = table_data[4:]
-    for i in range(entries):
-        addrrow = ctstruct_unpack(MIB_IPADDRROW, table_data)
-        ifrow = MIB_IFROW()
-        ifrow.dwIndex = addrrow.dwIndex
-        if iphlpapi.GetIfEntry(ctypes.byref(ifrow)) != 0:
-            continue
-        iface_info = {}
-        table_data = table_data[ctypes.sizeof(MIB_IPADDRROW):]
-        iface_info['index'] = addrrow.dwIndex
-        iface_info['addrs'] = [(socket.AF_INET, struct.pack('<I', addrrow.dwAddr), struct.pack('<I', addrrow.dwMask))]
-        if ifrow.dwPhysAddrLen:
-            iface_info['hw_addr'] = ctypes.string_at(ctypes.byref(ifrow.bPhysAddr), ifrow.dwPhysAddrLen)
-        if ifrow.dwDescrLen:
-            iface_info['name'] = ifrow.bDescr
-        iface_info['mtu'] = ifrow.dwMtu
         interfaces.append(iface_info)
     return interfaces
 

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1613,7 +1613,7 @@ class PythonMeterpreter(object):
                 debug_print('[*] running method ' + handler_name)
                 result = handler(request, response)
                 if result is None:
-                    debug_print("[-] Not a good result!")
+                    debug_print("[-] handler result is none")
                     return
                 result, response = result
             except Exception:
@@ -1628,10 +1628,10 @@ class PythonMeterpreter(object):
 
         reqid_tlv = packet_get_tlv(request, TLV_TYPE_REQUEST_ID)
         if not reqid_tlv:
-            debug_print("[-] No request ID found")
+            debug_print("[-] no request ID found")
             return
         response += tlv_pack(reqid_tlv)
-        debug_print("[*] Sending respond packet")
+        debug_print("[*] sending response packet")
         return response + tlv_pack(TLV_TYPE_RESULT, result)
 
 # PATCH-SETUP-ENCRYPTION #


### PR DESCRIPTION
This adds support for the `stdapi_net_config_get_routes` Meterpreter command to the Python Meterpreter. Like a few other commands in the Python Meterpreter, it needed platform specific implementations of which there are 4. The code documentation is a bit sparse because any comments would increase the size of the payload itself.

* `via_netlink` -- The Linux implementation using NETLINK sockets to get the information from the Kernel.
* `via_windll` -- The Windows Vista / Server 2008 and newer implementation leveraging the Windows API to obtain both the IPv4 and IPv6 routing table
* `via_windll2` -- The Windows XP implementation leveraging the Windows API for only the IPv4 routing table
* `via_osx_netstat` -- The OSX implementation that shells out to `netstat -nr` since OSX native API support isn't great and I don't have a system to test with

In all cases, the implementations are similar techniques to those used by the get_interfaces command, e.g. Linux uses NETLINK, Windows uses the Windows API and OSX shells out to a command.

## Refactoring
I also made a few changes to cleanup the code.

* A few log statements in the Meterpreter core were updated to blend in a bit more consistently with the logging output.
* The `stdapi_net_config_get_interfaces_via_windll_mib` function was removed entirely. This function avoided use of the modern `GetAdaptersAddresses` function which was added in Windows XP / Server 2003. Since Metasploit v6, Meterpreter is [documented](https://github.com/rapid7/metasploit-framework/wiki/Metasploit-6.0-Development-Notes#compatibility-changes) as not supporting Windows versions older than XP so this no longer seems necessary.
* The redundant libc definitions was moved to a global location.
* Added error handling to `stdapi_fs_delete_dir` and `stdapi_fs_delete_file` because the `post/test/meterpreter` module would try to delete a path that doesn't exist (the test still passes) and it would cause a stack trace which cluttered the output when using automation. It'll catch the error and return `ERROR_FAILURE` now as it did before but without printing the stack trace since it's caught and handled.

## Testing
I tested all supported versions of Python on Linux, that's 2.5-2.7 and 3.1-3.9 using a test harness [I have](https://gist.github.com/zeroSteiner/7e30697827e89e7708144fb3e605831f). The configuration ran the `post/test/meterpreter` module which pulls the route information and is great for automation. I also tested XP SP 2 using Python 2.5 and Windows 10 using Python 2.7 and 3.9. I think doing spot checks with different versions on the different platforms is sufficient here since the full matrix would be 48 test cases (12 Python versions x (1 Linux Function + 2 Windows Functions + 1 OS X Function)), probably less since the newest Python versions won't install on XP for testing one of the Windows functions.

### OS X
So I didn't actually test OS X at all 😬 . I don't have a testing system so the code is based heavily on the get interfaces code and the output I was able to gather from examples and documentation on the internet. I mocked this out and tested it in isolation, based on the `output` from the netstat command, so I'm confident that the parsing is correct, but again I didn't actually test it.

For each of the following cases, test the `route` command in Meterpreter to ensure it displays the hosts routing table. This group should be pretty well representative of the most common configurations to save time.

- [ ] Python 2.x on Linux
- [ ] Python 3.x on Linux
- [ ] Python 2.x on Windows XP
- [ ] Python 2.x on Windows 10
- [ ] Python 3.x on Windows 10
- [ ] Whatever the native Python is on OSX<sup>1</sup>

## Example Output
The following example is on my test system using Python 3.8 on Linux. It demonstrates that the output from Meterpreter (using the NETLINK backend) is the same as the `route` command.

You'll notice that some IPv6 routes are missing and that's because only the routes in the `RT_TABLE_MAIN` are returned.

```
meterpreter > sysinfo
Computer        : localhost.localdomain
OS              : Linux 5.10.22-100.fc32.x86_64 #1 SMP Tue Mar 9 17:40:24 UTC 2021
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > route

IPv4 network routes
===================

    Subnet         Netmask        Gateway        Metric  Interface
    ------         -------        -------        ------  ---------
    0.0.0.0        0.0.0.0        192.168.250.1  100     ens33
    0.0.0.0        0.0.0.0        192.168.159.2  101     ens37
    172.17.0.0     255.255.0.0    0.0.0.0        0       docker0
    172.18.0.0     255.255.0.0    0.0.0.0        0       br-4c63a408b89a
    192.168.122.0  255.255.255.0  0.0.0.0        0       virbr0
    192.168.159.0  255.255.255.0  0.0.0.0        101     ens37
    192.168.250.0  255.255.255.0  0.0.0.0        100     ens33


IPv6 network routes
===================

    Subnet  Netmask                          Gateway  Metric  Interface
    ------  -------                          -------  ------  ---------
    ::1     ffff:ffff:ffff:ffff:ffff:ffff::  ::       256     lo
    fe80::  ffff:ffff:ffff:ffff::            ::       101     ens37
    fe80::  ffff:ffff:ffff:ffff::            ::       256     ens33
    fe80::  ffff:ffff:ffff:ffff::            ::       256     docker0
meterpreter > shell
Process 129419 created.
Channel 9 created.
sh: cannot set terminal process group (129213): Inappropriate ioctl for device
sh: no job control in this shell
sh-5.0$ route -4 -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         192.168.250.1   0.0.0.0         UG    100    0        0 ens33
0.0.0.0         192.168.159.2   0.0.0.0         UG    101    0        0 ens37
172.17.0.0      0.0.0.0         255.255.0.0     U     0      0        0 docker0
172.18.0.0      0.0.0.0         255.255.0.0     U     0      0        0 br-4c63a408b89a
192.168.122.0   0.0.0.0         255.255.255.0   U     0      0        0 virbr0
192.168.159.0   0.0.0.0         255.255.255.0   U     101    0        0 ens37
192.168.250.0   0.0.0.0         255.255.255.0   U     100    0        0 ens33
sh-5.0$ route -6 -n
Kernel IPv6 routing table
Destination                    Next Hop                   Flag Met Ref Use If
::1/128                        ::                         U    256 1     0 lo
fe80::/64                      ::                         U    101 1     0 ens37
fe80::/64                      ::                         U    256 2     0 ens33
fe80::/64                      ::                         U    256 1     0 docker0
::/0                           ::                         !n   -1  1     0 lo
::1/128                        ::                         Un   0   18     0 lo
fe80::42:deff:feee:3d28/128    ::                         Un   0   5     0 docker0
fe80::20c:29ff:fe84:5f3/128    ::                         Un   0   3     0 ens33
fe80::a450:69d1:444f:3a7c/128  ::                         Un   0   2     0 ens37
ff00::/8                       ::                         U    256 15     0 ens33
ff00::/8                       ::                         U    256 11     0 docker0
ff00::/8                       ::                         U    256 5     0 ens37
::/0                           ::                         !n   -1  1     0 lo
sh-5.0$ 
```

Fixes #472