### PR TITLE
Add stdapi_net_resolve_host(s) to the Java meterpreter

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
@@ -110,6 +110,8 @@ public interface TLVType {
     public static final int TLV_TYPE_SUBNET_STRING  = TLVPacket.TLV_META_TYPE_STRING | 1440;
     public static final int TLV_TYPE_NETMASK_STRING = TLVPacket.TLV_META_TYPE_STRING | 1441;
     public static final int TLV_TYPE_GATEWAY_STRING = TLVPacket.TLV_META_TYPE_STRING | 1442;
+    public static final int TLV_TYPE_ROUTE_METRIC   = TLVPacket.TLV_META_TYPE_UINT   | 1443;
+    public static final int TLV_TYPE_ADDR_TYPE      = TLVPacket.TLV_META_TYPE_UINT   | 1444;
 
     // Socket
     public static final int TLV_TYPE_PEER_HOST       = TLVPacket.TLV_META_TYPE_STRING | 1500;

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
@@ -58,6 +58,8 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand(CommandId.STDAPI_NET_CONFIG_GET_INTERFACES, stdapi_net_config_get_interfaces.class, V1_4, V1_6);
         mgr.registerCommand(CommandId.STDAPI_NET_CONFIG_GET_ROUTES, stdapi_net_config_get_routes.class, V1_4);
         mgr.registerCommand(CommandId.STDAPI_NET_SOCKET_TCP_SHUTDOWN, stdapi_net_socket_tcp_shutdown.class, V1_2, V1_3);
+        mgr.registerCommand(CommandId.STDAPI_NET_RESOLVE_HOST, stdapi_net_resolve_host.class);
+        mgr.registerCommand(CommandId.STDAPI_NET_RESOLVE_HOSTS, stdapi_net_resolve_hosts.class);
         mgr.registerCommand(CommandId.STDAPI_SYS_CONFIG_GETUID, stdapi_sys_config_getuid.class);
         mgr.registerCommand(CommandId.STDAPI_SYS_CONFIG_GETENV, stdapi_sys_config_getenv.class);
         mgr.registerCommand(CommandId.STDAPI_SYS_CONFIG_SYSINFO, stdapi_sys_config_sysinfo.class);

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_host.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_host.java
@@ -1,0 +1,51 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class stdapi_net_resolve_host implements Command {
+
+    private static final int AF_INET = 2;
+    private static final int AF_INET6 = 23;
+
+    public static InetAddress resolve_host(String host, int family) {
+        InetAddress[] inetAddresses;
+        try {
+            inetAddresses = InetAddress.getAllByName(host);
+        } catch (UnknownHostException e) {
+            return null;
+        }
+        for (InetAddress address : inetAddresses) {
+            if (family == AF_INET6) {
+                if (address instanceof Inet6Address) {
+                    return address;
+                }
+            } else if (family == AF_INET) {
+                if (address instanceof Inet4Address) {
+                    return address;
+                }
+            } else {
+                return address;
+            }
+        }
+        return null;
+    }
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        String host = request.getStringValue(TLVType.TLV_TYPE_HOST_NAME);
+        int family = request.getIntValue(TLVType.TLV_TYPE_ADDR_TYPE);
+        InetAddress inetAddress = resolve_host(host, family);
+        if (inetAddress != null) {
+            response.addOverflow(TLVType.TLV_TYPE_IP, inetAddress.getAddress());
+            response.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);
+        }
+        return ERROR_SUCCESS;
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_hosts.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_hosts.java
@@ -1,0 +1,29 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+
+import java.net.InetAddress;
+import java.util.List;
+
+public class stdapi_net_resolve_hosts implements Command {
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        List<String> hosts = request.getValues(TLVType.TLV_TYPE_HOST_NAME);
+        int family = request.getIntValue(TLVType.TLV_TYPE_ADDR_TYPE);
+        for (int i=0;i<hosts.size();i++) {
+            String host = hosts.get(i);
+            InetAddress inetAddress = stdapi_net_resolve_host.resolve_host(host, family);
+            if (inetAddress != null) {
+                response.addOverflow(TLVType.TLV_TYPE_IP, inetAddress.getAddress());
+                response.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);
+            } else {
+                response.addOverflow(TLVType.TLV_TYPE_IP, new byte[0]);
+                response.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);
+            }
+        }
+        return ERROR_SUCCESS;
+    }
+}


### PR DESCRIPTION
## Testing
- [x] Open a Java Meterpreter session
- [x] Run the `resolve` command (this uses `stdapi_net_resolve_hosts` under the hood)
- [x] Check that it resolves IPv4 and IPv6 addresses (`google.com` and `ipv6.google.com` can be used as examples, use the -f flag to specify the family)
- [x] Check that if resolution fails (e.g resolve asdfasdfadssadf), the session remains active.

## Verification

```
meterpreter > resolve asdlfkjasdfasd

Host resolutions
================

    Hostname        IP Address
    --------        ----------
    asdlfkjasdfasd  [Failed To Resolve]

meterpreter > resolve www.example.com example.com

Host resolutions
================

    Hostname         IP Address
    --------         ----------
    example.com      93.184.216.34
    www.example.com  93.184.216.34

meterpreter > resolve www.example.com -f IPv6

Host resolutions
================

    Hostname         IP Address
    --------         ----------
    www.example.com  2606:2800:220:1:248:1893:25c8:1946

```