### PR TITLE
add getdesktop command to windows python meterpreter

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -2830,7 +2830,7 @@ def stdapi_ui_desktop_enum(request, response):
         ProcessIdToSessionId = ctypes.windll.kernel32.ProcessIdToSessionId
         ProcessIdToSessionId.argtypes = [ctypes.c_ulong, ctypes.POINTER(ctypes.c_ulong)]
         ProcessIdToSessionId.restype = ctypes.c_bool
-        
+
         if not ProcessIdToSessionId(ctypes.c_ulong(pid), ctypes.byref(dwSessionId)):
             dwSessionId = ctypes.c_ulong(-1)
 
@@ -2878,7 +2878,6 @@ def stdapi_ui_desktop_enum(request, response):
 
 @register_function_if(has_windll)
 def stdapi_ui_desktop_get(request, response):
-
     UOI_NAME = 2
 
     GetCurrentProcessId = ctypes.windll.kernel32.GetCurrentProcessId
@@ -2906,12 +2905,12 @@ def stdapi_ui_desktop_get(request, response):
     if not ProcessIdToSessionId(GetCurrentProcessId(), ctypes.byref(dwSessionId)):
         return error_result_windows(), response
 
-    station_name = ctypes.create_string_buffer(bytes(""), 256)
+    station_name = ctypes.create_string_buffer(bytes(), 256)
     success = GetUserObjectInformationA(GetProcessWindowStation(), UOI_NAME, ctypes.byref(station_name), 256, None)
     if not success:
         return error_result_windows(), response
 
-    desktop_name = ctypes.create_string_buffer(bytes(""), 256)
+    desktop_name = ctypes.create_string_buffer(bytes(), 256)
     success = GetUserObjectInformationA(GetThreadDesktop(GetCurrentThreadId()), UOI_NAME, ctypes.byref(desktop_name), 256, None)
     if not success:
         return error_result_windows(), response

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -2792,7 +2792,7 @@ def stdapi_ui_get_idle_time(request, response):
 
 @register_function_if(has_windll)
 def stdapi_ui_desktop_enum(request, response):
-    
+
     response_parts = []
     if ctypes.sizeof(ctypes.c_long) == ctypes.sizeof(ctypes.c_void_p):
         LPARAM = ctypes.c_long
@@ -2874,6 +2874,51 @@ def stdapi_ui_desktop_enum(request, response):
 
     response += bytes().join(response_parts)
 
+    return ERROR_SUCCESS, response
+
+@register_function_if(has_windll)
+def stdapi_ui_desktop_get(request, response):
+
+    UOI_NAME = 2
+
+    GetCurrentProcessId = ctypes.windll.kernel32.GetCurrentProcessId
+    GetCurrentProcessId.restype = ctypes.c_ulong
+
+    GetProcessWindowStation = ctypes.windll.user32.GetProcessWindowStation
+    GetProcessWindowStation.restype = ctypes.c_void_p
+
+    GetUserObjectInformationA = ctypes.windll.user32.GetUserObjectInformationA
+    GetUserObjectInformationA.argtypes = [ctypes.c_void_p, ctypes.c_int32, ctypes.c_void_p, ctypes.c_ulong, ctypes.POINTER(ctypes.c_ulong)]
+    GetUserObjectInformationA.restype = ctypes.c_bool
+
+    GetCurrentThreadId = ctypes.windll.kernel32.GetCurrentThreadId
+    GetCurrentThreadId.restype = ctypes.c_ulong
+
+    GetThreadDesktop = ctypes.windll.user32.GetThreadDesktop
+    GetThreadDesktop.argtypes = [ctypes.c_ulong]
+    GetThreadDesktop.restype = ctypes.c_void_p
+
+    ProcessIdToSessionId = ctypes.windll.kernel32.ProcessIdToSessionId
+    ProcessIdToSessionId.argtypes = [ctypes.c_ulong, ctypes.POINTER(ctypes.c_ulong)]
+    ProcessIdToSessionId.restype = ctypes.c_bool
+
+    dwSessionId = ctypes.c_ulong(0)
+    if not ProcessIdToSessionId(GetCurrentProcessId(), ctypes.byref(dwSessionId)):
+        return error_result_windows(), response
+
+    station_name = ctypes.create_string_buffer(bytes(""), 256)
+    success = GetUserObjectInformationA(GetProcessWindowStation(), UOI_NAME, ctypes.byref(station_name), 256, None)
+    if not success:
+        return error_result_windows(), response
+
+    desktop_name = ctypes.create_string_buffer(bytes(""), 256)
+    success = GetUserObjectInformationA(GetThreadDesktop(GetCurrentThreadId()), UOI_NAME, ctypes.byref(desktop_name), 256, None)
+    if not success:
+        return error_result_windows(), response
+
+    response += tlv_pack(TLV_TYPE_DESKTOP_SESSION, dwSessionId.value)
+    response += tlv_pack(TLV_TYPE_DESKTOP_STATION, station_name.value.decode())
+    response += tlv_pack(TLV_TYPE_DESKTOP_NAME, desktop_name.value.decode())
     return ERROR_SUCCESS, response
 
 @register_function_if(has_termios and has_fcntl)


### PR DESCRIPTION
This commit makes `getdesktop` command available for python meterpreter sessions. The information included in the output are:

- Session ID
- Station Name
- Desktop Name

Changes tested against Python 2.7 and 3.10.8 on Windows 10 Build 19041 with following contexts:

- Normal User
- Admin with UAC acccess
- Admin without UAC acccess
- SYSTEM

```
msf6 exploit(multi/handler) > sessions -C sysinfo
[*] Running 'sysinfo' on meterpreter session 15 (10.0.0.3)
Computer        : DESKTOP-4CQE3PS
OS              : Windows 10 (Build 19041)
Architecture    : x64
System Language : en_US
Meterpreter     : python/windows
[*] Running 'sysinfo' on meterpreter session 16 (10.0.0.3)
Computer        : DESKTOP-4CQE3PS
OS              : Windows 10 (Build 19041)
Architecture    : x64
System Language : en_US
Meterpreter     : python/windows
msf6 exploit(multi/handler) > sessions -C getdesktop
[*] Running 'getdesktop' on meterpreter session 15 (10.0.0.3)
Session 1\WinSta0\Default
[*] Running 'getdesktop' on meterpreter session 16 (10.0.0.3)
Session 1\WinSta0\Default
msf6 exploit(multi/handler) > 
```