### PR TITLE
add java native architecture to sysinfo

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_config_sysinfo_android.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_config_sysinfo_android.java
@@ -12,13 +12,8 @@ import android.os.Build;
 public class stdapi_sys_config_sysinfo_android extends
         stdapi_sys_config_sysinfo implements Command {
 
-    public int execute(Meterpreter meterpreter, TLVPacket request,
-                       TLVPacket response) throws Exception {
+    protected String getOsName() throws Exception {
         String androidOS = Utils.runCommand("getprop ro.build.version.release").replace("\n", "");
-        response.add(TLVType.TLV_TYPE_COMPUTER_NAME, Utils.getHostname());
-        response.add(TLVType.TLV_TYPE_OS_NAME, "Android " + androidOS
-                + " - " + System.getProperty("os.name")
-                + " " + System.getProperty("os.version") + " (" + System.getProperty("os.arch") + ")");
-        return ERROR_SUCCESS;
+        return "Android " + androidOS + " - " + System.getProperty("os.name");
     }
 }

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
@@ -137,6 +137,7 @@ public interface TLVType {
     public static final int TLV_TYPE_OS_NAME        = TLVPacket.TLV_META_TYPE_STRING | 1041;
     public static final int TLV_TYPE_USER_NAME      = TLVPacket.TLV_META_TYPE_STRING | 1042;
     public static final int TLV_TYPE_ARCHITECTURE   = TLVPacket.TLV_META_TYPE_STRING | 1043;
+    public static final int TLV_TYPE_LANG_SYSTEM    = TLVPacket.TLV_META_TYPE_STRING | 1044;
     public static final int TLV_TYPE_LOCAL_DATETIME = TLVPacket.TLV_META_TYPE_STRING | 1048;
 
     public static final int TLV_TYPE_ENV_VARIABLE = TLVPacket.TLV_META_TYPE_STRING | 1100;

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_config_sysinfo.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_config_sysinfo.java
@@ -1,16 +1,43 @@
 package com.metasploit.meterpreter.stdapi;
 
-import java.net.InetAddress;
-
 import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.TLVPacket;
 import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.Utils;
 import com.metasploit.meterpreter.command.Command;
 
+import java.util.Locale;
+
 public class stdapi_sys_config_sysinfo implements Command {
+
+    private static String normalizeArch(String arch) {
+        if (arch.equals("i386") || arch.equals("i486")  || arch.equals("i586") || arch.equals("i686")) {
+            return "x86";
+        }
+        if (arch.equals("amd64") || arch.equals("x86_64")) {
+            return "x64";
+        }
+        if (arch.equals("arm") || arch.equals("arm32")) {
+            return "armle";
+        }
+        if (arch.equals("arm64")) {
+            return "aarch64";
+        }
+        return arch;
+    }
+
+    protected String getOsName() throws Exception {
+        return System.getProperty("os.name");
+    }
+
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
-        response.add(TLVType.TLV_TYPE_COMPUTER_NAME, InetAddress.getLocalHost().getHostName());
-        response.add(TLVType.TLV_TYPE_OS_NAME, System.getProperty("os.name") + " " + System.getProperty("os.version") + " (" + System.getProperty("os.arch") + ")");
+        String arch = System.getProperty("os.arch");
+        response.add(TLVType.TLV_TYPE_COMPUTER_NAME, Utils.getHostname());
+        response.add(TLVType.TLV_TYPE_OS_NAME, getOsName() + " " + System.getProperty("os.version") + " (" + arch + ")");
+        if (arch != null) {
+            response.add(TLVType.TLV_TYPE_ARCHITECTURE, normalizeArch(arch));
+        }
+        response.add(TLVType.TLV_TYPE_LANG_SYSTEM, Locale.getDefault().toString());
         return ERROR_SUCCESS;
     }
 }


### PR DESCRIPTION
Quick change to add the `Architecture    : x64` field to `meterpreter > sysinfo`
This may be useful if we need to load native extensions in the future. 

## Verification

- [ ] Get an java (or android) meterpreter session
- [ ] Run `meterpreter > sysinfo`

## Before change
```
meterpreter > sysinfo
Computer        : ubuntu
OS              : Linux 5.11.0-37-generic (amd64)
Meterpreter     : java/linux
```

## After change

```
meterpreter > sysinfo
Computer        : ubuntu
OS              : Linux 5.11.0-37-generic (amd64)
Architecture    : x64
System Language : en_GB
Meterpreter     : java/linux

```