### PR TITLE
Add stdapi_sys_process_attach for Python

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1353,6 +1353,8 @@ def stdapi_sys_process_attach(request, response):
         handle = OpenProcess(permissions, inherit, pid)
     if not handle:
         return error_result_windows(), response
+    meterpreter.processes[handle] = None
+    debug_print('[*] added process id: ' + str(pid) + ', handle: ' + str(handle))
     response += tlv_pack(TLV_TYPE_HANDLE, handle)
     return ERROR_SUCCESS, response
 

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1336,6 +1336,24 @@ def stdapi_sys_config_sysinfo(request, response):
     response += tlv_pack(TLV_TYPE_ARCHITECTURE, get_system_arch())
     return ERROR_SUCCESS, response
 
+@register_function_if(has_windll)
+def stdapi_sys_process_attach(request, response):
+    pid = packet_get_tlv(request, TLV_TYPE_PID)['value']
+    if not pid:
+        handle = ctypes.windll.kernel32.GetCurrentProcess()
+    else:
+        inherit = packet_get_tlv(request, TLV_TYPE_INHERIT)['value']
+        permissions = packet_get_tlv(request, TLV_TYPE_PROCESS_PERMS)['value']
+
+        OpenProcess = ctypes.windll.kernel32.OpenProcess
+        OpenProcess.argtypes = [ctypes.c_uint32, ctypes.c_bool, ctypes.c_uint32]
+        OpenProcess.restype = ctypes.c_void_p
+        handle = OpenProcess(permissions, inherit, pid)
+    if not handle:
+        return error_result_windows(), response
+    response += tlv_pack(TLV_TYPE_HANDLE, handle)
+    return ERROR_SUCCESS, response
+
 @register_function
 def stdapi_sys_process_close(request, response):
     proc_h_id = packet_get_tlv(request, TLV_TYPE_HANDLE)['value']

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1340,7 +1340,9 @@ def stdapi_sys_config_sysinfo(request, response):
 def stdapi_sys_process_attach(request, response):
     pid = packet_get_tlv(request, TLV_TYPE_PID)['value']
     if not pid:
-        handle = ctypes.windll.kernel32.GetCurrentProcess()
+        GetCurrentProcess = ctypes.windll.kernel32.GetCurrentProcess
+        GetCurrentProcess.restype = ctypes.c_void_p
+        handle = GetCurrentProcess()
     else:
         inherit = packet_get_tlv(request, TLV_TYPE_INHERIT)['value']
         permissions = packet_get_tlv(request, TLV_TYPE_PROCESS_PERMS)['value']

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1259,6 +1259,21 @@ class PythonMeterpreter(object):
         self.next_channel_id += 1
         return idx
 
+    def close_channel(self, channel_id):
+        if channel_id not in self.channels:
+            return False
+        channel = self.channels[channel_id]
+        try:
+            channel.close()
+        except Exception:
+            debug_traceback('[-] failed to close channel id: ' + str(channel_id))
+            return False
+        del self.channels[channel_id]
+        if channel_id in self.interact_channels:
+            self.interact_channels.remove(channel_id)
+        debug_print('[*] closed and removed channel id: ' + str(channel_id))
+        return True
+
     def add_process(self, process):
         if has_windll:
             PROCESS_ALL_ACCESS = 0x1fffff
@@ -1274,37 +1289,24 @@ class PythonMeterpreter(object):
         return handle
 
     def close_process(self, proc_h_id):
-        proc_h = self.processes.pop(proc_h_id, None)
-        if not proc_h:
+        if proc_h_id not in self.processes:
             return False
-        for channel_id, channel in self.channels.items():
-            if not isinstance(channel, MeterpreterProcess):
-                continue
-            if not channel.proc_h is proc_h:
-                continue
-            self.close_channel(channel_id)
-            break
+        proc_h = self.processes.pop(proc_h_id)
+        if proc_h:
+            # proc_h is only set when we started the process via execute and not when we attached to it
+            for channel_id, channel in self.channels.items():
+                if not isinstance(channel, MeterpreterProcess):
+                    continue
+                if not channel.proc_h is proc_h:
+                    continue
+                self.close_channel(channel_id)
+                break
         if has_windll:
             CloseHandle = ctypes.windll.kernel32.CloseHandle
             CloseHandle.argtypes = [ctypes.c_void_p]
             CloseHandle.restype = ctypes.c_long
             CloseHandle(proc_h_id)
-        debug_print('[*] closed and removed process id: ' + str(proc_h.pid) + ', handle: ' + str(proc_h_id))
-        return True
-
-    def close_channel(self, channel_id):
-        if channel_id not in self.channels:
-            return False
-        channel = self.channels[channel_id]
-        try:
-            channel.close()
-        except Exception:
-            debug_traceback('[-] failed to close channel id: ' + str(channel_id))
-            return False
-        del self.channels[channel_id]
-        if channel_id in self.interact_channels:
-            self.interact_channels.remove(channel_id)
-        debug_print('[*] closed and removed channel id: ' + str(channel_id))
+        debug_print('[*] closed and removed process handle: ' + str(proc_h_id))
         return True
 
     def get_packet(self):


### PR DESCRIPTION
This adds the `stdapi_sys_process_attach` command to the Windows Python Meterpreter which allows users to attach to existing processes. This is required for some functions in the `Msf::Post::Windows::Process` mixin such as [`#execute_dll`](https://github.com/rapid7/metasploit-framework/blob/5b4962e2bd6ee3eacf7ec30e2e232032b2810ff5/lib/msf/core/post/windows/process.rb#L99) and [`#execute_shellcode`](https://github.com/rapid7/metasploit-framework/blob/5b4962e2bd6ee3eacf7ec30e2e232032b2810ff5/lib/msf/core/post/windows/process.rb#L130). Neither of these functions will work yet, but this gets us one step closer to that.

## For testing

- [x] Open process hacker so handles can be inspected
- [x] Start a Python Meterpreter session on Windows
- [x] Start a Notepad or other process as the same user running the Python Meterpreter (or any user if the Meterpreter instance is running as SYSTEM)
- [ ] Use pry to attach to the process and verify the handle ID
    - [ ] Run `proc = sys.process.open(pid)` where `pid` is the pid of the process to attach to
    - [ ] Verify that `proc.handle` is visible in Process Hacker's Handles tab
- [ ] Run `proc.close` to close the process and see it's removed from Process Hacker's Handles tab

## Example

![image](https://user-images.githubusercontent.com/2058303/222553231-0952720c-1444-46c8-8e1e-78aeb3b7b053.png)

