### PR TITLE
Add Java native_arch

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Utils.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Utils.java
@@ -68,4 +68,24 @@ public class Utils {
         return data;
     }
 
+    public static String getNormalizedArch() {
+        final String arch = System.getProperty("os.arch");
+        if (arch == null) {
+            return null;
+        }
+
+        if (arch.equals("i386") || arch.equals("i486")  || arch.equals("i586") || arch.equals("i686")) {
+            return "x86";
+        }
+        if (arch.equals("amd64") || arch.equals("x86_64")) {
+            return "x64";
+        }
+        if (arch.equals("arm") || arch.equals("arm32")) {
+            return "armle";
+        }
+        if (arch.equals("arm64")) {
+            return "aarch64";
+        }
+        return arch;
+    }
 }

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
@@ -34,5 +34,6 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand(CommandId.CORE_TRANSPORT_PREV, core_transport_prev.class);
         mgr.registerCommand(CommandId.CORE_TRANSPORT_REMOVE, core_transport_remove.class);
         mgr.registerCommand(CommandId.CORE_NEGOTIATE_TLV_ENCRYPTION, core_negotiate_tlv_encryption.class);
+        mgr.registerCommand(CommandId.CORE_NATIVE_ARCH, core_native_arch.class);
     }
 }

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_native_arch.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_native_arch.java
@@ -1,0 +1,14 @@
+package com.metasploit.meterpreter.core;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.Utils;
+import com.metasploit.meterpreter.command.Command;
+
+public class core_native_arch implements Command {
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        response.add(TLVType.TLV_TYPE_STRING, Utils.getNormalizedArch());
+        return ERROR_SUCCESS;
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_config_sysinfo.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_config_sysinfo.java
@@ -10,32 +10,16 @@ import java.util.Locale;
 
 public class stdapi_sys_config_sysinfo implements Command {
 
-    private static String normalizeArch(String arch) {
-        if (arch.equals("i386") || arch.equals("i486")  || arch.equals("i586") || arch.equals("i686")) {
-            return "x86";
-        }
-        if (arch.equals("amd64") || arch.equals("x86_64")) {
-            return "x64";
-        }
-        if (arch.equals("arm") || arch.equals("arm32")) {
-            return "armle";
-        }
-        if (arch.equals("arm64")) {
-            return "aarch64";
-        }
-        return arch;
-    }
-
     protected String getOsName() throws Exception {
         return System.getProperty("os.name");
     }
 
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
-        String arch = System.getProperty("os.arch");
         response.add(TLVType.TLV_TYPE_COMPUTER_NAME, Utils.getHostname());
-        response.add(TLVType.TLV_TYPE_OS_NAME, getOsName() + " " + System.getProperty("os.version") + " (" + arch + ")");
+        response.add(TLVType.TLV_TYPE_OS_NAME, getOsName() + " " + System.getProperty("os.version") + " (" + System.getProperty("os.arch") + ")");
+        String arch = Utils.getNormalizedArch();
         if (arch != null) {
-            response.add(TLVType.TLV_TYPE_ARCHITECTURE, normalizeArch(arch));
+            response.add(TLVType.TLV_TYPE_ARCHITECTURE, arch);
         }
         response.add(TLVType.TLV_TYPE_LANG_SYSTEM, Locale.getDefault().toString());
         return ERROR_SUCCESS;


### PR DESCRIPTION
This PR fixes Java Meterpreter's reporting of its architecture when creating a Railgun call. Prior to this fix, the architecture would be reported as `Java` instead of either `x86` or `x64`.

This PR requires https://github.com/rapid7/metasploit-framework/pull/16170

## Verification
- [ ] Get Java Meterpreter shell.
- [ ] `sessions -i -1`
- [ ] `irb`
- [ ] `native_arch` will return the correct architecture

## Before (with the Metasploit Framework code checked out)
```
>> native_arch
/Users/sjanusz/Desktop/Rapid7/Backend/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:213:in `send_packet_wait_response': core_native_arch: Operation failed: The command is not supported by this Meterpreter type (java/windows) (Rex::Post::Meterpreter::RequestError)
```

## After (with the Metasploit Framework code checked out)
```
>> native_arch
=> "x64"
```