### PR TITLE
Fix argument order for array join

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -1049,7 +1049,7 @@ function stdapi_sys_process_get_processes($req, &$pkt) {
         # full command line
         array_shift($proc);
         array_shift($proc);
-        $grp .= tlv_pack(create_tlv(TLV_TYPE_PROCESS_PATH, join($proc, " ")));
+        $grp .= tlv_pack(create_tlv(TLV_TYPE_PROCESS_PATH, join(" ", $proc)));
         packet_add_tlv($pkt, create_tlv(TLV_TYPE_PROCESS_GROUP, $grp));
     }
     return ERROR_SUCCESS;


### PR DESCRIPTION
This PR fixes incorrect argument order being passed into the `join` function.

The docs mention:
```
implode(string $separator, array $array): string

Alternative signature (not supported with named arguments):
implode(array $array): string

Legacy signature (deprecated as of PHP 7.4.0, removed as of PHP 8.0.0):
implode(array $array, string $separator): string
```

## PHP 7.3.2

This doesn't break backwards compatibility as the syntax is supported in versions prior to PHP 8.x.

```PHP
php > echo join(["hello", "world"], " ");
hello world
php > echo join(" ", ["hello","world"]);
hello world
```

## PHP 8.x

Docker container
```
docker run -w /var/www/html -v $(pwd):/var/www/html --rm -it php:8.1-apache /bin/bash
```

```PHP
php > echo join(["hello", "world"], " ");

Warning: Uncaught TypeError: join(): Argument #2 ($array) must be of type ?array, string given in php shell code:1
Stack trace:
#0 php shell code(1): join(Array, ' ')
#1 {main}
  thrown in php shell code on line 1
php > echo join(" ", ["hello","world"]);
hello world
```

## PHP 5.2

Set up the docker container and go to the php directory

```
docker run -w /var/www/html -v $(pwd):/var/www/html --rm -it luismesalas/php-5.2-apache /bin/bash
root@7c5ab9feb8a8:/var/www/html# cd /usr/bin/php52 
```

Then call the array join function.

```PHP
root@7c5ab9feb8a8:/usr/bin/php52# ./php -r 'echo join(array("hello", "world"), " ");'
hello world
root@7c5ab9feb8a8:/usr/bin/php52# ./php -r 'echo join(" ", array("hello", "world"));'
hello world
```

## Before

```
Fatal error: Uncaught TypeError: join(): Argument [#2] ($array) must be of type ?array, string given in /var/www/html/met.php(1) : eval()'d code(519) : eval()'d code:1057
```

## After

The command completes successfully.