### PR TITLE
Fix Python EventLog commands

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1459,7 +1459,8 @@ def stdapi_sys_eventlog_read(request, response):
     response += tlv_pack(TLV_TYPE_EVENT_TYPE, record.EventType)
     response += tlv_pack(TLV_TYPE_EVENT_CATEGORY, record.EventCategory)
     response += tlv_pack(TLV_TYPE_EVENT_DATA, ctarray_to_bytes(buf[record.DataOffset:record.DataOffset + record.DataLength]))
-    event_strings = ctarray_to_bytes(buf[record.StringOffset:]).split(NULL_BYTE, record.NumStrings - 1)
+    event_string_buf = (ctypes.c_uint8 * len(buf[record.StringOffset:]))(*buf[record.StringOffset:])
+    event_strings = ctarray_to_bytes(event_string_buf).split(NULL_BYTE, record.NumStrings)[:record.NumStrings]
     for event_string in event_strings:
         response += tlv_pack(TLV_TYPE_EVENT_STRING, event_string)
     return ERROR_SUCCESS, response


### PR DESCRIPTION
The Python Meterpreter's `stdapi_sys_eventlog` commands had multiple issues. This fixes all of the issues I noticed, so that the event logs can be read on Python 2 and Python 3. This was notably breaking the `clearev` Meterpreter command.

I don't see where the `#read_forwards` method that calls `stdapi_sys_eventlog_read` is referenced by a command, so the easiest way to test it is using Pry. 

# Testing

- [ ] Establish a Python Meterpreter session (test a 2.x and 3.x version)
- [ ] From pry, initialize a log object to test opening a log (run: `log = self.sys.eventlog.open('Security')`)
- [ ] Check the length of the object to test `stdapi_sys_eventlog_numrecords` (run: `log.length`)
- [ ] Check the oldest record to test `stdapi_sys_eventlog_oldest` (run: `log.oldest`)
- [ ] Check reading a record to test `stdapi_sys_eventlog_read` (run: `log.read_forwards`)
- [ ] Check that clearing logs work, from the Meterpreter prompt run the `clearev` command. See that there are now no event logs. This command requires privileges to run.

# Demo

```
meterpreter > pry
[*] Starting Pry shell...
[*] You are in the "client" (session) object

[1] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> log = self.sys.eventlog.open('Security')
=> #<#<Class:0x00007fdefc9bc890>:0x00007fdf1908a4a8 @client=#<Session:meterpreter 192.168.159.10:56257 (192.168.159.10) "MSFLAB\smcintyre @ DC">, @handle=2121989160968>
[2] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> log.length
=> 1208
[3] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> log.oldest
=> 143414
[4] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> log.read_forwards
=> #<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::EventLogSubsystem::EventRecord:0x00007fdf195ba8d8
 @category=104,
 @data="",
 @eventid=1102,
 @generated=2022-11-11 17:37:49 -0500,
 @num=143414,
 @strings=["S-1-5-21-3402587289-1488798532-3618296993-1000", "smcintyre", "MSFLAB", "0x580f0a"],
 @type=8,
 @written=2022-11-11 17:37:49 -0500>
[5] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> log.close
=> nil
[6] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> exit
meterpreter > clearev
[*] Wiping 48 records from Application...
[*] Wiping 266 records from System...
[*] Wiping 1214 records from Security...
meterpreter > 
```

<details>
<summary>Broken demo</summary>

Prior to these changes these were the errors for the same workflow.

```
meterpreter > pry
[*] Starting Pry shell...
[*] You are in the "client" (session) object

[1] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> log = self.sys.eventlog.open('Security')
=> #<#<Class:0x00007fdf19b726e0>:0x00007fdf197120f0 @client=#<Session:meterpreter 192.168.159.10:56273 (192.168.159.10) "MSFLAB\smcintyre @ DC">, @handle=26869768>
[2] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> log.length
Rex::Post::Meterpreter::RequestError: stdapi_sys_eventlog_numrecords: Operation failed: Windows error: The handle is invalid.
from /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/event_log.rb:80:in `length'
[3] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> log.oldest
Rex::Post::Meterpreter::RequestError: stdapi_sys_eventlog_oldest: Operation failed: Python exception: AttributeError
from /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/event_log.rb:157:in `oldest'
[4] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> log.read_forwards
Rex::Post::Meterpreter::RequestError: stdapi_sys_eventlog_read: Operation failed: Windows error: The handle is invalid.
from /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/event_log.rb:95:in `_read'
[5] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> exit
meterpreter > clearev
[-] stdapi_sys_eventlog_numrecords: Operation failed: Windows error: The handle is invalid.
meterpreter >
```
</details>