### PR TITLE
Add REQUEST_IGNORE_BATTERY_OPTIMIZATIONS android permission

### DIFF
--- a/java/androidpayload/app/src/main/AndroidManifest.xml
+++ b/java/androidpayload/app/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_SMS" />
@@ -29,6 +28,7 @@
     <uses-permission android:name="android.permission.READ_CALL_LOG"/>
     <uses-permission android:name="android.permission.WRITE_CALL_LOG"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />


### PR DESCRIPTION
This change adds the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission, which is useful for preventing the app from being killed by Android Doze.
Android Doze was introduced in Android 6.0, and will kill background apps that perform network activity outside set intervals (e.g meterpreter).
Enabling this permission allows us to automatically request (however user interaction is required) that the app ignore these battery optimisations and run freely in the background.

## Verification

- [ ] Rebuild with these changes (note the RECORD_AUDIO permission was duplicated and can safely be removed).
- [ ] Get an android meterpreter session on Android 6.0 and above (I tested with Android 9.0 on a samsung device).
- [ ] Run `meterpreter > activity_start 'intent:package:com.metasploit.stage#Intent;action=android.settings.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS;end'`
- [ ] Approve the UI on the device to disable battery optimisation.
- [ ] With adb, run `adb shell dumpsys deviceidle force-idle`, the session should die without this change or if the battery optimization request was denied.
- [ ] **Verify** the session is not killed when then battery optimisation is disabled.
- [ ] Run `adb shell dumpsys deviceidle unforce` to disable doze mode.


## TODO

- Perhaps we need an option (similar to `AndroidHideAppIcon`) that automatically (or continually?) prompts the user to disable this optimisation without needing an established session?
- There may be some other (new) permissions missing, e.g https://developer.android.com/reference/android/Manifest.permission#REQUEST_INSTALL_PACKAGES ?