### PR TITLE
Fix python meterpreter getuid crash on windows

### DIFF
--- a/python/meterpreter/README.md
+++ b/python/meterpreter/README.md
@@ -22,3 +22,9 @@ python3 ./tests/test_ext_server_stdapi.py TestExtServerStdApi.test_stdapi_net_co
 # Or:
 python3 -m unittest tests.test_ext_server_stdapi.ExtServerStdApiFileSystemTest.test_stdapi_fs_stat
 ```
+
+To debug tests, add the following code snippet to enter into an interactive debugger at the calling stack frame:
+
+```python
+import pdb; pdb.set_trace()
+```


### PR DESCRIPTION
### Before

The stdapi_sys_config_getuid call on windows would pass and fail intermittently: 

```
PS C:\metasploit-payloads\python\meterpreter> 1..1000 | % { python3 -m unittest tests.test_ext_server_stdapi.ExtServerStdApiSystemConfigTest.test_stdapi_sys_config_getuid }
...
.
----------------------------------------------------------------------
Ran 1 test in 0.077s

OK
F
======================================================================
FAIL: test_stdapi_sys_config_getuid (tests.test_ext_server_stdapi.ExtServerStdApiSystemConfigTest.test_stdapi_sys_config_getuid)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\metasploit-payloads\python\meterpreter\tests\test_ext_server_stdapi.py", line 294, in test_stdapi_sys_config_getuid
    _result_code, result_tlvs = self.assertMethodErrorSuccess(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\metasploit-payloads\python\meterpreter\tests\test_ext_server_stdapi.py", line 67, in assertMethodErrorSuccess
    self.assertErrorSuccess(result)
  File "C:\metasploit-payloads\python\meterpreter\tests\test_ext_server_stdapi.py", line 72, in assertErrorSuccess
    self.assertEqual(result[0], ERROR_SUCCESS)
AssertionError: 87293955 != 0

----------------------------------------------------------------------
Ran 1 test in 0.104s

FAILED (failures=1)
F
======================================================================
FAIL: test_stdapi_sys_config_getuid (tests.test_ext_server_stdapi.ExtServerStdApiSystemConfigTest.test_stdapi_sys_config_getuid)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\metasploit-payloads\python\meterpreter\tests\test_ext_server_stdapi.py", line 294, in test_stdapi_sys_config_getuid
    _result_code, result_tlvs = self.assertMethodErrorSuccess(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\metasploit-payloads\python\meterpreter\tests\test_ext_server_stdapi.py", line 67, in assertMethodErrorSuccess
    self.assertErrorSuccess(result)
  File "C:\metasploit-payloads\python\meterpreter\tests\test_ext_server_stdapi.py", line 72, in assertErrorSuccess
    self.assertEqual(result[0], ERROR_SUCCESS)
AssertionError: 87293955 != 0

----------------------------------------------------------------------
Ran 1 test in 0.113s

FAILED (failures=1)
F
======================================================================
FAIL: test_stdapi_sys_config_getuid (tests.test_ext_server_stdapi.ExtServerStdApiSystemConfigTest.test_stdapi_sys_config_getuid)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\metasploit-payloads\python\meterpreter\tests\test_ext_server_stdapi.py", line 294, in test_stdapi_sys_config_getuid
    _result_code, result_tlvs = self.assertMethodErrorSuccess(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\metasploit-payloads\python\meterpreter\tests\test_ext_server_stdapi.py", line 67, in assertMethodErrorSuccess
    self.assertErrorSuccess(result)
  File "C:\metasploit-payloads\python\meterpreter\tests\test_ext_server_stdapi.py", line 72, in assertErrorSuccess
    self.assertEqual(result[0], ERROR_SUCCESS)
AssertionError: 5701635 != 0
----------------------------------------------------------------------
Ran 1 test in 0.105s

FAILED (failures=1)
.
----------------------------------------------------------------------
Ran 1 test in 0.112s

OK
.
----------------------------------------------------------------------
Ran 1 test in 0.094s

OK
.
```

### After

Tests consistently pass:

```
----------------------------------------------------------------------
Ran 1 test in 0.077s

OK
.
----------------------------------------------------------------------
Ran 1 test in 0.095s

OK
.
----------------------------------------------------------------------
Ran 1 test in 0.137s

OK
.
----------------------------------------------------------------------
Ran 1 test in 0.075s

OK
... etc
```

## Context

For context, the current ctypes definition for token_user has an opaque ctype ref:

https://github.com/rapid7/metasploit-payloads/blob/1432ebbba30c8b46168e8dc737605a59487d91ce/python/meterpreter/ext_server_stdapi.py#L333-L335

https://github.com/rapid7/metasploit-payloads/blob/1432ebbba30c8b46168e8dc737605a59487d91ce/python/meterpreter/ext_server_stdapi.py#L350-L351

And I believe the issue was caused by the implementation of `ctstruct_unpack` not doing a deep copy of the SID pointer:

https://github.com/rapid7/metasploit-payloads/blob/1432ebbba30c8b46168e8dc737605a59487d91ce/python/meterpreter/ext_server_stdapi.py#L876-L880

Note that technically the Sid should be:

```python
class SID_IDENTIFIER_AUTHORITY(ctypes.Structure):
    _fields_ = [
        ("value", ctypes.c_byte * 6)
    ]

class SID(ctypes.Structure):
    _fields_ = [
        ("Revision", ctypes.c_byte),
        ("SubAuthorityCount", ctypes.c_byte),
        ("IdentifierAuthority", ctypes.POINTER(SID_IDENTIFIER_AUTHORITY))
    ]

class SID_AND_ATTRIBUTES(ctypes.Structure):
    _fields_ = [("Sid", ctypes.POINTER(SID)),
        ("Attributes", ctypes.c_uint32)]

class TOKEN_USER(ctypes.Structure):
    _fields_ = [("User", SID_AND_ATTRIBUTES)]
```

I believe `ctypes.memcopy` wasn't handling that scenario correctly, leading to potential failures. For now I just grabbed the SID bytes directly out of the user_token instead of passing the pointer around.