### PR TITLE
[Python] Return an empty stat buf when stat fails

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1494,7 +1494,11 @@ def stdapi_fs_ls(request, response):
         file_path = os.path.join(path, file_name)
         response += tlv_pack(TLV_TYPE_FILE_NAME, file_name)
         response += tlv_pack(TLV_TYPE_FILE_PATH, file_path)
-        response += tlv_pack(TLV_TYPE_STAT_BUF, get_stat_buffer(file_path))
+        try:
+            st_buf = get_stat_buffer(file_path)
+        except OSError:
+            st_buf = bytes()
+        response += tlv_pack(TLV_TYPE_STAT_BUF, st_buf)
     return ERROR_SUCCESS, response
 
 @register_function


### PR DESCRIPTION
This updates the Python Meterpreter to *always* return a stat buffer in response to the `stdapi_fs_ls` command. This ensures that when [Metasploit](https://github.com/rapid7/metasploit-framework/blob/46dc748bd00eaf3b3f7e17ab39692493f8c8cd12/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb#L74) lists the contents of a directory a stat buffer is returned for each and every entry that is returned to Metasploit. Without this in place, if a stat buffer is missing, then when Metasploit iterates over the set of names and stat buffers they will not be aligned causing the stat buffer for a different entry (the next in the array) to be used for the first entry that failed. A bad symbolic link will cause `stat` to fail and is the case that I ran into which raised this issue.

This is the Python version of rapid7/mettle#228. Whereas Mettle would skip the stat buffer and cause the results to be corrupt that are processed by Metasploit, the Python Meterpreter would throw an exception and the entire list operation would fail.

## Testing
Test on a Linux system

- [ ] Make a bad symbolic link in a directory: `ln -s /doesnotexist doesnotexist`
- [ ] Use the Python Meterpreter to list the contents of the directory using the builtin `ls` command
- [ ] See a stat buffer for each and every entry that is returned

Without these changes, an exception would be raised. With these changes, Metasploit will show blank fields for the entries that can not be stat'ed (like the bad symbolic link).

```
msf6 payload(python/meterpreter/reverse_tcp) > sessions -i 8
[*] Starting interaction with 8...

meterpreter > sysinfo
Computer        : localhost.localdomain
OS              : Linux 5.15.4-101.fc34.x86_64 #1 SMP Tue Nov 23 18:58:50 UTC 2021
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > ls /etc
[-] stdapi_fs_ls: Operation failed: Python exception: FileNotFoundError
meterpreter >
```
