### PR TITLE
Mimikatz update

### DIFF
--- a/c/meterpreter/workspace/ext_server_kiwi/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_kiwi/CMakeLists.txt
@@ -64,6 +64,7 @@ file(GLOB SRC_FILES
     ${SRC_DIR}/mimikatz/mimikatz/modules/*.c
     ${SRC_DIR}/mimikatz/mimikatz/modules/crypto/*.c
     ${SRC_DIR}/mimikatz/mimikatz/modules/dpapi/*.c
+    ${SRC_DIR}/mimikatz/mimikatz/modules/misc/*.c
     ${SRC_DIR}/mimikatz/mimikatz/modules/dpapi/packages/*.c
     ${SRC_DIR}/mimikatz/mimikatz/modules/kerberos/*.c
     ${SRC_DIR}/mimikatz/mimikatz/modules/lsadump/*.c

--- a/c/meterpreter/workspace/ext_server_kiwi/ext_server_kiwi.vcxproj
+++ b/c/meterpreter/workspace/ext_server_kiwi/ext_server_kiwi.vcxproj
@@ -546,6 +546,8 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\kuhl_m_ts.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\kuhl_m_vault.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\lsadump\kuhl_m_lsadump_dc.c" />
+    <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\misc\kuhl_m_misc_citrix.c" />
+    <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\misc\kuhl_m_misc_djoin.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\ngc\kuhl_m_ngc.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\sekurlsa\crypto\kuhl_m_sekurlsa_nt5.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\sekurlsa\crypto\kuhl_m_sekurlsa_nt6.c" />
@@ -605,6 +607,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-drsr_c.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-efsr_c.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-nrpc_c.c" />
+    <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-odj.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-pac.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-par_c.c" />
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-rprn.c" />
@@ -669,6 +672,8 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\kuhl_m_ts.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\kuhl_m_vault.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\lsadump\kuhl_m_lsadump_dc.h" />
+    <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\misc\kuhl_m_misc_citrix.h" />
+    <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\misc\kuhl_m_misc_djoin.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\ngc\kuhl_m_ngc.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\sekurlsa\crypto\kuhl_m_sekurlsa_nt5.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\sekurlsa\crypto\kuhl_m_sekurlsa_nt6.h" />
@@ -734,6 +739,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-drsr.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-efsr.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-nrpc.h" />
+    <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-odj.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-pac.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-par.h" />
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-rprn.h" />

--- a/c/meterpreter/workspace/ext_server_kiwi/ext_server_kiwi.vcxproj.filters
+++ b/c/meterpreter/workspace/ext_server_kiwi/ext_server_kiwi.vcxproj.filters
@@ -323,6 +323,10 @@
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-efsr_c.c">
       <Filter>common modules\rpc</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\source\logging\logging.c" />
+    <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\misc\kuhl_m_misc_citrix.c" />
+    <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\misc\kuhl_m_misc_djoin.c" />
+    <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-odj.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\source\extensions\kiwi\main.h" />
@@ -666,6 +670,9 @@
     <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-efsr.h">
       <Filter>common modules\rpc</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\misc\kuhl_m_misc_citrix.h" />
+    <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\mimikatz\modules\misc\kuhl_m_misc_djoin.h" />
+    <ClInclude Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-odj.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="local modules">


### PR DESCRIPTION
Requires rapid7/mimikatz#9.

This updates the kiwi extension to pull in the latest changes from the upstream mimikatz project.

## Testing

* Make sure everything builds correctly, with no errors
    - [x] x86 in Visual Studio
    - [x] x64 in Visual Studio
    - [x] x86 in MinGW (run the `make docker-ext-kiwi-x86` command from a Linux host with the build environment)
    - [x] x64 in MinGW (run the `make docker-ext-kiwi-x64` command from a Linux host with the build environment)
* Test the Visual Studio binaries (those are the ones that ship with the Framework), for both the x86 and x64 extensions
    - [x] Copy the built extension files from Visual Studio into the local directory at `~/.msf4/payloads/meterpreter` (make that folder if it does not already exist)
    - [x] Open a Metepreter session for the architecture you're testing on Windows
    - [x] Load the extension by running `load kiwi`
        * You should see a warning that a local file is being used
    - [x] Run a command to see it's working `creds_all`