### PR TITLE
Fix the output of `getdesktop`

### DIFF
--- a/c/meterpreter/source/metsrv/server_setup.c
+++ b/c/meterpreter/source/metsrv/server_setup.c
@@ -426,10 +426,10 @@ DWORD server_setup(MetsrvConfig* config)
 			// Save the initial session/station/desktop names...
 			remote->orig_sess_id = server_sessionid();
 			remote->curr_sess_id = remote->orig_sess_id;
-			GetUserObjectInformation(GetProcessWindowStation(), UOI_NAME, &stationName, 256, NULL);
+			GetUserObjectInformationA(GetProcessWindowStation(), UOI_NAME, &stationName, 256, NULL);
 			remote->orig_station_name = _strdup(stationName);
 			remote->curr_station_name = _strdup(stationName);
-			GetUserObjectInformation(GetThreadDesktop(GetCurrentThreadId()), UOI_NAME, &desktopName, 256, NULL);
+			GetUserObjectInformationA(GetThreadDesktop(GetCurrentThreadId()), UOI_NAME, &desktopName, 256, NULL);
 			remote->orig_desktop_name = _strdup(desktopName);
 			remote->curr_desktop_name = _strdup(desktopName);
 


### PR DESCRIPTION
The wide versions of these functions were causing characters to be dropped from the output of `getdesktop`. With this change in place, the string returned by the `getdesktop` meterpreter command will not be truncated.

## Before
```
msf6 exploit(windows/smb/psexec) > sessions -i 4
[*] Starting interaction with 4...

meterpreter > getdesktop
Session 0\S\D
meterpreter > 
```

## After

```
[*] Meterpreter session 10 opened (192.168.159.128:4444 -> 192.168.159.10:52523) at 2023-01-27 17:30:49 -0500

meterpreter > getdesktop 
Session 0\Service-0x0-3e7$\Default
meterpreter > 
```sess