### PR TITLE
Remove logging artifacts that made their way into the release build

### DIFF
--- a/c/meterpreter/source/logging/logging.c
+++ b/c/meterpreter/source/logging/logging.c
@@ -1,3 +1,4 @@
+#ifdef DEBUGTRACE
 #include "../common/common.h"
 
 HANDLE lock = NULL;
@@ -8,7 +9,7 @@ HANDLE init_logging(wchar_t* filePath) {
 		GENERIC_WRITE,          // open for writing
 		FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,    // do share (7)
 		NULL,                   // default security
-		CREATE_ALWAYS,             // create new file always
+		OPEN_ALWAYS,             // create new file or open existing file
 		FILE_ATTRIBUTE_NORMAL,  // normal file
 		NULL);                  // no attr. template
 	lock = CreateMutex(NULL, FALSE, NULL);
@@ -41,3 +42,4 @@ void set_logging_context(HANDLE ctx, HANDLE lock1) {
 	hFile = ctx;
 	lock = lock1;
 }
+#endif


### PR DESCRIPTION
Adds some condiontal logic to remove some extra artifacts that made it into the release build with the addition of the logging to file support from here #563 

DLL 1 is from before the logging to file changes, Dll 2 is after my logging changes, DLL 3 is after wrapping logging.c in an #ifdef

![image](https://user-images.githubusercontent.com/19910435/167840342-13503ad3-6717-4363-aa8e-c2c7c973ef25.png)

Also addresses a small oversight where we were always creating a new log file which would overwrite any previous logs, now if a log file already exists we just open and append to that file instead