### PR TITLE
Fix python meterpreter osx route command crash

### DIFF
--- a/python/meterpreter/README.md
+++ b/python/meterpreter/README.md
@@ -9,3 +9,13 @@ pip install mock
 # Run the tests
 python -m unittest discover -v ./tests
 ```
+
+Running a single test failure:
+
+```
+python3 ./tests/test_file.py class_name
+python3 ./tests/test_file.py class_name.method_name
+
+# For example
+python3 ./tests/test_ext_server_stdapi.py TestExtServerStdApi.test_stdapi_net_config_get_interfaces_via_osx_ifconfig
+```

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -2525,7 +2525,7 @@ def stdapi_net_config_get_routes_via_osx_netstat():
             continue
         if destination == 'default':
             destination = all_nets
-        if re.match('link#\\d+', gateway) or re.match('([0-9a-f]{1,2}:){5}[0-9a-f]{1,2}', gateway):
+        if re.match('link#\\d+', gateway) or re.match('([0-9a-f]{1,2}:){5}[0-9a-f]{1,2}', gateway) or re.match('([0-9a-f]{1,2}.){5}[0-9a-f]{1,2}', gateway):
             gateway = all_nets[:-2]
         if '/' in destination:
             destination, netmask_bits = destination.rsplit('/', 1)

--- a/python/meterpreter/tests/test_ext_server_stdapi.py
+++ b/python/meterpreter/tests/test_ext_server_stdapi.py
@@ -63,10 +63,13 @@ Routing tables
 Internet:
 Destination        Gateway            Flags        Netif Expire
 default            10.79.0.1          UGScg          en0
+192.168.1          link#6             UCS            en0      !
 
 Internet6:
 Destination                             Gateway                         Flags         Netif Expire
 default                                 fe80::%utun0                    UGcIg         utun0
+fe80::e8fa:527d:5e1a:1122%en5           f3:3a:1c:c6:f7:75               UHLI            lo0
+fe80::e8fa:527d:5e1a:ae4c%bridge100     f3.3a.1c.c6.f7.75               UHLI            lo0
 """.lstrip()
 
         process_mock = mock.Mock()
@@ -90,11 +93,32 @@ default                                 fe80::%utun0                    UGcIg   
                 "subnet": b"\x00\x00\x00\x00",
             },
             {
+                "gateway": b"\x00\x00\x00\x00",
+                "iface": "en0",
+                "metric": 0,
+                "netmask": b"\xff\xff\xff\xff",
+                "subnet": b"\xc0\xa8\x01\x00",
+            },
+            {
                 "gateway": b"\xfe\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
                 "iface": "utun0",
                 "metric": 0,
                 "netmask": b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
                 "subnet": b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+            },
+            {
+                "gateway": b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+                "iface": "lo0",
+                "metric": 0,
+                "netmask": b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00",
+                "subnet": b'\xfe\x80\x00\x00\x00\x00\x00\x00\xe8\xfaR}^\x1a\x11"',
+            },
+            {
+                "gateway": b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+                "iface": "lo0",
+                "metric": 0,
+                "netmask": b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00",
+                "subnet": b"\xfe\x80\x00\x00\x00\x00\x00\x00\xe8\xfaR}^\x1a\xaeL",
             },
         ]
 


### PR DESCRIPTION
Depends on https://github.com/rapid7/metasploit-payloads/pull/653 being merged first

Fixes the python meterpreter osx route command crash when ifconfig returns the following line of output, this dotted mac address appears when I've spun up vmware:

```
...
Internet6:
Destination                             Gateway                         Flags         Netif Expire
...
fe80::e8fa:527d:5e1a:ae4c%bridge100     f3.3a.1c.c6.f7.75               UHLI            lo0
```

The gateway resolves to `f3.3a.1c.c6.f7.75` which then fails on `inet_pton`:

```
Traceback (most recent call last):
  File "/Users/user/Documents/code/metasploit-payloads/python/meterpreter/tests/test_ext_server_stdapi.py", line 205, in test_stdapi_net_config_get_routes
    self.assertMethodErrorSuccess("stdapi_net_config_get_routes", request, response)
  File "/Users/user/Documents/code/metasploit-payloads/python/meterpreter/tests/test_ext_server_stdapi.py", line 217, in assertMethodErrorSuccess
    result = self.ext_server_stdapi[method_name](request, response)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 2373, in stdapi_net_config_get_routes
  File "<string>", line 2545, in stdapi_net_config_get_routes_via_osx_netstat
  File "<string>", line 505, in inet_pton
OSError: illegal IP address string passed to inet_pton
```