### PR TITLE
Update Javas stdapi_fs_delete_dir to be recursive

### DIFF
--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_delete_dir.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_delete_dir.java
@@ -9,16 +9,43 @@ import com.metasploit.meterpreter.TLVType;
 import com.metasploit.meterpreter.command.Command;
 
 public class stdapi_fs_delete_dir implements Command {
-
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         String path = request.getStringValue(TLVType.TLV_TYPE_DIRECTORY_PATH);
         File file = Loader.expand(path);
-        if (!file.exists() || !file.isDirectory()) {
+        if (isSymlink(file)) {
+            if (!file.delete()) {
+                throw new IOException("Cannot delete symbolic link " + file.getCanonicalPath());
+            }
+        } else if (file.isDirectory()) {
+            rmtree(file);
+        } else {
             throw new IOException("Directory not found: " + path);
         }
-        if (!file.delete()) {
-            throw new IOException("Cannot delete directory " + file.getCanonicalPath());
-        }
         return ERROR_SUCCESS;
+    }
+
+    private static boolean isSymlink(File file) throws IOException {
+        File canon;
+        if (file.getParent() == null) {
+            canon = file;
+        } else {
+            File canonDir = file.getParentFile().getCanonicalFile();
+            canon = new File(canonDir, file.getName());
+        }
+        return !canon.getCanonicalFile().equals(canon.getAbsoluteFile());
+    }
+
+    private void rmtree(File file) throws IOException {
+        for (File subFile : file.listFiles()) {
+            if (isSymlink(subFile)) {
+                subFile.delete();
+            } else if (subFile.isDirectory()) {
+                rmtree(subFile);
+            } else {
+                subFile.delete();
+            }
+        }
+        file.delete();
+        return;
     }
 }

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_delete_dir.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_delete_dir.java
@@ -17,7 +17,9 @@ public class stdapi_fs_delete_dir implements Command {
                 throw new IOException("Cannot delete symbolic link " + file.getCanonicalPath());
             }
         } else if (file.isDirectory()) {
-            rmtree(file);
+            if (!rmtree(file)) {
+                throw new IOException("Cannot delete " + file.getCanonicalPath());
+            }
         } else {
             throw new IOException("Directory not found: " + path);
         }
@@ -35,17 +37,18 @@ public class stdapi_fs_delete_dir implements Command {
         return !canon.getCanonicalFile().equals(canon.getAbsoluteFile());
     }
 
-    private void rmtree(File file) throws IOException {
+    private boolean rmtree(File file) throws IOException {
+        boolean ret = true;
         for (File subFile : file.listFiles()) {
             if (isSymlink(subFile)) {
-                subFile.delete();
+                ret = ret && subFile.delete();
             } else if (subFile.isDirectory()) {
-                rmtree(subFile);
+                ret = ret && rmtree(subFile);
             } else {
-                subFile.delete();
+                ret = ret && subFile.delete();
             }
         }
-        file.delete();
-        return;
+        ret = ret && file.delete();
+        return ret;
     }
 }


### PR DESCRIPTION
This is related to rapid7/metasploit-framework#13369 and updates the Java Meterpreter's `stdapi_fs_delete_dir` command to recursively delete the directory. While odd, the actual logic is modeled after the existing [Python implementation](https://github.com/rapid7/metasploit-payloads/blob/c3b9bbc18889f952b65d1905cc07424141dc86f3/python/meterpreter/ext_server_stdapi.py#L1412-L1423) and aims to be as consistent with it as possible.

Notable details are:
* If the path is a symbolic link, it's deleted (non-recursively)
* If the path is a directory, all of it's contents are deleted, recursively, **links are deleted not followed (non-recursive)**

To maintain Java 1.5 compatibility, I had to find a different symlink function. I used the same technique as the Apache commons-io FileUtils [method](https://github.com/apache/commons-io/blob/e36d53170875d26d59ca94bd376bf40bc5690ee6/src/main/java/org/apache/commons/io/FileUtils.java#L2920). Any suggestions for improvements would be great.

## Testing
- [x] Create a new directory, place a file in it, also place a symbolic link pointing to a non-empty directory
- [x] Use the `rmdir` Meterpreter command to delete the directory using the Java meterpreter
    - [x] See that the directory has been deleted despite not being empty
    - [ ] See that the directory the (now-deleted) symbolic link pointed to still has all of its contents
- [ ] Create a symbolic link
- [ ] Use the `rmdir` Meterpreter command to delete the symbolic link