### PR TITLE
[Python] Cleanup the process object

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1167,6 +1167,7 @@ def stdapi_sys_process_execute(request, response):
             proc_h.stdin = os.fdopen(master, 'wb')
             proc_h.stdout = os.fdopen(master, 'rb')
             proc_h.stderr = open(os.devnull, 'rb')
+            proc_h.ptyfd = slave
         else:
             proc_h = STDProcess(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             proc_h.echo_protection = True


### PR DESCRIPTION
This fixes a bug I noticed while testing another PR. When I used `git bisect` to determine where the issue was introduced, it became apparent that it's been present for quite some time. The issue is that on Linux systems where PTYs are used for channelized-subprocess, the streams are not properly closed. This causes a deadlock when the thread that is reading it never exits, ultimately leading to the Meterpreter process to last forever.

To reproduce the issue, on a Linux system:
- [x] Use the `payload/python/meterpreter/reverse_tcp` module
- [x] `set MeterpreterTryToFork false` to keep it in the foreground so you can observe the behavior
- [x] `set PythonMeterpreterDebug true` to get diagnostic output to observe what's happening
- [x] Now generate a payload with `generate -f raw` and execute it
- [x] In the new Meterpreter session start a channelized subprocess using the `shell` command
- [x] Exit out of the shell
- [x] Exit out of Meterpreter
- [x] Observe that the Meterpreter process is still running
    * With these changes in place, the Meterpreter process should exit

The reason why the Meterpreter process continues to run is the thread owned by the `STDProcessBuffer` is still running. A cheap trick could be to toggle the daemon flag on this thread, but that would cause those threads to be leaked as more and more channelized processes are started.

I tested this using Python 2.5, 2.6, 3.7 and 3.9 all on Linux, then Python 3.9 on Windows just to make sure nothing broke there as well. The changes should primarily affect Posix compatible systems where the `openpty` call is [used and then the streams are swapped](https://github.com/rapid7/metasploit-payloads/blob/b64f52dca5f1c7bf1ae15b27d688daf25282ad12/python/meterpreter/ext_server_stdapi.py#L1158-L1169).

## Testing
Follow the steps outlined to reproduce the issue, but see that the Meterpreter process exits correctly.