### PR TITLE
Support enumerating binary suffixs for an extension 

### DIFF
--- a/gem/lib/metasploit-payloads.rb
+++ b/gem/lib/metasploit-payloads.rb
@@ -69,9 +69,12 @@ module MetasploitPayloads
   end
 
   #
-  # List all the available extensions for the given suffix.
+  # List all the available extensions, optionally filtered by the given suffix.
   #
-  def self.list_meterpreter_extensions(binary_suffix)
+  # @param [String] binary_suffix An optional suffix to use for filtering results. If omitted, all extensions will be
+  #   returned.
+  # @return [Array<String>] Returns an array of extensions.
+  def self.list_meterpreter_extensions(binary_suffix=nil)
     extensions = []
 
     root_dirs = [local_meterpreter_dir]
@@ -124,13 +127,18 @@ module MetasploitPayloads
   end
 
   #
-  # Enumerate extensions in the given root folder based on the suffix.
+  # Enumerate extensions in the given root folder based on an optional suffix.
   #
-  def self.meterpreter_enum_ext(root_dir, binary_suffix)
+  # @param [String] root_dir The path to the directory from which to enumerate extensions.
+  # @param [String] binary_suffix An optional suffix to use for filtering results. If omitted, all extensions will be
+  #   returned.
+  # @return [Array<String>] Returns an array of extensions.
+  def self.meterpreter_enum_ext(root_dir, binary_suffix=nil)
     exts = []
+    binary_suffix ||= '.*'
     ::Dir.entries(root_dir).each do |f|
       if ::File.readable?(::File.join(root_dir, f)) && \
-         f =~ /#{EXTENSION_PREFIX}(.*)\.#{binary_suffix}/
+         f =~ /#{EXTENSION_PREFIX}(\w+)\.#{binary_suffix}/
         exts.push($1)
       end
     end

--- a/gem/lib/metasploit-payloads.rb
+++ b/gem/lib/metasploit-payloads.rb
@@ -79,14 +79,14 @@ module MetasploitPayloads
   end
 
   #
-  # List all the available suffixs, optionally filtered by the given extension name. This is mostly useful for
+  # List all the available suffixes, optionally filtered by the given extension name. This is mostly useful for
   # determining support for a specific extension.
   #
-  # @param [String] extension_name An optional extension name to use for filtering results. If omitted, all suffixs will
-  #   be returned.
-  # @return [Array<String>] Returns an array of binary suffixs.
-  def self.list_meterpreter_extension_suffixs(extension_name=nil)
-    list_meterpreter_things { |dir| meterpreter_enum_ext_suffixs(dir, extension_name) }
+  # @param [String] extension_name An optional extension name to use for filtering results. If omitted, all suffixes
+  #   will be returned.
+  # @return [Array<String>] Returns an array of binary suffixes.
+  def self.list_meterpreter_extension_suffixes(extension_name=nil)
+    list_meterpreter_things { |dir| meterpreter_enum_ext_suffixes(dir, extension_name) }
   end
 
   #
@@ -137,13 +137,13 @@ module MetasploitPayloads
   end
 
   #
-  # Enumerate binary suffixs in the given root folder based on an optional extension name.
+  # Enumerate binary suffixes in the given root folder based on an optional extension name.
   #
-  # @param [String] root_dir The path to the directory from which to enumerate extension suffixs.
-  # @param [String] extension_name An optional extension name to use for filtering results. If omitted, all suffixs will
+  # @param [String] root_dir The path to the directory from which to enumerate extension suffixes.
+  # @param [String] extension_name An optional extension name to use for filtering results. If omitted, all suffixes will
   #   be returned.
-  # @return [Array<String>] Returns an array of binary suffixs.
-  def self.meterpreter_enum_ext_suffixs(root_dir, extension_name=nil)
+  # @return [Array<String>] Returns an array of binary suffixes.
+  def self.meterpreter_enum_ext_suffixes(root_dir, extension_name=nil)
     suffixes = []
     extension_name ||= '\w+'
     ::Dir.entries(root_dir).each do |f|

--- a/gem/lib/metasploit-payloads.rb
+++ b/gem/lib/metasploit-payloads.rb
@@ -75,7 +75,7 @@ module MetasploitPayloads
   #   returned.
   # @return [Array<String>] Returns an array of extensions.
   def self.list_meterpreter_extensions(binary_suffix=nil)
-    list_meterpreter_things { |dir| meterpreter_enum_ext(dir, binary_suffix) }
+    list_meterpreter_dirs { |dir| meterpreter_enum_ext(dir, binary_suffix) }
   end
 
   #
@@ -86,7 +86,7 @@ module MetasploitPayloads
   #   will be returned.
   # @return [Array<String>] Returns an array of binary suffixes.
   def self.list_meterpreter_extension_suffixes(extension_name=nil)
-    list_meterpreter_things { |dir| meterpreter_enum_ext_suffixes(dir, extension_name) }
+    list_meterpreter_dirs { |dir| meterpreter_enum_ext_suffixes(dir, extension_name) }
   end
 
   #
@@ -148,7 +148,7 @@ module MetasploitPayloads
     extension_name ||= '\w+'
     ::Dir.entries(root_dir).each do |f|
       if ::File.readable?(::File.join(root_dir, f)) && \
-         f =~ /#{EXTENSION_PREFIX}#{extension_name}\.(.*)/
+         f =~ /#{EXTENSION_PREFIX}#{extension_name}\.(\w+(\.\w+)*)/
         suffixes.push($1)
       end
     end
@@ -185,7 +185,7 @@ module MetasploitPayloads
 
   class << self
     private
-    def list_meterpreter_things(&block)
+    def list_meterpreter_dirs(&block)
       things = [] # *things* is whatever is being enumerated (extension names, suffixes, etc.) as determined by the block
       root_dirs = [local_meterpreter_dir]
 
@@ -197,7 +197,7 @@ module MetasploitPayloads
       end
 
       root_dirs.each do |dir|
-	next unless ::File.directory?(dir)
+        next unless ::File.directory?(dir)
 
         # Merge in any that don't already exist in the collection.
         (yield dir).each do |e|


### PR DESCRIPTION
Support enumerating the extension suffixes for which a particular extension is available. This is foundational work that will allow Metasploit to suggest a Meterpreter that provides a particular extension.

## Testing Steps

- [x] Install the gem locally.
- [x] Start msfconsole and then load IRB.
- [x] Run `MetasploitPayloads.list_meterpreter_extension_suffixes('stdapi')
- [x] See a list of Meterpreter extensions for Python, PHP, Java and 2 for Windows

## Example

```
msf6 payload(python/meterpreter/reverse_tcp) > irb
[*] Starting IRB shell...
[*] You are in payload/python/meterpreter/reverse_tcp

>> MetasploitPayloads.list_meterpreter_extension_suffixes('stdapi')
=> ["php", "jar", "x64.dll", "py", "x86.dll"]
```
