### PR TITLE
Return an error for invalid getsystem techniques

### DIFF
--- a/c/meterpreter/source/extensions/priv/elevate.c
+++ b/c/meterpreter/source/extensions/priv/elevate.c
@@ -71,7 +71,7 @@ DWORD elevate_getnativearch( VOID )
  */
 DWORD elevate_getsystem( Remote * remote, Packet * packet )
 {
-	DWORD dwResult    = ERROR_SUCCESS;
+	DWORD dwResult    = ERROR_BAD_ARGUMENTS;
 	DWORD dwTechnique = ELEVATE_TECHNIQUE_ANY;
 	Packet * response = NULL;
 


### PR DESCRIPTION
This fixes #526 by returning an error code for invalid getsystem techniques. Prior to this change, if a getsystem technique number was specified that wasn't supported it would result in a success message being returned due to how the `dwResult`variable is initialized.

Testing:

- [ ] Open a Meterpreter sessions and load the updated version of the priv extension
- [ ] From a  pry session, call getsystem with an invalid technique number
- [ ] See an error is returned instead of a successful result

## Demo
In this case, "23" is not a valid getsystem technique.
```
msf6 payload(windows/x64/meterpreter/reverse_tcp) > 
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Sending stage (200262 bytes) to 192.168.159.11
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/ext_server_priv.x64.dll is being used
WARNING: Local files may be incompatible with the Metasploit Framework

msf6 payload(windows/x64/meterpreter/reverse_tcp) > 
msf6 payload(windows/x64/meterpreter/reverse_tcp) > [*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.11:51292 ) at 2022-01-24 15:11:18 -0500
sessions -i -1
[*] Starting interaction with 1...

meterpreter > pry
[*] Starting Pry shell...
[*] You are in the "client" (session) object

[1] pry(#<Msf::Sessions::Meterpreter_x64_Win>)> priv.getsystem(23)
Rex::Post::Meterpreter::RequestError: priv_elevate_getsystem: Operation failed: One or more arguments are not correct.
from /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/priv/priv.rb:96:in `getsystem'
[2] pry(#<Msf::Sessions::Meterpreter_x64_Win>)>
```