### PR TITLE
Fix #582 Add reading for REG_MULTI_SZ values

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
@@ -22,7 +22,7 @@ DWORD request_registry_check_key_exists(Remote *remote, Packet *packet)
 	if (rootKey && baseKey) {
 		BOOL exists = FALSE;
 		HKEY resultKey = NULL;
-		if (RegOpenKeyW(rootKey, baseKey, &resultKey) == ERROR_SUCCESS) {
+		if (RegOpenKeyExW(rootKey, baseKey, 0, KEY_QUERY_VALUE, &resultKey) == ERROR_SUCCESS) {
 			dprintf("[REG] Key found");
 			RegCloseKey(resultKey);
 			exists = TRUE;

--- a/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
@@ -440,12 +440,16 @@ out:
 
 /*
  * @brief Unparse a REG_MULTI_SZ value to send back to Metasploit. Encode the
-          UTF-16LE string array into UTF-8. The caller must free the returned buffer.
-		  This does not assume that str is terminated by two null characters
-		  which is why it is necessary to pass in the size in bytes of the
-		  input buffer.
+ *        UTF-16LE string array into UTF-8. The caller must free the returned buffer.
+ *        This does not assume that str is terminated by two null characters
+ *        which is why it is necessary to pass in the size in bytes of the
+ *        input buffer.
+ *
+ *        Example:
+ *          "S1\x00S2\x00\x00" => "S\x001\x00\x00\x00S\x002\x00\x00\x00\x00\x00"
  * @param str The string to convert.
- * @param length An optional pointer to receive the size in bytes of the resulting buffer.
+ * @param size A pointer that on input is the size of str in bytes and on
+ *             output will receive the size in bytes of the resulting buffer.
  */
 static char* reg_multi_sz_unparse(wchar_t* str, size_t* size)
 {
@@ -462,18 +466,18 @@ static char* reg_multi_sz_unparse(wchar_t* str, size_t* size)
 		SetLastError(ERROR_BAD_ARGUMENTS);
 		return NULL;
 	}
-	// if the input does not end in two null characters create and user our own buffer
-	// this is obviously less effecient if the input isn't properly terminated
+	// if the input does not end in two null characters, then create and use our own buffer
+	// which is obviously less efficient if the input isn't properly terminated
 	if ((str[*size - 1] == 0) && (str[*size - 2]) == 0) {
 		my_str = str;
 	}
 	else {
-		my_str = malloc(*size + (2 * sizeof(sizeof(str[0]))));
+		my_str = malloc(*size + (2 * sizeof(str[0])));
 		if (!my_str) {
 			SetLastError(ERROR_NOT_ENOUGH_MEMORY);
 			goto out;
 		}
-		memset(my_str, 0, *size + (2 * sizeof(sizeof(str[0]))));
+		memset(my_str, 0, *size + (2 * sizeof(str[0])));
 		memcpy(my_str, str, *size);
 	}
 
@@ -492,7 +496,7 @@ static char* reg_multi_sz_unparse(wchar_t* str, size_t* size)
 	res = calloc(total_size + (count - 1) + 2, sizeof(char));
 	if (!res) {
 		SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-		return NULL;
+		goto out;
 	}
 	if (size)
 		*size = (total_size + (count - 1) + 2) * sizeof(char);
@@ -518,13 +522,13 @@ out:
 
 /*
  * @brief Parse a REG_MULTI_SZ value from Metasploit. Encode the UTF-8
-		  string array into UTF-16LE. The caller must free the returned buffer.
-		  This does not assume that str is terminated by two null characters
-		  which is why it is necessary to pass in the size in bytes of the 
-		  input buffer.
+ *        string array into UTF-16LE. The caller must free the returned buffer.
+ *        This does not assume that str is terminated by two null characters
+ *        which is why it is necessary to pass in the size in bytes of the 
+ *        input buffer.
  * @param str The string to convert.
- * @param length A pointer that on input is the size of str in bytes and on
-          output will receive the size in bytes of the resulting buffer.
+ * @param size A pointer that on input is the size of str in bytes and on
+ *             output will receive the size in bytes of the resulting buffer.
  */
 static wchar_t *reg_multi_sz_parse(char* str, size_t* size)
 {
@@ -546,12 +550,12 @@ static wchar_t *reg_multi_sz_parse(char* str, size_t* size)
 	if ((str[*size - 1] == 0) && (str[*size - 2]) == 0) {
 		my_str = str;
 	} else {
-		my_str = malloc(*size + (2 * sizeof(sizeof(str[0]))));
+		my_str = malloc(*size + (2 * sizeof(str[0])));
 		if (!my_str) {
 			SetLastError(ERROR_NOT_ENOUGH_MEMORY);
 			goto out;
 		}
-		memset(my_str, 0, *size + (2 * sizeof(sizeof(str[0]))));
+		memset(my_str, 0, *size + (2 * sizeof(str[0])));
 		memcpy(my_str, str, *size);
 	}
 

--- a/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/registry/registry.c
@@ -438,8 +438,13 @@ out:
 	return ERROR_SUCCESS;
 }
 
-// todo: write these docs
-static char* reg_multi_sz_unparse(wchar_t* str, size_t* length)
+/*
+ * @brief Unparse a REG_MULTI_SZ value to send back to Metasploit. Encode the UTF-16LE
+          string array into UTF-8. The caller must free the returned buffer.
+ * @param str The string to convert.
+ * @param length An optional pointer to receive the size in bytes of the resulting buffer.
+ */
+static char* reg_multi_sz_unparse(wchar_t* str, size_t* size)
 {
 	// Count the number of chunks
 	int count = 0;
@@ -465,8 +470,8 @@ static char* reg_multi_sz_unparse(wchar_t* str, size_t* length)
 		SetLastError(ERROR_NOT_ENOUGH_MEMORY);
 		return NULL;
 	}
-	if (length)
-		*length = (total_size + (count - 1) + 2) * sizeof(char);
+	if (size)
+		*size = (total_size + (count - 1) + 2) * sizeof(char);
 
 	char* write_cursor = res;
 	wchunk = str;
@@ -484,8 +489,13 @@ static char* reg_multi_sz_unparse(wchar_t* str, size_t* length)
 	return res;
 }
 
-// todo: write these docs
-static wchar_t *reg_multi_sz_parse(char* str, size_t* length)
+/*
+ * @brief Parse a REG_MULTI_SZ value from Metasploit. Encode the UTF-8
+		  string array into UTF-16LE. The caller must free the returned buffer.
+ * @param str The string to convert.
+ * @param length An  pointer to receive the size in bytes of the resulting buffer.
+ */
+static wchar_t *reg_multi_sz_parse(char* str, size_t* size)
 {
 	// Count the number of chunks
 	int count = 0;
@@ -511,8 +521,8 @@ static wchar_t *reg_multi_sz_parse(char* str, size_t* length)
 		SetLastError(ERROR_NOT_ENOUGH_MEMORY);
 		return NULL;
 	}
-	if (length)
-		*length = (total_size + (count - 1) + 2) * sizeof(wchar_t);
+	if (size)
+		*size = (total_size + (count - 1) + 2) * sizeof(wchar_t);
 
 	wchar_t* write_cursor = res;
 	chunk = str;


### PR DESCRIPTION
# REG_MULTI_SZ
This updates the Windows meterpreter to handle REG_MULTI_SZ keys differently now. Previously the Meterpreter expected the input value for REG_MULTI_SZ keys to be a single, NULL-terminated string with values separated by `\0` (two characters). This pattern is aligned with what the `reg` command wants as its argument. Reading REG_MULTI_SZ keys didn't work, since the encoding wasn't done again, all values after the first was lost due to the null terminator that's present in the response from the Windows API. Basically the Meterpreter could write REG_MULTI_SZ values but not read them. The Python Meterpreter is the only other Meterpreter with the native registry commands<sup>1</sup> and expects the input values to be in the binary, format that the Windows API expects, and returns the same.

Now with these changes, the Windows Meterpreter accepts the binary input format and handles Unicode encoding for both inputs and outputs. This is necessary because the Meterpreter API assumes that strings are UTF-8 encoded, but the Wide-variants of the Win32 API functions are invoked.

I'll open a PR to Metasploit that tweaks things around to ensure that REG_MULTI_SZ is handled correctly for shell sessions, Python and Windows Meterpreter sessions and from the Meterpreter command line interface.

Also switched to using `RegOpenKeyExW` for checking if a key exists. This makes the permissions deterministic. According to the docs for [RegQueryValueW](https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regopenkeyW#remarks):

> The RegOpenKey function uses the default security access mask to open a key. 

Using the Ex version allows the permission to be specified, ensuring that it's consistent.

This is technically a breaking change in how the Windows Meterpreter handles REG_MULTI_SZ input values. The whole REG_MULTI_SZ handling is pretty broken as it is though, the Python Meterpreter isn't compatible with the write format and the Windows Meterpreter isn't reading correctly. 

There will be a corresponding test added in the Metasploit PR that demonstrates this works.

<sup>1</sup> The PHP Meterpreter [optionally registers](https://github.com/rapid7/metasploit-payloads/blob/9d11bb84b13e8aa96d1e1704d74d5295761bd125/php/meterpreter/ext_server_stdapi.php#L1239) the native Registry Meterpreter commands, but only if the [`win32std` package](https://pecl.php.net/package/win32std) is available. This package hasn't been updated since November 2003. Furthermore the command set is incomplete (direct variants are missing) and the `stdapi_registry_set_value` command doesn't [appear to do anything](https://github.com/rapid7/metasploit-payloads/blob/9d11bb84b13e8aa96d1e1704d74d5295761bd125/php/meterpreter/ext_server_stdapi.php#L1242). For those reasons, it doesn't seem worth acknowledging that the PHP Meterpreter's registry capabilities are in a functional state.