### PR TITLE
add memory read/write abilities to python windows meterpreter

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1670,6 +1670,9 @@ def stdapi_sys_process_memory_read(request, response):
     base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value', 0)
     size = packet_get_tlv(request, TLV_TYPE_LENGTH).get('value', 0)
 
+    if not (handle and base and size):
+        return ERROR_INVALID_PARAMETER, response
+
     ReadProcessMemory = ctypes.windll.kernel32.ReadProcessMemory
     ReadProcessMemory.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t)]
     ReadProcessMemory.restype = ctypes.c_bool
@@ -1689,6 +1692,9 @@ def stdapi_sys_process_memory_write(request, response):
     handle = packet_get_tlv(request, TLV_TYPE_HANDLE).get('value', 0)
     base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value', 0)
     data = packet_get_tlv(request, TLV_TYPE_PROCESS_MEMORY).get('value', 0)
+
+    if not (handle and base and data):
+        return ERROR_INVALID_PARAMETER, response
 
     WriteProcessMemory = ctypes.windll.kernel32.WriteProcessMemory
     WriteProcessMemory.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t)]

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1664,6 +1664,44 @@ def stdapi_sys_process_memory_unlock(request, response):
     return ERROR_SUCCESS, response
 
 @register_function_if(has_windll)
+def stdapi_sys_process_memory_read(request, response):
+    ERROR_PARTIAL_COPY = 229
+    handle = packet_get_tlv(request, TLV_TYPE_HANDLE).get('value', 0)
+    base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value', 0)
+    size = packet_get_tlv(request, TLV_TYPE_LENGTH).get('value', 0)
+
+    ReadProcessMemory = ctypes.windll.kernel32.ReadProcessMemory
+    ReadProcessMemory.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t)]
+    ReadProcessMemory.restype = ctypes.c_bool
+
+    buffer = ctypes.create_string_buffer(size)
+    bytes_read = ctypes.c_size_t(0)
+    if (not ReadProcessMemory(handle, base, ctypes.byref(buffer), ctypes.sizeof(buffer), ctypes.byref(bytes_read))) and (ctypes.windll.kernel32.GetLastError() != ERROR_PARTIAL_COPY):
+        return error_result_windows(), response
+
+    readed_data = buffer.raw[:bytes_read.value]
+    response += tlv_pack(TLV_TYPE_PROCESS_MEMORY, readed_data)
+    return ERROR_SUCCESS, response
+
+@register_function_if(has_windll)
+def stdapi_sys_process_memory_write(request, response):
+    ERROR_PARTIAL_COPY = 229
+    handle = packet_get_tlv(request, TLV_TYPE_HANDLE).get('value', 0)
+    base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value', 0)
+    data = packet_get_tlv(request, TLV_TYPE_PROCESS_MEMORY).get('value', 0)
+
+    WriteProcessMemory = ctypes.windll.kernel32.WriteProcessMemory
+    WriteProcessMemory.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t)]
+    WriteProcessMemory.restype = ctypes.c_bool
+
+    written = ctypes.c_size_t(0)
+    if (not WriteProcessMemory(handle, base, data, len(data), ctypes.byref(written))) and (ctypes.windll.kernel32.GetLastError() != ERROR_PARTIAL_COPY):
+        return error_result_windows(), response
+
+    response += tlv_pack(TLV_TYPE_LENGTH, written.value)
+    return ERROR_SUCCESS, response
+
+@register_function_if(has_windll)
 def stdapi_sys_process_memory_free(request, response):
     handle = packet_get_tlv(request, TLV_TYPE_HANDLE).get('value', 0)
     base   = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value', 0)

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1666,9 +1666,9 @@ def stdapi_sys_process_memory_unlock(request, response):
 @register_function_if(has_windll)
 def stdapi_sys_process_memory_read(request, response):
     ERROR_PARTIAL_COPY = 229
-    handle = packet_get_tlv(request, TLV_TYPE_HANDLE).get('value', 0)
-    base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value', 0)
-    size = packet_get_tlv(request, TLV_TYPE_LENGTH).get('value', 0)
+    handle = packet_get_tlv(request, TLV_TYPE_HANDLE).get('value')
+    base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value')
+    size = packet_get_tlv(request, TLV_TYPE_LENGTH).get('value')
 
     if not (handle and base and size):
         return ERROR_INVALID_PARAMETER, response
@@ -1689,9 +1689,9 @@ def stdapi_sys_process_memory_read(request, response):
 @register_function_if(has_windll)
 def stdapi_sys_process_memory_write(request, response):
     ERROR_PARTIAL_COPY = 229
-    handle = packet_get_tlv(request, TLV_TYPE_HANDLE).get('value', 0)
-    base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value', 0)
-    data = packet_get_tlv(request, TLV_TYPE_PROCESS_MEMORY).get('value', 0)
+    handle = packet_get_tlv(request, TLV_TYPE_HANDLE).get('value')
+    base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value')
+    data = packet_get_tlv(request, TLV_TYPE_PROCESS_MEMORY).get('value')
 
     if not (handle and base and data):
         return ERROR_INVALID_PARAMETER, response


### PR DESCRIPTION
This PR adds two memory functions to python meterpreter on windows platform:
- stdapi_sys_process_memory_read
- stdapi_sys_process_memory_write

Tested with:
- Python 3.7.2
- Python 2.7.15

Test output:
```
meterpreter > sysinfo 
Computer        : DESKTOP-5HNNBGG
OS              : Windows 10 (Build 22000)
Architecture    : x64
System Language : en_GB
Meterpreter     : python/windows
meterpreter > pry
[*] Starting Pry shell...
[*] You are in the "client" (session) object

[1] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc = sys.process.open(6152)
=> #<#<Class:0x00007f098a1dc550>:0x00007f098a7c6f88
 @aliases=
  {"image"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::Image:0x00007f098a7c6e20 @process=#<#<Class:0x00007f098a1dc550>:0x00007f098a7c6f88 ...>>,
   "io"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::IO:0x00007f098a7c6dd0 @process=#<#<Class:0x00007f098a1dc550>:0x00007f098a7c6f88 ...>>,
   "memory"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::Memory:0x00007f098a7c6d58 @process=#<#<Class:0x00007f098a1dc550>:0x00007f098a7c6f88 ...>>,
   "thread"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::Thread:0x00007f098a7c6d08 @process=#<#<Class:0x00007f098a1dc550>:0x00007f098a7c6f88 ...>>},
 @channel=nil,
 @client=#<Session:meterpreter 10.0.0.2:49694 (10.0.0.2) "DESKTOP-5HNNBGG\John @ DESKTOP-5HNNBGG">,
 @handle=916,
 @pid=6152>
[2] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc.memory.write(addr, "Hello world!")
Rex::Post::Meterpreter::RequestError: stdapi_sys_process_memory_write: Operation failed: Windows error: 998
from /home/kali/git/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process_subsystem/memory.rb:176:in `write'
[3] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> addr = proc.memory.allocate(2048)
=> 17367040
[4] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc.memory.write(addr, "Hello world!")
=> 12
[5] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc.memory.read(addr, 12)
=> "Hello world!"
[6] pry(#<Msf::Sessions::Meterpreter_Python_Python>)>
```