### PR TITLE
Convert error codes to be consistent HRESULTS

### DIFF
--- a/c/meterpreter/source/extensions/powershell/powershell.c
+++ b/c/meterpreter/source/extensions/powershell/powershell.c
@@ -38,14 +38,13 @@ DWORD InitServerExtension(MetApi* api, Remote* remote)
 
 	gRemote = remote;
 
-	DWORD result = initialize_dotnet_host();
-
-	if (result == ERROR_SUCCESS)
+	HRESULT hresult = initialize_dotnet_host();
+	if (hresult == S_OK)
 	{
 		met_api->command.register_all(customCommands);
 	}
 
-	return result;
+	return (DWORD)hresult;
 }
 
 /*!

--- a/c/meterpreter/source/extensions/powershell/powershell_bridge.h
+++ b/c/meterpreter/source/extensions/powershell/powershell_bridge.h
@@ -5,12 +5,12 @@
 #ifndef _METERPRETER_SOURCE_EXTENSION_POWERSHELL_BRIDGE_H
 #define _METERPRETER_SOURCE_EXTENSION_POWERSHELL_BRIDGE_H
 
-DWORD initialize_dotnet_host();
+HRESULT initialize_dotnet_host();
 VOID deinitialize_dotnet_host();
-DWORD request_powershell_execute(Remote *remote, Packet *packet);
-DWORD request_powershell_shell(Remote *remote, Packet *packet);
-DWORD request_powershell_session_remove(Remote *remote, Packet *packet);
-DWORD request_powershell_assembly_load(Remote *remote, Packet *packet);
-DWORD invoke_startup_script(LPCSTR script);
+HRESULT request_powershell_execute(Remote *remote, Packet *packet);
+HRESULT request_powershell_shell(Remote *remote, Packet *packet);
+HRESULT request_powershell_session_remove(Remote *remote, Packet *packet);
+HRESULT request_powershell_assembly_load(Remote *remote, Packet *packet);
+HRESULT invoke_startup_script(LPCSTR script);
 
 #endif

--- a/c/meterpreter/source/metsrv/remote_dispatch.c
+++ b/c/meterpreter/source/metsrv/remote_dispatch.c
@@ -68,7 +68,7 @@ DWORD buffer_to_file(LPCSTR filePath, PUCHAR buffer, ULONG length)
 
 		// Keep writing until everything is written
 		while ((bytesLeft) &&
-		       (WriteFile(h, buffer + offset, bytesLeft, &bytesWritten, NULL)))
+			   (WriteFile(h, buffer + offset, bytesLeft, &bytesWritten, NULL)))
 		{
 			bytesLeft -= bytesWritten;
 			offset    += bytesWritten;
@@ -272,6 +272,7 @@ DWORD load_extension(HMODULE hLibrary, BOOL bLibLoadedReflectivly, Remote* remot
 			dprintf("[SERVER] Calling init()...");
 
 			pExtension->end = pFirstCommand;
+			// dwResult can be a mixture of different error types, e.g. HRESULT, win32 error
 			dwResult = pExtension->init(met_api, remote);
 			pExtension->start = extensionCommands;
 


### PR DESCRIPTION
Resolves https://github.com/rapid7/metasploit-framework/issues/15907 and https://github.com/rapid7/metasploit-framework/issues/15943

The local exploit suggester was found to be killing some sessions. The issue was tracked down to `load powershell` being run on the sessions which was killing it due to some incorrect error handling here: https://github.com/rapid7/metasploit-payloads/blob/7c5930b02e48ce7fecc2e4cb29f85c9c3d9b3789/c/meterpreter/source/extensions/powershell/powershell_bridge.cpp#L322-L326

`FAILED` is intended top check an HRESULT but instead the result from `GetLastError()` was being returned leading to the crash
