### PR TITLE
Honor the pty flag

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -662,6 +662,7 @@ PROCESS_EXECUTE_FLAG_CHANNELIZED = (1 << 1)
 PROCESS_EXECUTE_FLAG_SUSPENDED = (1 << 2)
 PROCESS_EXECUTE_FLAG_USE_THREAD_TOKEN = (1 << 3)
 PROCESS_EXECUTE_FLAG_SUBSHELL         = (1 << 6)
+PROCESS_EXECUTE_FLAG_PTY              = (1 << 7)
 
 PROCESS_ARCH_UNKNOWN = 0
 PROCESS_ARCH_X86 = 1
@@ -1166,7 +1167,7 @@ def stdapi_sys_process_execute(request, response):
         args.extend(shlex.split(raw_args))
 
     if (flags & PROCESS_EXECUTE_FLAG_CHANNELIZED):
-        if has_pty:
+        if has_pty and (flags & PROCESS_EXECUTE_FLAG_PTY):
             master, slave = pty.openpty()
             if has_termios:
                 try:


### PR DESCRIPTION
Small change to honor the `PROCESS_EXECUTE_FLAG_PTY` in the same way we do in mettle

https://github.com/rapid7/mettle/blob/6fffb8a945bea1391567cdcfcad80371f73ca520/mettle/src/stdapi/sys/process.c#L298

# Verification
- [x] Start msfconsole
- [x] run `features set fully_interactive_shells true`
- [x] Get a session with the python meterpreter
- [x] Run `shell -it`
- [x] Check that tab completion and reverse search etc. still work
