### PR TITLE
Fix a cross compile build error

### DIFF
--- a/c/meterpreter/source/extensions/priv/namedpipe_rpcss.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_rpcss.c
@@ -1,4 +1,3 @@
-#include <winternl.h>
 #include "precomp.h"
 #include "common_metapi.h"
 #include "namedpipe.h"


### PR DESCRIPTION
Including `winternl.h` is apparently unnecessary, probably because the definitions that are required are defined in the source file. Including it however broke compilation via MinGw from within the docker build. Removing this line fixes that build while leaving the Visual Studio build unaffected.

<details>
<summary>Original Build Error</summary>

Truncated to only the last 100 lines.
```
      |                ^~~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:44:18: note: originally defined here
   44 |   typedef struct _PEB_LDR_DATA {
      |                  ^~~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/precomp.h:11,
                 from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:2:
/meterpreter/source/extensions/priv/../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.h:128:3: error: conflicting types for 'PEB_LDR_DATA'
  128 | } PEB_LDR_DATA, * PPEB_LDR_DATA;
      |   ^~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:48:5: note: previous declaration of 'PEB_LDR_DATA' was here
   48 |   } PEB_LDR_DATA,*PPEB_LDR_DATA;
      |     ^~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/precomp.h:11,
                 from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:2:
/meterpreter/source/extensions/priv/../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.h:128:19: error: conflicting types for 'PPEB_LDR_DATA'
  128 | } PEB_LDR_DATA, * PPEB_LDR_DATA;
      |                   ^~~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:48:19: note: previous declaration of 'PPEB_LDR_DATA' was here
   48 |   } PEB_LDR_DATA,*PPEB_LDR_DATA;
      |                   ^~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:7: warning: "NT_SUCCESS" redefined
    7 | #define NT_SUCCESS(Status) ((NTSTATUS)(Status) >= 0)
      | 
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:12: note: this is the location of the previous definition
   12 | #define NT_SUCCESS(status) ((NTSTATUS) (status) >= 0)
      | 
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:13:14: error: nested redefinition of 'enum _OBJECT_INFORMATION_CLASS'
   13 | typedef enum _OBJECT_INFORMATION_CLASS {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:13:14: error: redeclaration of 'enum _OBJECT_INFORMATION_CLASS'
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:1050:16: note: originally defined here
 1050 |   typedef enum _OBJECT_INFORMATION_CLASS {
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:14:2: error: redeclaration of enumerator 'ObjectBasicInformation'
   14 |  ObjectBasicInformation = 0,
      |  ^~~~~~~~~~~~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:1051:5: note: previous definition of 'ObjectBasicInformation' was here
 1051 |     ObjectBasicInformation,
      |     ^~~~~~~~~~~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:15:2: error: redeclaration of enumerator 'ObjectTypeInformation'
   15 |  ObjectTypeInformation = 2
      |  ^~~~~~~~~~~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:1053:5: note: previous definition of 'ObjectTypeInformation' was here
 1053 |     ObjectTypeInformation,
      |     ^~~~~~~~~~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:18:14: error: nested redefinition of 'enum _PROCESSINFOCLASS'
   18 | typedef enum _PROCESSINFOCLASS
      |              ^~~~~~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:18:14: error: redeclaration of 'enum _PROCESSINFOCLASS'
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:939:16: note: originally defined here
  939 |   typedef enum _PROCESSINFOCLASS {
      |                ^~~~~~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:20:2: error: redeclaration of enumerator 'ProcessBasicInformation'
   20 |  ProcessBasicInformation = 0,
      |  ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:940:5: note: previous definition of 'ProcessBasicInformation' was here
  940 |     ProcessBasicInformation,
      |     ^~~~~~~~~~~~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:42:16: error: redefinition of 'struct _OBJECT_TYPE_INFORMATION'
   42 | typedef struct _OBJECT_TYPE_INFORMATION
      |                ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:251:18: note: originally defined here
  251 |   typedef struct _OBJECT_TYPE_INFORMATION {
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:67:3: error: conflicting types for 'OBJECT_TYPE_INFORMATION'
   67 | } OBJECT_TYPE_INFORMATION, * POBJECT_TYPE_INFORMATION;
      |   ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:273:5: note: previous declaration of 'OBJECT_TYPE_INFORMATION' was here
  273 |   } OBJECT_TYPE_INFORMATION, *POBJECT_TYPE_INFORMATION;
      |     ^~~~~~~~~~~~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:67:30: error: conflicting types for 'POBJECT_TYPE_INFORMATION'
   67 | } OBJECT_TYPE_INFORMATION, * POBJECT_TYPE_INFORMATION;
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /meterpreter/source/extensions/priv/namedpipe_rpcss.c:1:
/usr/share/mingw-w64/include/winternl.h:273:31: note: previous declaration of 'POBJECT_TYPE_INFORMATION' was here
  273 |   } OBJECT_TYPE_INFORMATION, *POBJECT_TYPE_INFORMATION;
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~
/meterpreter/source/extensions/priv/namedpipe_rpcss.c: In function 'elevate_via_service_namedpipe_rpcss':
/meterpreter/source/extensions/priv/namedpipe_rpcss.c:347:31: warning: assignment to 'PostImpersonationCallback' {aka 'long unsigned int (*)(void *)'} from incompatible pointer type 'DWORD (*)(Remote *)' {aka 'long unsigned int (*)(struct _Remote *)'} [-Wincompatible-pointer-types]
  347 |   PostImpersonation.pCallback = post_callback_use_rpcss;
      |                               ^
make[3]: *** [ext_server_priv/CMakeFiles/ext_server_priv.dir/build.make:106: ext_server_priv/CMakeFiles/ext_server_priv.dir/meterpreter/source/extensions/priv/namedpipe_rpcss.c.obj] Error 1
make[3]: Leaving directory '/meterpreter/workspace/build/mingw-x86'
make[2]: *** [CMakeFiles/Makefile2:406: ext_server_priv/CMakeFiles/ext_server_priv.dir/all] Error 2
make[2]: Leaving directory '/meterpreter/workspace/build/mingw-x86'
make[1]: *** [Makefile:84: all] Error 2
make[1]: Leaving directory '/meterpreter/workspace/build/mingw-x86'
make: *** [Makefile:27: meterpreter-x86-build] Error 2
make: *** [Makefile:272: docker] Error 2
```
</details>

## Verification

- [ ] Run the build using docker (run `make docker` from within `c/meterpreter`)
- [ ] See no build errors
- [ ] Run the build using Visual Studio
- [ ] See no build errors