### PR TITLE
fix request_fs_ls on an inaccessible file

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/fs/dir.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/dir.c
@@ -6,7 +6,7 @@
 void request_fs_ls_cb(void *arg, char *name, char *short_name, char *path)
 {
 	Packet *response = arg;
-	struct meterp_stat s;
+	struct meterp_stat s = {0};
 
 	/*
 	 * Add the file name, full path and stat information


### PR DESCRIPTION
This is a quick fix for https://github.com/rapid7/metasploit-framework/pull/14961
If a file is not accessible, the stat struct is not populated. This change ensure that the struct is 0 initialised, which prevents returning uninitialised memory when the file can not be accessed.

### Before
```
meterpreter > ls
[-] Error running command dir: NoMethodError undefined method `[]' for nil:NilClass
```
### After applying https://github.com/rapid7/metasploit-framework/issues/14940
```
meterpreter > ls
Listing: C:\
============

Mode                Size                Type  Last modified                    Name
----                ----                ----  -------------                    ----
40777/rwxrwxrwx     0                   dir   2009-07-14 04:18:56 +0100        $Recycle.Bin
40777/rwxrwxrwx     0                   dir   2009-07-14 06:08:56 +0100        Documents and Settings
40777/rwxrwxrwx     0                   dir   2009-07-14 04:20:08 +0100        PerfLogs
40555/r-xr-xr-x     4096                dir   2009-07-14 04:20:08 +0100        Program Files
40555/r-xr-xr-x     4096                dir   2009-07-14 04:20:08 +0100        Program Files (x86)
40777/rwxrwxrwx     4096                dir   2009-07-14 04:20:08 +0100        ProgramData
40777/rwxrwxrwx     0                   dir   2018-03-10 15:31:00 +0000        Recovery
40777/rwxrwxrwx     8192                dir   2018-03-10 15:28:42 +0000        System Volume Information
40555/r-xr-xr-x     4096                dir   2009-07-14 04:20:08 +0100        Users
40777/rwxrwxrwx     24576               dir   2009-07-14 04:20:08 +0100        Windows
22173454/r--r-xr--  172821856129155055        5485510914-02-22 19:35:28 +0000  pagefile.sys

```

### After this fix
```
meterpreter > ls
Listing: C:\
============

Mode              Size     Type  Last modified              Name
----              ----     ----  -------------              ----
40777/rwxrwxrwx   0        dir   2009-07-14 04:18:56 +0100  $Recycle.Bin
40777/rwxrwxrwx   0        dir   2009-07-14 06:08:56 +0100  Documents and Settings
40777/rwxrwxrwx   0        dir   2009-07-14 04:20:08 +0100  PerfLogs
40555/r-xr-xr-x   4096     dir   2009-07-14 04:20:08 +0100  Program Files
40555/r-xr-xr-x   4096     dir   2009-07-14 04:20:08 +0100  Program Files (x86)
40777/rwxrwxrwx   4096     dir   2009-07-14 04:20:08 +0100  ProgramData
40777/rwxrwxrwx   0        dir   2018-03-10 15:31:00 +0000  Recovery
40777/rwxrwxrwx   8192     dir   2018-03-10 15:28:42 +0000  System Volume Information
40555/r-xr-xr-x   4096     dir   2009-07-14 04:20:08 +0100  Users
40777/rwxrwxrwx   24576    dir   2009-07-14 04:20:08 +0100  Windows
0000/---------    0        fif   1970-01-01 01:00:00 +0100  pagefile.sys

```