### PR TITLE
Fix python unittest deprecation warning

### DIFF
--- a/python/meterpreter/tests/test_ext_server_stdapi.py
+++ b/python/meterpreter/tests/test_ext_server_stdapi.py
@@ -73,11 +73,11 @@ class ExtServerStdApiTest(unittest.TestCase):
         self.assertIsInstance(result[1], bytes)
 
     def assertRegex(self, text, regexp, msg=None):
-        # Python 2.7
-        if self.assertRegexpMatches:
-            self.assertRegexpMatches(text, regexp, msg)
+        if hasattr(super(self.__class__.__bases__[0], self), 'assertRegex'):
+            super(self.__class__.__bases__[0], self).assertRegex(text, regexp, msg)
         else:
-            super().assertRegex(text, regexp, msg)
+            # Python 2.7 fallback
+            self.assertRegexpMatches(text, regexp, msg)
 
 
 class ExtServerStdApiNetworkTest(ExtServerStdApiTest):


### PR DESCRIPTION
Fixes the following warning:

```
python3 ./tests/test_ext_server_stdapi.py             
.........s/Users/user/metasploit-payloads/python/meterpreter/./tests/test_ext_server_stdapi.py:78: DeprecationWarning: Please use assertRegex instead.
  self.assertRegexpMatches(text, regexp, msg)
.
----------------------------------------------------------------------
Ran 11 tests in 0.871s

OK (skipped=1)

```

After:

```
python3 ./tests/test_ext_server_stdapi.py
.........s.
----------------------------------------------------------------------
Ran 11 tests in 0.854s

OK (skipped=1)

```
