### PR TITLE
Fix double-free in free

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/process/memory.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/process/memory.c
@@ -53,20 +53,18 @@ DWORD request_sys_process_memory_free(Remote *remote, Packet *packet)
 {
 	Packet *response = met_api->packet.create_response(packet);
 	HANDLE handle;
-	SIZE_T size;
 	LPVOID base;
 	DWORD result = ERROR_SUCCESS;
 
 	handle = (HANDLE)met_api->packet.get_tlv_value_qword(packet, TLV_TYPE_HANDLE);
 	base   = (LPVOID)met_api->packet.get_tlv_value_qword(packet, TLV_TYPE_BASE_ADDRESS);
-	size   = met_api->packet.get_tlv_value_uint(packet, TLV_TYPE_LENGTH);
 
 	// Free the memory
-	if (!VirtualFreeEx(handle, base, size, MEM_RELEASE))
+	if (!VirtualFreeEx(handle, base, 0, MEM_RELEASE))
 		result = GetLastError();
 
 	// Transmit the response
-	met_api->packet.transmit_response(result, remote, packet);
+	met_api->packet.transmit_response(result, remote, response);
 
 	return ERROR_SUCCESS;
 }


### PR DESCRIPTION
I observed a crash in Meterpreter when calling the `stdapi_sys_process_memory_free` command. Ironically, this turned out to be a double-free, unrelated to the freeing of the actual memory.

## Root cause analysis

The last debug message before a crash was "Packet is not local, destroying".
Suspecting a double-free issue, I added some logging, and observed the following:

```
[11452] [2e5c] [PACKET] Sent packet to remote, length: 192, command id: 1079, result: 0 
[11452] [2e5c] *** Destroying packet: 0x5367f0 
[11452] [2e5c] [COMMAND] Calling completion handlers... 
[11452] [2e5c] [PKT FIND] Looking for type 65538 
[11452] [2e5c] [COMMAND] Completion handlers finished for 1079. 
[11452] [2e5c] [COMMAND] Packet is not local, destroying 
[11452] [2e5c] *** Destroying packet: 0x5367f0 
```

So we can see a double free: both freeing the same packet.

The issue ended up being that the call to `transmit_response` was being made with the original packet, rather than the response packet. So then `packet` was freed twice. Changing this resolved the issue.

While I was here, I also removed the TLV size parameter, which (according to [MSDN](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualfreeex)) can never have any value other than 0 with `MEM_RELEASE`:

> If you specify [MEM_RELEASE], dwSize must be 0 (zero), and lpAddress must point to the base address returned by the [VirtualAlloc](https://learn.microsoft.com/en-us/windows/desktop/api/memoryapi/nf-memoryapi-virtualalloc) function when the region is reserved. The function fails if either of these conditions is not met.

Any code that previously used a non-zero value for size would have failed. Incidentally, no-one actually calls this anyway.

For neatness, this should have a separate PR in metasploit-framework to remove the length TLV and the length parameter from `free`; although technically it's a non-blocker since the value will just be ignored anyway.

## Verification

To reproduce the issue (and verify the fix):

- [ ] Obtain a meterpreter session
- [ ] Run:
- [ ] `irb`
- [ ] `p = sys.process.execute('notepad.exe')`
- [ ] `process = sys.process.open(p.pid, PROCESS_ALL_ACCESS)`
- [ ] `addr = process.memory.allocate(1000)`
- [ ] `process.memory.free(addr)`