### PR TITLE
Don't delete channels when handling dead resources

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -667,6 +667,7 @@ class MeterpreterProcess(MeterpreterChannel):
             self.proc_h.kill()
         if self.proc_h.ptyfd is not None:
             os.close(self.proc_h.ptyfd)
+            self.proc_h.ptyfd = None
         for stream in (self.proc_h.stdin, self.proc_h.stdout, self.proc_h.stderr):
             if not hasattr(stream, 'close'):
                 continue
@@ -1362,7 +1363,6 @@ class PythonMeterpreter(object):
                     self.send_packet(tlv_pack_request('core_channel_write', write_request_parts))
 
     def handle_dead_resource_channel(self, channel_id):
-        del self.channels[channel_id]
         if channel_id in self.interact_channels:
             self.interact_channels.remove(channel_id)
         self.send_packet(tlv_pack_request('core_channel_close', [


### PR DESCRIPTION
Deleting the channels when they are dead prevented Metasploit from reading their streams before closing them. This is the case when the command is expected to return immediately. This behavior notable breaks things like `command_exists?`.

The bug can be verified by running the Meterpreter in the foreground, and enabling the debug log. From this output you can see that the command is executed, the channel is created but the read operation fails because the channel is almost immediately deleted. The channel should be kept around until Metasploit closes it which provides an opportunity for Metasploit to read from it. The `core_channel_close` handler will still delete the channel.

```
[*] running method stdapi_sys_process_execute
[*] starting process: ['/bin/sh', '-c', 'command -v python3 || which python3 && echo ONUKNAQI', '']
[*] added process id: 1
[*] added channel id: 1 type: MeterpreterProcess
[*] sending response packet
[*] running method core_channel_read
[-] method core_channel_read resulted in error: #1
[*] sending response packet
[*] running method core_channel_close
[-] method core_channel_close resulted in error: #1
[*] sending response packet
[*] running method stdapi_sys_process_close
[*] sending response packet
```

## Verification
- [ ] Establish a Python Meterpreter session
- [ ] Use a post module that provides the `command_exists?` command (`post/linux/gather/checkvm` works for this purpose)
- [ ] Drop into a `pry` session
- [ ] Run `command_exists?('python3')` and see that it identifies that `python3` is available on the remote system (assuming that's accurate, otherwise substitute for another binary that should be working)

## Example

```
msf6 payload(python/meterpreter/reverse_tcp) > use post/linux/gather/checkvm 
msf6 post(linux/gather/checkvm) > show options 

Module options (post/linux/gather/checkvm):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   yes       The session to run this module on

msf6 post(linux/gather/checkvm) > set SESSION -1
SESSION => -1
msf6 post(linux/gather/checkvm) > pry
[*] Starting Pry shell...
[*] You are in the "post/linux/gather/checkvm" module object

[1] pry(#<Msf::Modules::Post__Linux__Gather__Checkvm::MetasploitModule>)> command_exists?('python3')
=> true
[2] pry(#<Msf::Modules::Post__Linux__Gather__Checkvm::MetasploitModule>)> 
```