### PR TITLE
Fix Python Meterpreter Host Resolution

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -953,7 +953,7 @@ def netlink_request(req_type, req_data):
 
 def resolve_host(hostname, family):
     address_info = getaddrinfo(hostname, family=family, socktype=socket.SOCK_DGRAM, proto=socket.IPPROTO_UDP)
-    address = address_info['sockaddr'][0]
+    address = address_info[0]['sockaddr'][0]
     return {'family': family, 'address': address, 'packed_address': inet_pton(family, address)}
 
 def tlv_pack_local_addrinfo(sock):


### PR DESCRIPTION
This fixes a bug in the Python Meterpreter where the `resolve_host` helper function was expecting `getaddrinfo` to return a single hash instead of an array of hashes. This resulted in a `TypeError` being raised by the `stdapi_net_resolve_hosts` meterpreter command which is used by the `resolve` meterpreter UI command.

Fixes #479

## Testing Steps

- [ ] Open a Python Meterpreter session (version and platform don't matter)
- [ ] Run the command `resolve google.com`
- [ ] See an IP address for google.com and not an error message