### PR TITLE
[Python] Cleanup channels when closing processes

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1147,6 +1147,8 @@ def stdapi_sys_process_close(request, response):
     proc_h_id = proc_h_id['value']
     if proc_h_id in meterpreter.processes:
         del meterpreter.processes[proc_h_id]
+    if not meterpreter.close_channel(proc_h_id):
+        return ERROR_FAILURE, response
     return ERROR_SUCCESS, response
 
 @register_function


### PR DESCRIPTION
This ensures that when `stdapi_sys_process_close` is called, that the process channel is also closed as a normal channel. This cleans up the process object and removes the BrokenPipeErrors when the session is closed because there are a bunch of process channels still around.

Debugging output before this patch, after running the `post/test/cmd_exec` module and then running the `shutdown` command.
```
[*] running method core_shutdown
[*] sending response packet
Traceback (most recent call last):
  File "<string>", line 982, in send_packet
  File "<string>", line 1181, in _send_packet
BrokenPipeError: [Errno 32] Broken pipe
Traceback (most recent call last):
  File "<string>", line 982, in send_packet
  File "<string>", line 1181, in _send_packet
BrokenPipeError: [Errno 32] Broken pipe
Traceback (most recent call last):
  File "<string>", line 982, in send_packet
  File "<string>", line 1181, in _send_packet
BrokenPipeError: [Errno 32] Broken pipe
```

## Testing

With debugging enabled, and the Meterpreter running in the foreground (disable forking with `set MeterpreterTryToFork false`):

- [ ] Run `post/test/cmd_exec` and then `shutdown`
   - [ ] See all of the tests pass, see no BrokenPipeErrors when shutting down
- [ ] Run `post/test/meterpreter`
   - [ ] See all of the tests pass, see no BrokenPipeErrors when shutting down