### PR TITLE
Add logging prerequisites to PHP Meterpreter

### DIFF
--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -42,8 +42,31 @@ function register_command($c, $i) {
   }
 }
 
+# Debugging payload definitions
+define("MY_DEBUGGING", false);
+define("MY_DEBUGGING_LOG_FILE_PATH", false);
+
+function my_logfile($str) {
+  if (MY_DEBUGGING && MY_DEBUGGING_LOG_FILE_PATH) {
+    if (!isset($GLOBALS['logfile'])) {
+      $GLOBALS['logfile'] = fopen(MY_DEBUGGING_LOG_FILE_PATH, 'a');
+
+      if (!$GLOBALS['logfile']) {
+        my_print("Failed to open debug log file");
+      }
+    }
+
+    if ($GLOBALS['logfile']) {
+      fwrite($GLOBALS['logfile'], "$str\n");
+    }
+  }
+}
+
 function my_print($str) {
-  #error_log($str);
+  if (MY_DEBUGGING) {
+    error_log($str);
+    my_logfile($str);
+  }
 }
 
 my_print("Evaling main meterpreter stage");
@@ -1411,11 +1434,13 @@ function remove_reader($resource) {
 
 ob_implicit_flush();
 
-# For debugging
-#error_reporting(E_ALL);
 # Turn off error reporting so we don't leave any ugly logs.  Why make an
 # administrator's job easier if we don't have to?  =)
-error_reporting(0);
+if (MY_DEBUGGING) {
+  error_reporting(E_ALL);
+} else {
+  error_reporting(0);
+}
 
 @ignore_user_abort(true);
 # Has no effect in safe mode, but try anyway


### PR DESCRIPTION
This PR adds in the necessary defines to allow us to toggle logging to file/console when generating the payload or sending it across.

It is required by this PR: https://github.com/rapid7/metasploit-framework/pull/16396