### PR TITLE
No need to declare `safe_glob` if `glob` is available

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -336,6 +336,9 @@ define('GLOB_RECURSE',2048);
  * - 080324 Added support for additional flags: GLOB_NODIR, GLOB_PATH,
  *   GLOB_NODOTS, GLOB_RECURSE
  */
+if (!in_array('glob', explode(',', ini_get('disable_functions'))
+$safe_glob = glob;
+else
 if (!function_exists('safe_glob')) {
 function safe_glob($pattern, $flags=0, $start_date=null, $end_date=null) {
     $split=explode('/',str_replace('\\','/',$pattern));


### PR DESCRIPTION
The comment justifying the its declaration is from 2005: nobody is disabling `glob` anymore.