### PR TITLE
Use string IPs for LOCAL_HOST and PEER_HOST TLVs

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1337,9 +1337,9 @@ class PythonMeterpreter(object):
                         self.send_packet(tlv_pack_request('stdapi_net_tcp_channel_open', [
                             {'type': TLV_TYPE_CHANNEL_ID, 'value': client_channel_id},
                             {'type': TLV_TYPE_CHANNEL_PARENTID, 'value': channel_id},
-                            {'type': TLV_TYPE_LOCAL_HOST, 'value': inet_pton(channel.sock.family, server_addr[0])},
+                            {'type': TLV_TYPE_LOCAL_HOST, 'value': server_addr[0]},
                             {'type': TLV_TYPE_LOCAL_PORT, 'value': server_addr[1]},
-                            {'type': TLV_TYPE_PEER_HOST, 'value': inet_pton(client_sock.family, client_addr[0])},
+                            {'type': TLV_TYPE_PEER_HOST, 'value': client_addr[0]},
                             {'type': TLV_TYPE_PEER_PORT, 'value': client_addr[1]},
                         ]))
                 elif isinstance(channel, MeterpreterSocketUDPClient):


### PR DESCRIPTION
This fixes a bug in the Python Meterpreter where it would send packed IP addresses in the channel creation request when a client connects to a listening TCP server. This would result in Metasploit printing the packed IP address and it's session command crashing whan a pivoted Meterpreter is connected. The [`TLV_TYPE_LOCAL_HOST`](https://github.com/rapid7/metasploit-payloads/blob/d07f44ed4623c5a51b59da507155f97baabdade0/python/meterpreter/meterpreter.py#L174) and [`TLV_TYPE_PEER_HOST`](https://github.com/rapid7/metasploit-payloads/blob/d07f44ed4623c5a51b59da507155f97baabdade0/python/meterpreter/meterpreter.py#L172) data types are strings so they should use the human-readable IP address like `127.0.0.1` not the packed address like `\x7f\x00\x00\x01`.

## Testing

- [ ] Obtain a Python Meterpreter session some how
- [ ] Route all traffic through it (run `route add 0 0 -1`)
- [ ] Use an exploit to deliver a new payload, but set the LHOST to the compromised hosts address
- [ ] See a proper IP address
- [ ] Run the `sessions` command and see the expected output, not a crash

<details>
<summary>Exception Example</summary>

This was generated from a resource file, but the invalid address and exception details are clearly visible.

```
[*] Session 6 created in the background.
resource (/home/smcintyre/Repositories/metasploit-framework/test.rc)> route add 0 0 -1
[*] Route added
resource (/home/smcintyre/Repositories/metasploit-framework/test.rc)> set RHOSTS 192.168.159.128
RHOSTS => 192.168.159.128
resource (/home/smcintyre/Repositories/metasploit-framework/test.rc)> set LHOST 192.168.159.31
LHOST => 192.168.159.31
resource (/home/smcintyre/Repositories/metasploit-framework/test.rc)> run -z
[*] Started reverse TCP handler on 192.168.159.31:5555 via the meterpreter on session 6
[*] 192.168.159.128:22 - Sending stager...
[*] Sending stage (39732 bytes) to ����
[*] Meterpreter session 7 opened (���:5555 -> 127.0.0.1) at 2021-10-01 16:56:17 -0400
[*] Sending stage (39732 bytes) to ����
[!] Timed out while waiting for command to return
[*] Session 7 created in the background.
resource (/home/smcintyre/Repositories/metasploit-framework/test.rc)> sessions

[-] Session manipulation failed: invalid byte sequence in UTF-8 ["/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:413:in `split'", "/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:413:in `block in chunk_values'", "/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:410:in `each'", "/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:410:in `each_with_index'", "/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:410:in `each'", "/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:410:in `map'", "/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:410:in `chunk_values'", "/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:395:in `row_to_s'", "/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:125:in `block in to_s'", "/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:121:in `each'", "/home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:121:in `to_s'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/serializer/readable_text.rb:775:in `dump_sessions'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1620:in `cmd_sessions'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:557:in `run_command'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:506:in `block in run_single'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:500:in `each'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:500:in `run_single'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/resource.rb:69:in `load_resource'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/resource.rb:73:in `block in cmd_resource'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/resource.rb:52:in `each'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/resource.rb:52:in `cmd_resource'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:557:in `run_command'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:506:in `block in run_single'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:500:in `each'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:500:in `run_single'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'", "/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'", "/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'", "./msfconsole:23:in `<main>'"]
msf6 exploit(multi/ssh/sshexec) > [*] Meterpreter session 8 opened (���:5555 -> 127.0.0.1) at 2021-10-01 16:56:24 -0400

```
</details>