### PR TITLE
Fix #512, fix python cmd_exec argument list during PROCESS_EXECUTE_FLAG_SUBSHELL

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1163,7 +1163,9 @@ def stdapi_sys_process_execute(request, response):
     if len(cmd) == 0:
         return ERROR_FAILURE, response
     if os.path.isfile('/bin/sh') and (flags & PROCESS_EXECUTE_FLAG_SUBSHELL):
-        args = ['/bin/sh', '-c', cmd, raw_args]
+        if raw_args:
+            cmd = cmd + ' ' + raw_args
+        args = ['/bin/sh', '-c', cmd]
     else:
         args = [cmd]
         args.extend(shlex.split(raw_args))


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-payloads/issues/512 to ensure the arguments are appended (with a space) to the cmd, when PROCESS_EXECUTE_FLAG_SUBSHELL is set.

# Verification
- [ ] Start msfconsole
- [ ] Get a python session
- [ ] Run the cmd_exec tests:
```
loadpath test/modules
use post/test/cmd_exec
set SESSION -1
set VERBOSE true
run
```
- [ ] Run cmd_exec with irb:
```
msf6 post(test/cmd_exec) > irb
[*] Starting IRB shell...
[*] You are in post/test/cmd_exec
>> cmd_exec('echo', 'test')
=> "test"
```
