### PR TITLE
Fix AF_INET constants in PHP Meterpreter

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -302,11 +302,6 @@ define("ERROR_CONNECTION_ERROR", 10000);
 # eval'd twice
 my_print("Evaling stdapi");
 
-##
-# Windows Constants
-##
-define("WIN_AF_INET", 2);
-define("WIN_AF_INET6", 23);
 
 ##
 # Search Helpers
@@ -456,9 +451,9 @@ function add_stat_buf($path) {
 if (!function_exists('resolve_host')) {
 function resolve_host($hostname, $family) {
     /* requires PHP >= 5 */
-    if ($family == AF_INET) {
+    if ($family == WIN_AF_INET) {
         $dns_family = DNS_A;
-    } elseif ($family == AF_INET6) {
+    } elseif ($family == WIN_AF_INET6) {
         $dns_family = DNS_AAAA;
     } else {
         my_print('invalid family, must be AF_INET or AF_INET6');
@@ -1265,11 +1260,7 @@ function stdapi_net_resolve_host($req, &$pkt) {
     $family_tlv = packet_get_tlv($req, TLV_TYPE_ADDR_TYPE);
     $family = $family['value'];
 
-    if ($family == WIN_AF_INET) {
-        $family = AF_INET;
-    } elseif ($family == WIN_AF_INET6) {
-        $family = AF_INET6;
-    } else {
+    if ($family != WIN_AF_INET && $family != WIN_AF_INET6) {
         my_print('invalid family, must be AF_INET or AF_INET6');
         return ERROR_FAILURE;
     }
@@ -1292,11 +1283,7 @@ function stdapi_net_resolve_hosts($req, &$pkt) {
     $family_tlv = packet_get_tlv($req, TLV_TYPE_ADDR_TYPE);
     $family = $family_tlv['value'];
 
-    if ($family == WIN_AF_INET) {
-        $family = AF_INET;
-    } elseif ($family == WIN_AF_INET6) {
-        $family = AF_INET6;
-    } else {
+    if ($family != WIN_AF_INET && $family != WIN_AF_INET6) {
         my_print('invalid family, must be AF_INET or AF_INET6');
         return ERROR_FAILURE;
     }

--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -125,6 +125,13 @@ define("CHANNEL_CLASS_STREAM",   1);
 define("CHANNEL_CLASS_DATAGRAM", 2);
 define("CHANNEL_CLASS_POOL",     3);
 
+
+##
+# Windows Constants
+##
+define("WIN_AF_INET", 2);
+define("WIN_AF_INET6", 23);
+
 #
 # TLV Meta Types
 #
@@ -1072,10 +1079,10 @@ function connect($ipaddr, $port, $proto='tcp') {
   # IPv6 requires brackets around the address in some cases, but not all.
   # Keep track of the un-bracketed address for the functions that don't like
   # brackets, specifically socket_connect and socket_sendto.
-  $ipf = AF_INET;
+  $ipf = WIN_AF_INET;
   $raw_ip = $ipaddr;
   if (FALSE !== strpos($ipaddr, ":")) {
-    $ipf = AF_INET6;
+    $ipf = WIN_AF_INET6;
     $ipaddr = "[". $raw_ip ."]";
   }
 


### PR DESCRIPTION
This change fixes https://github.com/rapid7/metasploit-framework/issues/16409, by using our own WIN_AF_INET definitions that match with the meterpreter definitions here:
https://github.com/rapid7/metasploit-framework/blob/3e63fe579ff7e97bdb75069b3e120166cfb101d4/lib/rex/post/meterpreter/extensions/stdapi/constants.rb#L14-L20

## Verification
- [ ] Open a PHP Meterpreter session
- [ ] Run the `resolve` command (this uses `stdapi_net_resolve_hosts` under the hood)
- [ ] Check that it resolves IPv4 and IPv6 addresses (`example.com` is a good example, use the -f flag to specify the family)
- [ ] Check that if resolution fails, the session stays active

```
meterpreter > resolve www.example.com example.com -f IPv6

Host resolutions
================

    Hostname         IP Address
    --------         ----------
    example.com      2606:2800:220:1:248:1893:25c8:1946
    www.example.com  2606:2800:220:1:248:1893:25c8:1946

meterpreter > resolve www.example.com example.com

Host resolutions
================

    Hostname         IP Address
    --------         ----------
    example.com      93.184.216.34
    www.example.com  93.184.216.34
```