### PR TITLE
Only return the username for getuid

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -756,12 +756,12 @@ function stdapi_sys_config_getuid($req, &$pkt) {
     if (is_callable('posix_getuid')) {
         $uid = posix_getuid();
         $pwinfo = posix_getpwuid($uid);
-        $user = $pwinfo['name'] . " ($uid)";
+        $user = $pwinfo['name'];
     } else {
         # The posix functions aren't available, this is probably windows.  Use
         # the functions for getting user name and uid based on file ownership
         # instead.
-        $user = get_current_user() . " (" . getmyuid() . ")";
+        $user = get_current_user();
     }
     my_print("getuid - returning: " . $user);
     packet_add_tlv($pkt, create_tlv(TLV_TYPE_USER_NAME, $user));


### PR DESCRIPTION
This is one of two changes needed to fix rapid7/metasploit-framework#15672 which is caused by the Meterpreters returning inconsistent values for the `sys.config.getuid`. Despite being called "getuid" it should return the username. What it was doing prior to these changes was returning a string containing the username and numeric UID.

## Testing

- [ ] Establish a PHP Meterpreter session into Metasploit
- [ ] Run the `getuid` command
- [ ] See the username and only the username