### PR TITLE
Fix sudo prompt

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1146,11 +1146,8 @@ def stdapi_sys_process_execute(request, response):
     flags = packet_get_tlv(request, TLV_TYPE_PROCESS_FLAGS)['value']
     if len(cmd) == 0:
         return ERROR_FAILURE, response
-    if os.path.isfile('/bin/sh'):
-        args = ['/bin/sh', '-c', cmd + ' ' + raw_args]
-    else:
-        args = [cmd]
-        args.extend(shlex.split(raw_args))
+    args = [cmd]
+    args.extend(shlex.split(raw_args))
     if (flags & PROCESS_EXECUTE_FLAG_CHANNELIZED):
         if has_pty:
             master, slave = pty.openpty()
@@ -1161,7 +1158,7 @@ def stdapi_sys_process_execute(request, response):
                     termios.tcsetattr(master, termios.TCSADRAIN, settings)
                 except:
                     pass
-            proc_h = STDProcess(args, stdin=slave, stdout=slave, stderr=slave, bufsize=0)
+            proc_h = STDProcess(args, stdin=slave, stdout=slave, stderr=slave, bufsize=0, start_new_session=True)
             proc_h.stdin = os.fdopen(master, 'wb')
             proc_h.stdout = os.fdopen(master, 'rb')
             proc_h.stderr = open(os.devnull, 'rb')

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1158,7 +1158,7 @@ def stdapi_sys_process_execute(request, response):
                     termios.tcsetattr(master, termios.TCSADRAIN, settings)
                 except:
                     pass
-            proc_h = STDProcess(args, stdin=slave, stdout=slave, stderr=slave, bufsize=0, start_new_session=True)
+            proc_h = STDProcess(args, stdin=slave, stdout=slave, stderr=slave, bufsize=0, preexec_fn=os.setsid)
             proc_h.stdin = os.fdopen(master, 'wb')
             proc_h.stdout = os.fdopen(master, 'rb')
             proc_h.stderr = open(os.devnull, 'rb')


### PR DESCRIPTION
Previously when dropping into a pty shell with `shell -t` and using the `sudo` command it would appear to hang, in reality the `sudo` password prompt would be appearing on the target machine resulting in you not being able to use `sudo` if a password prompt was required

This PR removes running the shell as a subprocess of another shell in a new process (I'm not at all sure why it was implemented this way in the first place, I can't think of any reason why it would be required, testing on windows/unix shows no issues but please let me know of any concerns you might have) and I also set the `start_new_session` flag to `True` which is on;y used for POSIX environments and is ignored on windows platforms where it's not necessary

From https://docs.python.org/3/library/subprocess.html#popen-constructor
```
If start_new_session is true the setsid() system call will be made in the child process prior to the execution of the subprocess. (POSIX only)
```

One minor concern is that now in the `sudo` password prompt the password will be echoed to the screen, I think this is a fair trade off in order to get `sudo` to work and this is also something that we hope to address soon in out work on improving the interactivity of Meterpreter shells.

Before:
![image](https://user-images.githubusercontent.com/19910435/127323691-d66c96ae-87a5-45c1-b48c-c6393b53310d.png)


After:
![image](https://user-images.githubusercontent.com/19910435/127323489-015fa4e0-2abb-45e0-bbf4-b9bfff254ec2.png)


Sidenote: I ran the post module tests found here https://github.com/rapid7/metasploit-framework/tree/master/test/modules/post/test and got the same results on master as I did with this branch on both linux and windows