### PR TITLE
Fix #584: Close memory and handle leaks

### DIFF
--- a/c/meterpreter/source/extensions/incognito/list_tokens.c
+++ b/c/meterpreter/source/extensions/incognito/list_tokens.c
@@ -194,87 +194,90 @@ SavedToken *get_token_list(DWORD *num_tokens_enum, TOKEN_PRIVS *token_privs)
 					{
 						LPWSTR lpwsType = NULL;
 						lpwsType = GetObjectInfo(hObject, ObjectTypeInformation);
-						if ((lpwsType != NULL) && !wcscmp(lpwsType, L"Token") && ImpersonateLoggedOnUser(hObject) != 0)
+						if (lpwsType)
 						{
-							// ImpersonateLoggedOnUser() always returns true. Need to check whether impersonated token kept impersonate status - failure degrades to identification
-							// also revert to self after getting new token context
-							// only process if it was impersonation or higher
-							OpenThreadToken(GetCurrentThread(), MAXIMUM_ALLOWED, TRUE, &hObject2);
-							RevertToSelf();
-							if (is_impersonation_token(hObject2))
+							if (wcscmp(lpwsType, L"Token") && (ImpersonateLoggedOnUser(hObject)))
 							{
-								// Reallocate space if necessary
-								if (*num_tokens_enum >= token_list_size)
+								// ImpersonateLoggedOnUser() always returns true. Need to check whether impersonated token kept impersonate status - failure degrades to identification
+								// also revert to self after getting new token context
+								// only process if it was impersonation or higher
+								OpenThreadToken(GetCurrentThread(), MAXIMUM_ALLOWED, TRUE, &hObject2);
+								RevertToSelf();
+								if (is_impersonation_token(hObject2))
 								{
-									token_list_size *= 2;
-									token_list = (SavedToken*)realloc(token_list, token_list_size*sizeof(SavedToken));
-									if (!token_list)
+									// Reallocate space if necessary
+									if (*num_tokens_enum >= token_list_size)
 									{
-										goto cleanup;
-									}
-								}
-
-								token_list[*num_tokens_enum].token = hObject;
-								get_domain_username_from_token(hObject, token_list[*num_tokens_enum].username);
-
-								if (GetTokenInformation(hObject, TokenPrivileges, TokenPrivilegesInfo, BUF_SIZE, &returned_privileges_length))
-								{
-									if (((TOKEN_PRIVILEGES*)TokenPrivilegesInfo)->PrivilegeCount > 0)
-									{
-										for (j = 0; j < ((TOKEN_PRIVILEGES*)TokenPrivilegesInfo)->PrivilegeCount; j++)
+										token_list_size *= 2;
+										token_list = (SavedToken*)realloc(token_list, token_list_size * sizeof(SavedToken));
+										if (!token_list)
 										{
-											returned_name_length = BUF_SIZE;
-											LookupPrivilegeNameW(NULL, &(((TOKEN_PRIVILEGES*)TokenPrivilegesInfo)->Privileges[j].Luid), privilege_name, &returned_name_length);
-											if (wcscmp(privilege_name, L"SeAssignPrimaryTokenPrivilege") == 0)
+											goto cleanup;
+										}
+									}
+
+									token_list[*num_tokens_enum].token = hObject;
+									get_domain_username_from_token(hObject, token_list[*num_tokens_enum].username);
+
+									if (GetTokenInformation(hObject, TokenPrivileges, TokenPrivilegesInfo, BUF_SIZE, &returned_privileges_length))
+									{
+										if (((TOKEN_PRIVILEGES*)TokenPrivilegesInfo)->PrivilegeCount > 0)
+										{
+											for (j = 0; j < ((TOKEN_PRIVILEGES*)TokenPrivilegesInfo)->PrivilegeCount; j++)
 											{
-												token_privs->SE_ASSIGNPRIMARYTOKEN_PRIVILEGE = TRUE;
-											}
-											else if (wcscmp(privilege_name, L"SeCreateTokenPrivilege") == 0)
-											{
-												token_privs->SE_CREATE_TOKEN_PRIVILEGE = TRUE;
-											}
-											else if (wcscmp(privilege_name, L"SeTcbPrivilege") == 0)
-											{
-												token_privs->SE_TCB_PRIVILEGE = TRUE;
-											}
-											else if (wcscmp(privilege_name, L"SeTakeOwnershipPrivilege") == 0)
-											{
-												token_privs->SE_TAKE_OWNERSHIP_PRIVILEGE = TRUE;
-											}
-											else if (wcscmp(privilege_name, L"SeBackupPrivilege") == 0)
-											{
-												token_privs->SE_BACKUP_PRIVILEGE = TRUE;
-											}
-											else if (wcscmp(privilege_name, L"SeRestorePrivilege") == 0)
-											{
-												token_privs->SE_RESTORE_PRIVILEGE = TRUE;
-											}
-											else if (wcscmp(privilege_name, L"SeDebugPrivilege") == 0)
-											{
-												token_privs->SE_DEBUG_PRIVILEGE = TRUE;
-											}
-											else if (wcscmp(privilege_name, L"SeImpersonatePrivilege") == 0)
-											{
-												token_privs->SE_IMPERSONATE_PRIVILEGE = TRUE;
-											}
-											else if (wcscmp(privilege_name, L"SeRelabelPrivilege") == 0)
-											{
-												token_privs->SE_RELABEL_PRIVILEGE = TRUE;
-											}
-											else if (wcscmp(privilege_name, L"SeLoadDriverPrivilege") == 0)
-											{
-												token_privs->SE_LOAD_DRIVER_PRIVILEGE = TRUE;
+												returned_name_length = BUF_SIZE;
+												LookupPrivilegeNameW(NULL, &(((TOKEN_PRIVILEGES*)TokenPrivilegesInfo)->Privileges[j].Luid), privilege_name, &returned_name_length);
+												if (wcscmp(privilege_name, L"SeAssignPrimaryTokenPrivilege") == 0)
+												{
+													token_privs->SE_ASSIGNPRIMARYTOKEN_PRIVILEGE = TRUE;
+												}
+												else if (wcscmp(privilege_name, L"SeCreateTokenPrivilege") == 0)
+												{
+													token_privs->SE_CREATE_TOKEN_PRIVILEGE = TRUE;
+												}
+												else if (wcscmp(privilege_name, L"SeTcbPrivilege") == 0)
+												{
+													token_privs->SE_TCB_PRIVILEGE = TRUE;
+												}
+												else if (wcscmp(privilege_name, L"SeTakeOwnershipPrivilege") == 0)
+												{
+													token_privs->SE_TAKE_OWNERSHIP_PRIVILEGE = TRUE;
+												}
+												else if (wcscmp(privilege_name, L"SeBackupPrivilege") == 0)
+												{
+													token_privs->SE_BACKUP_PRIVILEGE = TRUE;
+												}
+												else if (wcscmp(privilege_name, L"SeRestorePrivilege") == 0)
+												{
+													token_privs->SE_RESTORE_PRIVILEGE = TRUE;
+												}
+												else if (wcscmp(privilege_name, L"SeDebugPrivilege") == 0)
+												{
+													token_privs->SE_DEBUG_PRIVILEGE = TRUE;
+												}
+												else if (wcscmp(privilege_name, L"SeImpersonatePrivilege") == 0)
+												{
+													token_privs->SE_IMPERSONATE_PRIVILEGE = TRUE;
+												}
+												else if (wcscmp(privilege_name, L"SeRelabelPrivilege") == 0)
+												{
+													token_privs->SE_RELABEL_PRIVILEGE = TRUE;
+												}
+												else if (wcscmp(privilege_name, L"SeLoadDriverPrivilege") == 0)
+												{
+													token_privs->SE_LOAD_DRIVER_PRIVILEGE = TRUE;
+												}
 											}
 										}
 									}
-								}
 
-								(*num_tokens_enum)++;
+									(*num_tokens_enum)++;
+								}
+								CloseHandle(hObject2);
 							}
-							CloseHandle(hObject2);
+							free(lpwsType);
 						}
-						else
-						{
+						else {
 							CloseHandle(hObject);
 						}
 					}
@@ -353,6 +356,7 @@ SavedToken *get_token_list(DWORD *num_tokens_enum, TOKEN_PRIVS *token_privs)
 				{
 					dprintf("[INCOGNITO] Failed next level impersonation with %u (%x)", GetLastError(), GetLastError());
 				}
+				CloseHandle(process);
 			}
 
 			dprintf("[INCOGNITO] Moving to next process from %p", pProcessInfo);

--- a/c/meterpreter/source/extensions/incognito/list_tokens.c
+++ b/c/meterpreter/source/extensions/incognito/list_tokens.c
@@ -211,6 +211,9 @@ SavedToken *get_token_list(DWORD *num_tokens_enum, TOKEN_PRIVS *token_privs)
 										token_list = (SavedToken*)realloc(token_list, token_list_size * sizeof(SavedToken));
 										if (!token_list)
 										{
+											CloseHandle(hObject2);
+											CloseHandle(hObject);
+											CloseHandle(process);
 											goto cleanup;
 										}
 									}


### PR DESCRIPTION
This fixes a memory and a handle leak in Incognito's list_token functionality. The memory leak is the larger issue and was due to `lpwsType` not being freed. On success `GetObjecInfo` returns a pointer to memory from `calloc` that the caller needs to clean up. This wasn't happening before, and this function is called *alot* so that led to a noticeable memory leak.

The handle issue was that the process handle wasn't closed once it wasn't needed any more.

## Testing

- [x] Open a Windows Meterpreter session
- [x] Load incognito (run: `load incognito`)
- [x] On the Windows host open Process Explorer or whatever, find the Meterpreter process and note how much memory it is using
- [x] Run `list_tokens -u` multiple times, say 5+
- [x] See that the was not a significant increase in memory usage

Prior to these changes, each time `list_tokens -u` was run, the memory usage would increase by about 1,500 bytes or so on a workstation with a single user logged in.