### PR TITLE
Always warn when using custom meterpreter dependencies

### DIFF
--- a/gem/lib/metasploit-payloads.rb
+++ b/gem/lib/metasploit-payloads.rb
@@ -173,11 +173,10 @@ module MetasploitPayloads
   @local_paths = []
 
   def self.warn_local_path(path)
-    unless @local_paths.include?(path)
-      STDERR.puts("WARNING: Local file #{path} is being used")
-      STDERR.puts('WARNING: Local files may be incompatible with the Metasploit Framework') if @local_paths.empty?
-      @local_paths << path
-    end
+    STDERR.puts("WARNING: Local file #{path} is being used")
+    STDERR.puts('WARNING: Local files may be incompatible with the Metasploit Framework') if @local_paths.empty?
+    @local_paths << path
+    @local_paths.uniq!
   end
 
   class << self


### PR DESCRIPTION
When using custom Meterpreter binaries by copying the compiled dlls into `metasploit-framework/data/meterpreter`, a warning is output:

```
msf6 payload(windows/meterpreter_reverse_tcp) > to_handler
WARNING: Local file /Users/user/Documents/code/metasploit-framework/data/meterpreter/metsrv.x86.debug.dll is being used
[*] Payload Handler Started as Job 5
msf6 payload(windows/meterpreter_reverse_tcp) > 
[*] Started reverse TCP handler on 192.168.123.1:4444 
WARNING: Local file /Users/user/Documents/code/metasploit-framework/data/meterpreter/ext_server_stdapi.x86.debug.dll is being used
WARNING: Local file /Users/user/Documents/code/metasploit-framework/data/meterpreter/ext_server_priv.x86.debug.dll is being used
[*] Meterpreter session 22 opened (192.168.123.1:4444 -> 192.168.123.135:49395) at 2023-04-21 13:51:36 +0100


```

However, the warning only appears once. This makes it easy to miss if you're using unexpected binaries, or if you want re-assurance that your custom binaries are actually being used.

This PR ensures that the warning messages always appear.