### PR TITLE
fix androidpayload dump_contacts failed in Android 10 or higher

### DIFF
--- a/java/androidpayload/library/src/com/metasploit/meterpreter/android/android_dump_contacts.java
+++ b/java/androidpayload/library/src/com/metasploit/meterpreter/android/android_dump_contacts.java
@@ -35,7 +35,7 @@ public class android_dump_contacts implements Command {
         ContentResolver cr = AndroidMeterpreter.getContext()
                 .getContentResolver();
 
-        if (Integer.parseInt(Build.VERSION.RELEASE.substring(0, 1)) >= 2) {
+        if (Integer.parseInt(Build.VERSION.RELEASE.split("\\.")[0]) >= 2) {
             Uri ContactUri = ContactsContract.Contacts.CONTENT_URI;
             Uri PhoneUri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI;
             Uri EmailUri = ContactsContract.CommonDataKinds.Email.CONTENT_URI;


### PR DESCRIPTION
if android payload runs on phones with Android 10 or above, dump_contacts command will return "No contacts were found!" even if there are contacts on the phone. 
beacause only the first number of android build version is selected and this if statement`if (Integer.parseInt(Build.VERSION.RELEASE.substring(0, 1)) >= 2) ` will always return false.