### PR TITLE
minor fixes to make python meterpreter comptaible with Python 2.5

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1777,7 +1777,7 @@ def stdapi_net_config_get_arp_table(request, response):
     result = GetIpNetTable(ipnet_table, size, False)
 
     if result == ERROR_INSUFFICIENT_BUFFER:
-        ipnet_table = ctypes.cast(ctypes.create_string_buffer(b'', size.value), ctypes.c_void_p)
+        ipnet_table = ctypes.cast(ctypes.create_string_buffer(bytes(''), size.value), ctypes.c_void_p)
 
     elif result != ERROR_SUCCESS and result != ERROR_NO_DATA:
         return error_result_windows(result), response

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -361,18 +361,19 @@ if DEBUGGING:
         file_handler.setLevel(logging.DEBUG)
         logging.getLogger().addHandler(file_handler)
 
-class SYSTEM_INFO(ctypes.Structure):
-    _fields_ = [("wProcessorArchitecture", ctypes.c_uint16),
-        ("wReserved", ctypes.c_uint16),
-        ("dwPageSize", ctypes.c_uint32),
-        ("lpMinimumApplicationAddress", ctypes.c_void_p),
-        ("lpMaximumApplicationAddress", ctypes.c_void_p),
-        ("dwActiveProcessorMask", ctypes.c_uint32),
-        ("dwNumberOfProcessors", ctypes.c_uint32),
-        ("dwProcessorType", ctypes.c_uint32),
-        ("dwAllocationGranularity", ctypes.c_uint32),
-        ("wProcessorLevel", ctypes.c_uint16),
-        ("wProcessorRevision", ctypes.c_uint16)]
+if has_windll:
+    class SYSTEM_INFO(ctypes.Structure):
+        _fields_ = [("wProcessorArchitecture", ctypes.c_uint16),
+            ("wReserved", ctypes.c_uint16),
+            ("dwPageSize", ctypes.c_uint32),
+            ("lpMinimumApplicationAddress", ctypes.c_void_p),
+            ("lpMaximumApplicationAddress", ctypes.c_void_p),
+            ("dwActiveProcessorMask", ctypes.c_uint32),
+            ("dwNumberOfProcessors", ctypes.c_uint32),
+            ("dwProcessorType", ctypes.c_uint32),
+            ("dwAllocationGranularity", ctypes.c_uint32),
+            ("wProcessorLevel", ctypes.c_uint16),
+            ("wProcessorRevision", ctypes.c_uint16)]
 
 def rand_bytes(n):
     return os.urandom(n)


### PR DESCRIPTION
- check if ctypes exists, for class `SYSTEM_INFO` definition
- use `bytes('')` instead of `b''` in a missed line

this patch fixes #594 