### PR TITLE
Also build debug version for `r7_all`

### DIFF
--- a/c/meterpreter/workspace/make.msbuild
+++ b/c/meterpreter/workspace/make.msbuild
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <Target Name="all" DependsOnTargets="x86;x64;debug_x86;debug_x64" />
-  <Target Name="r7_all" DependsOnTargets="r7_x86;r7_x64" />
+  <Target Name="r7_all" DependsOnTargets="r7_x86;r7_x64;debug_x86;debug_x64" />
   <Target Name="debug" DependsOnTargets="debug_x86;debug_x64" />
 
   <Target Name="x86">


### PR DESCRIPTION
Follow on from https://github.com/rapid7/metasploit-payloads/pull/553

Builds debug versions when `r7_all` is specififed as well (this is the option used for our release process)