### PR TITLE
Update extapi OpenClipboard to support retrying if acquiring the lock failed

### DIFF
--- a/c/meterpreter/source/extensions/extapi/clipboard.c
+++ b/c/meterpreter/source/extensions/extapi/clipboard.c
@@ -258,7 +258,7 @@ DWORD initialise_clipboard()
 }
 
 /*!
- * @brief Attempt to open the clipboard. If opening the clipboard fails, it will be retried until success or failure.
+ * @brief Attempt to open the clipboard. If opening the clipboard fails, it will be retried until max_retry_count is hit, or success occurs.
  * @param hWndNewOwner handle to the window to be associated with the open clipboard. If this parameter is NULL, the open clipboard is associated with the current task.
  * @retval TRUE if the clipboard has been opened
  * @retval FALSE if the clipboard has not been opened

--- a/c/meterpreter/source/extensions/extapi/clipboard.c
+++ b/c/meterpreter/source/extensions/extapi/clipboard.c
@@ -258,6 +258,27 @@ DWORD initialise_clipboard()
 }
 
 /*!
+ * @brief Attempt to open the clipboard. If opening the clipboard fails, it will be retried until success or failure.
+ * @param hWndNewOwner handle to the window to be associated with the open clipboard. If this parameter is NULL, the open clipboard is associated with the current task.
+ * @retval TRUE if the clipboard has been opened
+ * @retval FALSE if the clipboard has not been opened
+ */
+BOOL open_clipboard_with_retries(HWND hWndNewOwner) {
+	int max_retry_count = 5;
+	for (int i = 0; i < max_retry_count; i++) {
+		if (i > 0) {
+			dprintf("[EXTAPI CLIPBOARD] Failed to OpenClipboard, sleeping before trying again");
+			Sleep(100);
+		}
+
+		if (pOpenClipboard(hWndNewOwner)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+/*!
  * @brief Clean up the list of captures in the given list of captures.
  * @param pCaptureList Pointer to the list of captures to clean up.
  * @param bRemoveLock If \c TRUE, remove the list capture lock.
@@ -573,7 +594,7 @@ DWORD capture_clipboard(BOOL bCaptureImageData, ClipboardCapture** ppCapture)
 	do
 	{
 		// Try to get a lock on the clipboard
-		if (!pOpenClipboard(NULL))
+		if (!open_clipboard_with_retries(NULL))
 		{
 			dwResult = GetLastError();
 			BREAK_WITH_ERROR("[EXTAPI CLIPBOARD] Unable to open the clipboard", dwResult);
@@ -1018,7 +1039,7 @@ DWORD request_clipboard_set_data(Remote *remote, Packet *packet)
 		pGlobalUnlock(hClipboardData);
 
 		// Try to get a lock on the clipboard
-		if (!pOpenClipboard(NULL))
+		if (!open_clipboard_with_retries(NULL))
 		{
 			dwResult = GetLastError();
 			BREAK_WITH_ERROR("[EXTAPI CLIPBOARD] Unable to open the clipboard", dwResult);


### PR DESCRIPTION
Other applications may have access to the clipboard lock when Meterpreter attempts to acquire the [OpenClipboard](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-openclipboard) lock. When failing to acquire the clipboard lock, we'll now retry $x amount of times before succeeding or failing.

The issue was initially spotted as part of the [extapi](https://github.com/rapid7/metasploit-framework/blob/5157897412bbb6f21ca8e883f913a8e13638b4e0/test/modules/post/test/extapi.rb#L76-L90) test suite failing

![image](https://github.com/rapid7/metasploit-payloads/assets/60357436/0f7be80b-ec0d-4d15-a909-8beb48d40815)

We also noticed another race condition were taking a screenshot in the test suite can cause the clipboard to still be locked for a while, but msfconsole's test suite calls `get_data` on the clipboard too soon - causing it to fail.

This PR wraps the `OpenClipboard` failure with additional sleep/retry logic. We choose 100 milliseconds arbitrarily, we could probably exponentially backoff.

The test suite consistently passes locally now, but might not be long enough of a wait for CI. We'll decide what to do if the flakey test suite persist on CI - i.e. we might require some extra retry logic built into the msfconsole test suite itself.

### Replication

- Open a `windows/meterpreter/reverse_tcp` session
- `loadpath test/modules`
- `use test/extapi`
- Verify `repeat -n 100 run session=-1` doesn't fail (as frequently?)