### PR TITLE
Add Rake task to generate manifest

### DIFF
--- a/gem/.gitignore
+++ b/gem/.gitignore
@@ -41,3 +41,6 @@ data/*
 # never include private bins!
 # If you're interested in these, consider http://metasploit.pro
 data/meterpreter/ext_server_pivot.*
+
+manifest
+manifest.uuid

--- a/gem/Rakefile
+++ b/gem/Rakefile
@@ -1,4 +1,5 @@
 require "bundler/gem_tasks"
+require 'openssl'
 
 c_source = "../c/meterpreter/"
 java_source = "../java"
@@ -6,6 +7,9 @@ php_source = "../php/meterpreter/"
 python_source = "../python/meterpreter/"
 dest = "./data"
 meterpreter_dest = "./data/meterpreter"
+manifest_file = './manifest'
+manifest_uuid_file = './manifest.uuid'
+manifest_hash_type = 'SHA3-256'
 
 platform_config = {
   :windows => {
@@ -90,7 +94,14 @@ task :python_copy do
   copy_files(platform_config[:python], meterpreter_dest)
 end
 
-task :win_prep => [:create_dir, :win_compile, :win_copy] do
+task :create_manifest do
+  all_data_files = ::Dir.glob(dest + '/**/*').select { |f| ::File.file?(f) }.sort
+  manifest = all_data_files.map { |f| [f, manifest_hash_type, ::OpenSSL::Digest.new(manifest_hash_type, ::File.binread(f))].join(':') }
+  ::File.binwrite(manifest_file, manifest.join("\n"))
+  ::File.binwrite(manifest_uuid_file, ::OpenSSL::Digest.new(manifest_hash_type, ::File.binread(manifest_file)))
+end
+
+task :win_prep => [:create_dir, :win_compile, :win_copy, :create_manifest] do
 end
 
 task :java_prep => [:create_dir, :java_compile, :java_copy] do
@@ -102,7 +113,7 @@ end
 task :python_prep => [:create_dir, :python_copy] do
 end
 
-task :default => [:python_prep, :php_prep, :java_prep] do
+task :default => [:python_prep, :php_prep, :java_prep, :create_manifest] do
 end
 
 # Override tag_version in bundler-#.#.#/lib/bundler/gem_helper.rb to force signed tags


### PR DESCRIPTION
This PR is a pre-requisite for #673 
This PR adds a Rake task to generate a manifest allowing us to keep track of all the necessary Meterpreter files in this gem.

## Example:
### `manifest`
```
./data/meterpreter/dump_sam.x64.debug.dll:SHA3-256:6326bcf12074a1b3c987d4ef8a590f746879a07c4485e34bd2bd7d0e1aa2f08b
./data/meterpreter/dump_sam.x64.dll:SHA3-256:fe8a1a4bf17988e9b9457b8058c500dda9fb7cf8d2baff900d297a34711534d8
./data/meterpreter/dump_sam.x86.debug.dll:SHA3-256:ef28b3971032a0a532ad67971b86247aa4572ef5c320e013833ababc4761dac7
./data/meterpreter/dump_sam.x86.dll:SHA3-256:58f2e89466287199affbfc07dd05acba94fbd9cc172826cc8543571b11d2f717
./data/meterpreter/elevator.x64.debug.dll:SHA3-256:6c8e412d550f343453b8f327af3e7bcc4d81c4d952fc414dff766095134eb5ab
./data/meterpreter/elevator.x64.dll:SHA3-256:f1dce39c09da8ecb361d401ace57c76c30bbacb2943b4f49256c6f80aa4ed65f
./data/meterpreter/elevator.x86.debug.dll:SHA3-256:03bb05b0d58289e2a8ee00402f45ef355ef9078228bdbd16f391c858a07475fc
./data/meterpreter/elevator.x86.dll:SHA3-256:b0173d8a5e433b621294e8e235c4d6f1587dfab34e19f862d111a6814d272e2e
```

### `manifest.uuid`
```
25b9ff7f3931007a47e3c21e975244404cf159b3237e8d54ac37934fc1a77cae
```

## Testing
- [ ] `bundle install`
- [ ] `bundle exec 'rake create_manifest'`
- [ ] Confirm that the `manifest` file is created and contains a list of all Meterpreter files
- [ ] Confirm that the `manifest.uuid` file contains the SHA3-256 hash for the `manifest` file