### PR TITLE
add 'AMD64' arch in `get_system_arch()`

### DIFF
--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -483,7 +483,7 @@ def get_system_arch():
         ctypes.windll.kernel32.GetNativeSystemInfo(ctypes.byref(sysinfo))
         values = {0:'x86', 5:'armle', 6:'IA64', 9:'x64'}
         arch = values.get(sysinfo.wProcessorArchitecture, uname_info[4])
-    if arch == 'x86_64':
+    if arch == 'x86_64' or arch == 'AMD64':
         arch = 'x64'
     return arch
 

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -483,7 +483,7 @@ def get_system_arch():
         ctypes.windll.kernel32.GetNativeSystemInfo(ctypes.byref(sysinfo))
         values = {0:'x86', 5:'armle', 6:'IA64', 9:'x64'}
         arch = values.get(sysinfo.wProcessorArchitecture, uname_info[4])
-    if arch == 'x86_64' or arch == 'AMD64':
+    if arch == 'x86_64' or arch.lower() == 'amd64':
         arch = 'x64'
     return arch
 


### PR DESCRIPTION
## Summary
This PR appends a condition in the method `get_system_arch()`  which returns the value of `platform.uname()[4]` when `ctypes` module is not present. The value can be `x86_64` and `AMD64` based on the processor type. But for consistency it should return `x64`  in both the cases.

### Before
```python
if arch == 'x86_64`:
    return arch
```
### After
```python
if arch == `x86_64` or arch == `AMD64`:
    return arch
```

