### PR TITLE
Fix debug logging for Windows 7

### DIFF
--- a/c/meterpreter/source/logging/logging.c
+++ b/c/meterpreter/source/logging/logging.c
@@ -24,8 +24,8 @@ void log_to_file(char* buffer) {
 	if (hFile) {
 		WaitForSingleObject(lock, INFINITE);
 
-		LPDWORD bytesWritten = 0;
-		WriteFile(hFile, buffer, (DWORD)strlen(buffer), bytesWritten, NULL);
+		DWORD bytesWritten = 0;
+		WriteFile(hFile, buffer, (DWORD)strlen(buffer), &bytesWritten, NULL);
 		ReleaseMutex(lock);
 	}
 }


### PR DESCRIPTION
Fixes a crash when running debug logging on Windows 7

Verification steps:

1. Build meterpreter from source, run the [make install](https://github.com/rapid7/metasploit-payloads/blob/d9b04ace74b9262a54c1127818ad6ac74e0f156d/c/meterpreter/Makefile#L12-L13) command to copy the created DLLs into your metasploit-framework repo
2. Build a debug build:
```
use windows/x64/meterpreter_reverse_tcp
generate -f exe -o shell.exe MeterpreterDebugBuild=true MeterpreterDebugLogging='rpath:C:/Windows/Temp/foo.txt'
``

Run the handler:
```
to_handler
```

Open on Windows 7 and Windows 10, verify that the logging works:

```
C:\WINDOWS\system32>type C:\Windows\Temp\foo.txt | more
[21d0] [METSRV] Getting ready to init with config 0000000140048200
[21d0] [SERVER] Initializing from configuration: 0x0000000140048200
[21d0] [SESSION] Comms handle: 0
[21d0] [SESSION] Expiry: 604800
[21d0] [SERVER] UUID: 7c3bd7532a48f27f4889498b2cc94486
[21d0] [SERVER] Session GUID: 00000000-0000-0000-0000-000000000000
[21d0] [SERVER] main server thread: handle=0x0000017C id=0x000021D0 sigterm=0x00542E80
[21d0] [REMOTE] remote created 0000000000542420
[21d0] [DISPATCH] Session going for 604800 seconds from 1681919014 to 1682523814
... etc ...
```