### PR TITLE
[PHP] Return an empty stat buf when stat fails

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -628,8 +628,10 @@ function stdapi_fs_ls($req, &$pkt) {
                 packet_add_tlv($pkt, create_tlv(TLV_TYPE_FILE_NAME, $file));
                 packet_add_tlv($pkt, create_tlv(TLV_TYPE_FILE_PATH, $path . DIRECTORY_SEPARATOR . $file));
                 $st_buf = add_stat_buf($path . DIRECTORY_SEPARATOR . $file);
-                if ($st_buf)
-                    packet_add_tlv($pkt, $st_buf);
+                if (!$st_buf) {
+                    $st_buf = create_tlv(TLV_TYPE_STAT_BUF32, '');
+                }
+                packet_add_tlv($pkt, $st_buf);
             }
         }
         closedir($dir_handle);


### PR DESCRIPTION
This updates the PHP Meterpreter to *always* return a stat buffer in response to the `stdapi_fs_ls` command. This ensures that when [Metasploit](https://github.com/rapid7/metasploit-framework/blob/46dc748bd00eaf3b3f7e17ab39692493f8c8cd12/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb#L74) lists the contents of a directory a stat buffer is returned for each and every entry that is returned to Metasploit. Without this in place, if a stat buffer is missing, then when Metasploit iterates over the set of names and stat buffers they will not be aligned causing the stat buffer for a different entry (the next in the array) to be used for the first entry that failed. A bad symbolic link will cause `stat` to fail and is the case that I ran into which raised this issue.

## Testing
Test on a Linux system

- [ ] Make a bad symbolic link in a directory: `ln -s /doesnotexist doesnotexist`
- [ ] Use the PHP Meterpreter to list the contents of the directory using the builtin `ls` command
- [ ] See a stat buffer for each entry that can be stat'ed

Without these changes, some entries would have missing data in the table that's printed out and entries would have been shifted causing the incorrect data to be printed for others. With these changes, Metasploit will show blank fields for the correct entries that can not be stat'ed  (like the bad symbolic link).

