### PR TITLE
return interface name instead of index for arp command

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/net/config/arp.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/config/arp.c
@@ -45,27 +45,19 @@ DWORD get_arp_table(Remote *remote, Packet *response)
 					arp[1].buffer        = (PUCHAR)pIpNetTable->table[i].bPhysAddr;
 
 					arp[2].header.type   = TLV_TYPE_MAC_NAME;
-
-					BOOL has_description = FALSE;
-					MIB_IFROW iface;
-					iface.dwIndex = pIpNetTable->table[i].dwIndex;
+					MIB_IFROW iface = { .dwIndex = pIpNetTable->table[i].dwIndex };
 					result = GetIfEntry(&iface);
-					if (result == NO_ERROR)
-					{
-						if (iface.bDescr)
-						{
-							arp[2].header.length = (DWORD)strlen(iface.bDescr) + 1;
-							arp[2].buffer = (PUCHAR)iface.bDescr;
-							has_description = TRUE;
-						}
+					if ((result == NO_ERROR) && (iface.bDescr)) {
+						arp[2].header.length = (DWORD)strlen(iface.bDescr) + 1;
+						arp[2].buffer = (PUCHAR)iface.bDescr;
 					}
-
-					if (!has_description) {
+					else {
 						char interface_index[10];
 						sprintf_s(interface_index, sizeof(interface_index), "%d", pIpNetTable->table[i].dwIndex);
 						arp[2].header.length = (DWORD)strlen(interface_index) + 1;
 						arp[2].buffer        = (PUCHAR)interface_index;
 					}
+
 
 					met_api->packet.add_tlv_group(response, TLV_TYPE_ARP_ENTRY, arp, 3);
 				}

--- a/c/meterpreter/source/extensions/stdapi/server/net/config/arp.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/config/arp.c
@@ -9,7 +9,6 @@ DWORD get_arp_table(Remote *remote, Packet *response)
 	DWORD dwSize = 0;
 	DWORD dwRetVal;
 	DWORD i;
-	char interface_index[10];
 
 	do {
 		dwRetVal = GetIpNetTable(NULL, &dwSize, 0);
@@ -36,8 +35,6 @@ DWORD get_arp_table(Remote *remote, Packet *response)
 				if ((pIpNetTable->table[i].dwType == MIB_IPNET_TYPE_DYNAMIC) ||
 					(pIpNetTable->table[i].dwType == MIB_IPNET_TYPE_STATIC)) {
 					Tlv arp[3];
-					// can't send interface name as it can be _big_, so send index instead
-					sprintf_s(interface_index, sizeof(interface_index), "%d", pIpNetTable->table[i].dwIndex);
 
 					arp[0].header.type   = TLV_TYPE_IP;
 					arp[0].header.length = sizeof(DWORD);
@@ -48,8 +45,27 @@ DWORD get_arp_table(Remote *remote, Packet *response)
 					arp[1].buffer        = (PUCHAR)pIpNetTable->table[i].bPhysAddr;
 
 					arp[2].header.type   = TLV_TYPE_MAC_NAME;
-					arp[2].header.length = (DWORD)strlen(interface_index) + 1;
-					arp[2].buffer        = (PUCHAR)interface_index;
+
+					BOOL has_description = FALSE;
+					MIB_IFROW iface;
+					iface.dwIndex = pIpNetTable->table[i].dwIndex;
+					result = GetIfEntry(&iface);
+					if (result == NO_ERROR)
+					{
+						if (iface.bDescr)
+						{
+							arp[2].header.length = (DWORD)strlen(iface.bDescr) + 1;
+							arp[2].buffer = (PUCHAR)iface.bDescr;
+							has_description = TRUE;
+						}
+					}
+
+					if (!has_description) {
+						char interface_index[10];
+						sprintf_s(interface_index, sizeof(interface_index), "%d", pIpNetTable->table[i].dwIndex);
+						arp[2].header.length = (DWORD)strlen(interface_index) + 1;
+						arp[2].buffer        = (PUCHAR)interface_index;
+					}
 
 					met_api->packet.add_tlv_group(response, TLV_TYPE_ARP_ENTRY, arp, 3);
 				}


### PR DESCRIPTION
This PR contains a patch for #612 issue. By this PR, executing `arp` command results interface name.

Before:
```
meterpreter > arp

ARP cache
=========

    IP address       MAC address        Interface
    ----------       -----------        ---------
    10.0.0.22        00:0c:29:7f:05:87  5
    10.255.255.255   ff:ff:ff:ff:ff:ff  5
    224.0.0.22       00:00:00:00:00:00  1
    224.0.0.22       01:00:5e:00:00:16  5
    224.0.0.22       01:00:5e:00:00:16  15
    224.0.0.251      01:00:5e:00:00:fb  5
    224.0.0.252      01:00:5e:00:00:fc  5
    239.255.255.250  00:00:00:00:00:00  1
    239.255.255.250  01:00:5e:7f:ff:fa  5
    239.255.255.250  01:00:5e:7f:ff:fa  15

```

Now:
```

meterpreter > arp

ARP cache
=========

    IP address       MAC address        Interface
    ----------       -----------        ---------
    10.0.0.22        00:0c:29:7f:05:87  Intel(R) 82574L Gigabit Network Connection
    10.255.255.255   ff:ff:ff:ff:ff:ff  Intel(R) 82574L Gigabit Network Connection
    224.0.0.22       00:00:00:00:00:00  Software Loopback Interface 1
    224.0.0.22       01:00:5e:00:00:16  Intel(R) 82574L Gigabit Network Connection
    224.0.0.22       01:00:5e:00:00:16  Intel(R) 82574L Gigabit Network Connection #2
    224.0.0.251      01:00:5e:00:00:fb  Intel(R) 82574L Gigabit Network Connection
    224.0.0.252      01:00:5e:00:00:fc  Intel(R) 82574L Gigabit Network Connection
    239.255.255.250  00:00:00:00:00:00  Software Loopback Interface 1
    239.255.255.250  01:00:5e:7f:ff:fa  Intel(R) 82574L Gigabit Network Connection
    239.255.255.250  01:00:5e:7f:ff:fa  Intel(R) 82574L Gigabit Network Connection #2

```