### PR TITLE
Support dual IPv4 / IPv6 TCP servers in Python

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1125,15 +1125,24 @@ def channel_open_stdapi_net_tcp_client(request, response):
 
 @register_function
 def channel_open_stdapi_net_tcp_server(request, response):
-    local_host = packet_get_tlv(request, TLV_TYPE_LOCAL_HOST).get('value', '0.0.0.0')
+    use_dual_stack = False
+    local_host = packet_get_tlv(request, TLV_TYPE_LOCAL_HOST).get('value', '')
     local_port = packet_get_tlv(request, TLV_TYPE_LOCAL_PORT)['value']
-    local_address_info = getaddrinfo(local_host, local_port, socktype=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP)
-    if not local_address_info:
-        return ERROR_FAILURE, response
-    local_address_info = local_address_info[0]
-    server_sock = socket.socket(local_address_info['family'], local_address_info['socktype'], local_address_info['proto'])
+    if local_host:
+        local_address_info = getaddrinfo(local_host, local_port, socktype=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP, flags=socket.AI_NUMERICHOST)
+        if not local_address_info:
+            return ERROR_FAILURE, response
+        local_address_info = local_address_info[0]
+    else:
+        local_address_info = {
+            'family': socket.AF_INET6,
+            'sockaddr': ('::', local_port, 0, 0)
+        }
+        use_dual_stack = hasattr(socket, 'IPV6_V6ONLY')
+        debug_print('[*] no local host information, binding to all available interfaces...')
+    server_sock = socket.socket(local_address_info['family'], socket.SOCK_STREAM, socket.IPPROTO_TCP)
     server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    if local_address_info['family'] == socket.AF_INET6 and hasattr(socket, 'IPV6_V6ONLY'):
+    if local_address_info['family'] == socket.AF_INET6 and use_dual_stack:
         server_sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
     server_sock.bind(local_address_info['sockaddr'])
     server_sock.listen(socket.SOMAXCONN)


### PR DESCRIPTION
This adds dual stack IPv4 / IPv6 TCP server support to the Python Meterpreter. When a TCP server channel is opened and the LocalHost is blank (the TLV is completely missing or the value is an empty string), the Meterpreter will bind to all interfaces it can. This includes both IPv4 and IPv6 addresses. This does what the Windows Meterpreter *currently* does. Once #599 is landed, the Windows Meterpreter will also actually honor the LocalHost option meaning that once both are landed they will both behave in the same way.

Test this with:

* https://github.com/rapid7/metasploit-framework/pull/17340

- [x] Open a Meterpreter session
- [x] Setup a reverse port forward
- [x] See that the target host is listening on both IPv4 and IPv6 addresses
    * On Windows, these will show up as separate entries in netstat, you can check with `netstat /anp tcp` and `netstat /anp tcpv6`. On Linux it'll only show up as a listening IPv6 socket, but you'll be able to connect to the host on IPv4 too.

Tested on both Windows and Linux.