### PR TITLE
Add support for updating terminal size dynamically

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -2564,4 +2564,6 @@ def stdapi_set_term_size(request, response):
         proc_h = meterpreter.channels[channel_id].proc_h
         winsize = struct.pack("HHHH", rows, columns, 0, 0)
         fcntl.ioctl(proc_h.stdin, termios.TIOCSWINSZ, winsize)
+    else:
+        return ERROR_FAILURE, response
     return ERROR_SUCCESS, response

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -616,6 +616,9 @@ TLV_TYPE_REGISTER_SIZE         = TLV_META_TYPE_UINT    | 2541
 TLV_TYPE_REGISTER_VALUE_32     = TLV_META_TYPE_UINT    | 2542
 TLV_TYPE_REGISTER              = TLV_META_TYPE_GROUP   | 2550
 
+TLV_TYPE_TERMINAL_ROWS         = TLV_META_TYPE_UINT    | 2600
+TLV_TYPE_TERMINAL_COLUMNS      = TLV_META_TYPE_UINT    | 2601
+
 ##
 # Ui
 ##
@@ -2555,11 +2558,10 @@ def stdapi_ui_get_idle_time(request, response):
     return ERROR_SUCCESS, response
 
 @register_function_if(has_termios and has_fcntl)
-def stdapi_set_term_size(request, response):
+def stdapi_sys_set_term_size(request, response):
     channel_id = packet_get_tlv(request, TLV_TYPE_CHANNEL_ID)['value']
-    tlvs = list(packet_enum_tlvs(request, TLV_TYPE_UINT))
-    rows = tlvs[0]['value']
-    columns = tlvs[1]['value']
+    rows = packet_get_tlv(request, TLV_TYPE_TERMINAL_ROWS)['value']
+    columns = packet_get_tlv(request, TLV_TYPE_TERMINAL_COLUMNS)['value']
     if channel_id in meterpreter.interact_channels:
         proc_h = meterpreter.channels[channel_id].proc_h
         winsize = struct.pack("HHHH", rows, columns, 0, 0)

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -2558,7 +2558,7 @@ def stdapi_ui_get_idle_time(request, response):
     return ERROR_SUCCESS, response
 
 @register_function_if(has_termios and has_fcntl)
-def stdapi_sys_set_term_size(request, response):
+def stdapi_sys_process_set_term_size(request, response):
     channel_id = packet_get_tlv(request, TLV_TYPE_CHANNEL_ID)['value']
     rows = packet_get_tlv(request, TLV_TYPE_TERMINAL_ROWS)['value']
     columns = packet_get_tlv(request, TLV_TYPE_TERMINAL_COLUMNS)['value']

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -347,7 +347,7 @@ COMMAND_IDS = (
     (1115, 'stdapi_audio_mic_start'),
     (1116, 'stdapi_audio_mic_stop'),
     (1117, 'stdapi_audio_mic_list'),
-    (1118, 'stdapi_sys_set_term_size'),
+    (1118, 'stdapi_sys_process_set_term_size'),
 
 )
 # ---------------------------------------------------------------

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -347,6 +347,8 @@ COMMAND_IDS = (
     (1115, 'stdapi_audio_mic_start'),
     (1116, 'stdapi_audio_mic_stop'),
     (1117, 'stdapi_audio_mic_list'),
+    (1118, 'stdapi_set_term_size'),
+
 )
 # ---------------------------------------------------------------
 

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -347,7 +347,7 @@ COMMAND_IDS = (
     (1115, 'stdapi_audio_mic_start'),
     (1116, 'stdapi_audio_mic_stop'),
     (1117, 'stdapi_audio_mic_list'),
-    (1118, 'stdapi_set_term_size'),
+    (1118, 'stdapi_sys_set_term_size'),
 
 )
 # ---------------------------------------------------------------


### PR DESCRIPTION
Companion PR to this one over in framework: https://github.com/rapid7/metasploit-framework/pull/15522

Adds a new stdapi command to set the terminal rows/columns for an interactive shell that you may have

Using the metasploit version in the PR linked above you can use `shell -it` to get an interactive PTY which will update the terminal size correctly as you resize the window running msfconsole, you can use `stty size` to see the current rows/columns that have been set and using something like `vim` should now work much better using up the full screen instead of the default size

To test out this PR you can just drop `meterpreter.py` and `ext_server_stdapi.py` into `metasploit-framework/data/meterpreter/` before you generate your python payload, you'll know it's working when you see a warning like this
`WARNING: Local file /home/dwelch/dev/metasploit-framework/data/meterpreter/meterpreter.py is being used`