### PR TITLE
add stdapi_sys_process_getpid on Android and fix Android post/test/meterpreter tests

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -134,6 +134,7 @@ public class AndroidMeterpreter extends Meterpreter {
         mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_EXECUTE, stdapi_sys_process_execute_V1_3.class);
         mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_CLOSE, stdapi_sys_process_close.class);
         mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_GET_PROCESSES, stdapi_sys_process_get_processes_android.class);
+        mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_GETPID, stdapi_sys_process_getpid_android.class);
         mgr.registerCommand(CommandId.STDAPI_UI_DESKTOP_SCREENSHOT, stdapi_ui_desktop_screenshot.class);
         if (context != null) {
             mgr.registerCommand(CommandId.APPAPI_APP_LIST, appapi_app_list.class);

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_process_getpid_android.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_process_getpid_android.java
@@ -1,0 +1,19 @@
+package com.metasploit.meterpreter.android;
+
+import android.os.Process;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+import com.metasploit.meterpreter.stdapi.stdapi_sys_process_getpid;
+
+public class stdapi_sys_process_getpid_android extends stdapi_sys_process_getpid implements Command {
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        int pid = Process.myPid();
+        response.add(TLVType.TLV_TYPE_PID, pid);
+        return ERROR_SUCCESS;
+
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_config_getenv.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_config_getenv.java
@@ -22,10 +22,12 @@ public class stdapi_sys_config_getenv implements Command {
                 }
 
                 String envVal = System.getenv(envVar);
-                TLVPacket grp = new TLVPacket();
-                grp.add(TLVType.TLV_TYPE_ENV_VARIABLE, envVar);
-                grp.add(TLVType.TLV_TYPE_ENV_VALUE, envVal);
-                response.addOverflow(TLVType.TLV_TYPE_ENV_GROUP, grp);
+                if (envVal != null) {
+                    TLVPacket grp = new TLVPacket();
+                    grp.add(TLVType.TLV_TYPE_ENV_VARIABLE, envVar);
+                    grp.add(TLVType.TLV_TYPE_ENV_VALUE, envVal);
+                    response.addOverflow(TLVType.TLV_TYPE_ENV_GROUP, grp);
+                }
             }
         } catch (IllegalArgumentException e) {
             Map<String,String> envVals = System.getenv();


### PR DESCRIPTION
This pull request contains two changes. I can separate them out if needed but it's probably easier just to land them together.
Firstly it adds stdapi_sys_process_getpid for Android (see https://github.com/rapid7/metasploit-payloads/pull/521)

Secondly it contains a fix for stdapi_sys_config_getenv. Previously `meterpreter > getenv MISSINGENVVARIABLE` would return `null` as a string. After this change an actual nil value is returned. This fixes the post/test/meterpreter tests, which would fail because chdir("null") would throw an exception (as "null" is not a valid directory).


## Verification

- [ ] Get an Android meterpreter session (via adb):
```
msfvenom -p android/meterpreter/reverse_tcp SessionRetryWait=2 LHOST=127.0.0.1 LPORT=4444 -o met.apk
adb install met.apk
adb reverse tcp:4444 tcp:4444
adb shell am startservice com.metasploit.stage/.MainService
msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; setg lhost 127.0.0.1; set lport 4444; set ExitOnSession false; run -j"
```
- [ ] Run `meterpreter > getenv TEMP`
- [ ] Ensure the post/test/meterpreter tests now pass
```
msf6 post(test/meterpreter) > loadpath test/modules/
msf6 post(test/meterpreter) > use post/test/meterpreter
msf6 post(test/meterpreter) > set SESSION -1
msf6 post(test/meterpreter) > run
```

## Before change
```
meterpreter > getenv TEMP

Environment Variables
=====================

Variable  Value
--------  -----
TEMP      null

meterpreter > background

msf6 exploit(multi/handler) > loadpath test/modules/
Loaded 38 modules:
    11 post modules
    13 exploit modules
    14 auxiliary modules
msf6 exploit(multi/handler) > use post/test/meterpreter
msf6 post(test/meterpreter) > set SESSION -1
SESSION => -1
msf6 post(test/meterpreter) > run

[-] Post failed: Rex::Post::Meterpreter::RequestError stdapi_fs_chdir: Operation failed: 1
[-] Call stack:
[-]   /home/user/dev/git/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb:189:in `chdir'
[-]   /home/user/dev/git/metasploit-framework/test/modules/post/test/meterpreter.rb:45:in `setup'

```

## After change

```
meterpreter > getenv TEMP
[-] None of the specified environment variables were found/set.

meterpreter > background

msf6 post(test/meterpreter) > rexploit
[*] Reloading module...

[*] Setup: changing working directory to
[!] SESSION may not be compatible with this module:
[!]  * incompatible session platform: android
[*] Running against session -1
[*] Session type is meterpreter and platform is android
[+] should enumerate supported core commands
[+] should support 3 or more core commands
[*] Starting process tests
[*] Pid: 6891
[+] should return its own process id
[*] PID info: {"pid"=>6891, "ppid"=>nil, "name"=>"com.metasploit.stage", "path"=>nil, "session"=>nil, "user"=>"u0_a103", "arch"=>nil}
[+] should return a list of processes
[*] Starting system config tests
[+] should return a user id
[+] should return a sysinfo Hash
[*] Starting networking tests
[+] should return network interfaces
[+] should have an interface that matches session_host
[+] should return network routes
[*] Starting filesystem tests
[+] should return the proper directory separator
[*] CWD: /data/data/com.metasploit.stage/files
[+] should return the current working directory
[+] should list files in the current directory
[*] Current directory: "/data/data/com.metasploit.stage/files"
[*] Stat of current directory: #<#<Class:0x0000557a97ec9d90>:0x0000557a9c233630 @stathash={"st_dev"=>0, "st_mode"=>16894, "st_nlink"=>1, "st_uid"=>65535, "st_gid"=>65535, "st_rdev"=>0, "st_ino"=>0, "st_size"=>4096, "st_atime"=>1642414245, "st_mtime"=>1642414245, "st_ctime"=>1642414245}>
[+] should stat a directory
[*] Directory Name: meterpreter-test-dir
[*] Directory created successfully
[*] Directory removed successfully
[+] should create and remove a dir
[*] Directory Name: meterpreter-test-dir
[*] Directory created successfully
[*] Old CWD: /data/data/com.metasploit.stage/files
[*] New CWD: /data/data/com.metasploit.stage/files/meterpreter-test-dir
[*] Back to old CWD: /data/data/com.metasploit.stage/files
[*] Directory removed successfully
[+] should change directories
[*] File Name: meterpreter-test
[*] Wrote to meterpreter-test, checking contents
[*] Wrote test
[+] should create and remove files
[*] Remote File Name: meterpreter-test-file.txt
[*] uploading
[*] done
[*] remote file exists? true
[+] should upload a file
[*] Source File Name: meterpreter-test
[*] Destination File Name: meterpreter-test-moved
[+] should move files
[*] Source File Name: meterpreter-test
[*] Destination File Name: meterpreter-test-copied
[+] should copy files
[*] Remote File Name: meterpreter-test-file.txt
[*] uploading
[*] done
[*] remote file exists? true
[*] remote md5: 238bab901e240f3e78ad6f290bca0510
[*] local md5 : 238bab901e240f3e78ad6f290bca0510
[*] remote sha: ea186228a55278d32516182f230181dccf4b7934
[*] local sha : ea186228a55278d32516182f230181dccf4b7934
[+] should do md5 and sha1 of files
[*] Testing complete in 0.094404467
[*] Passed: 20; Failed: 0
[*] Cleanup: changing working directory back to /data/data/com.metasploit.stage/files
[*] Post module execution completed


```