### PR TITLE
Fail on invalid impersonation levels

### DIFF
--- a/c/meterpreter/source/extensions/priv/namedpipe.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe.c
@@ -17,6 +17,18 @@ DWORD set_meterp_thread_use_current_token(Remote * remote)
 		return GetLastError();
 	}
 
+	DWORD dwLevel, dwSize;
+	if (!GetTokenInformation(hToken, TokenImpersonationLevel, &dwLevel, sizeof(dwLevel), &dwSize)) {
+		dprintf("[ELEVATE] set_meterp_thread_use_current_token. GetTokenInformation failed");
+		return GetLastError();
+	}
+
+	// check that the token can be used
+	if ((dwLevel == SecurityAnonymous) || (dwLevel == SecurityIdentification)) {
+		SetLastError(ERROR_BAD_IMPERSONATION_LEVEL);
+		return ERROR_BAD_IMPERSONATION_LEVEL;
+	}
+
 	// now we can set the meterpreters thread token to that of our system
 	// token so all subsequent meterpreter threads will use this token.
 	met_api->thread.update_token(remote, hToken);


### PR DESCRIPTION
This fixes #538 which is a bug whereby when `getsystem` technique 5 fails in certain conditions, the Metepreter session appears unusable until the user runs `rev2self` to correct the token. This fixes the condition by checking the token and failing when it can not be impersonated. The `getsystem` operation will still fail, but the Meterpreter session will function correctly.

To reproduce the original error:
1. Create a Windows Meterpreter EXE payload and copy it to a Windows host, I tested with Windows 10 21H2
2. Run the executable as normal, this should result in a session being opened as a normal or administrative user
3. Run `getsystem -t 5`, see it fail because the session is not running as Local or Network service
4. Run `getuid` or `sysinfo`, see those commands also fail with error 1346 / ERROR_BAD_IMPERSONATION_LEVEL
5. Run `rev2self` see that `getuid` / `sysinfo` now work correctly

# Proposed Solution
The proposed solution updates the impersonation callback `set_meterp_thread_use_current_token` to check the impersonation level of the token. When the level is either `SecurityAnonymous` or `SecurityIdentification` the token can't be impersonated according to the [MSDN docs](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-security_impersonation_level#constants). In this case, the callback should fail, triggering the caller to clean up after itself by calling [`RevertToSelf`](https://github.com/rapid7/metasploit-payloads/blob/75e6bb746581e2992fbb67dfc1927d3cf9ac6b96/c/meterpreter/source/extensions/priv/namedpipe.c#L103-L105). This means the session will continue to act normally without the user needing to take further action.

# Testing
- [x] Follow the steps to reproduce the original error, see that `getuid` and `sysinfo` work without running `rev2self` explicitly
- [x] Re-test that technique 5 works
    - [x] Use Process Hacker to start the payload executable as Local and Network service then run `getsystem -t 5` and it should work
- [x] Re-test that technique 1 works (the same callback is used by technique one, so we should confirm it still works as intended. 