### PR TITLE
Fix Android compilation issues - Add Java parent to AndroidPayload

### DIFF
--- a/java/androidpayload/app/pom.xml
+++ b/java/androidpayload/app/pom.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.metasploit</groupId>
 	<artifactId>Metasploit-AndroidPayload</artifactId>
 	<version>1-SNAPSHOT</version>
 	<packaging>apk</packaging>
 	<name>AndroidPayload for Metasploit</name>
+	<parent>
+		<groupId>com.metasploit</groupId>
+		<artifactId>Metasploit-JavaPayload-parent</artifactId>
+		<version>1-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 
 	<properties>
 		<deploy.path>../../metasploit-framework</deploy.path>

--- a/java/androidpayload/library/pom.xml
+++ b/java/androidpayload/library/pom.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.metasploit</groupId>
 	<artifactId>Metasploit-AndroidLibrary</artifactId>
 	<version>1-SNAPSHOT</version>
 	<packaging>apk</packaging>
 	<name>Android Meterpreter</name>
+	<parent>
+		<groupId>com.metasploit</groupId>
+		<artifactId>Metasploit-JavaPayload-parent</artifactId>
+		<version>1-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 
 	<properties>
 		<deploy.path>../../metasploit-framework</deploy.path>


### PR DESCRIPTION
This PR is necessary to fix Java compiling issues on the `rapid7/msf-ubuntu-x64-meterpreter:2020_06` image. The old `rapid7/build:meterpreter` image has not been used due to HTTP 501 errors.

The Rakefile `rake java_prep` task which was failing calls off to `mvn package -Ddeploy.path=output -Dandroid.sdk.path=$ANDROID_HOME -Dandroid.ndk.path=$ANDROID_NDK_HOME -Dandroid.release=true -q -P deploy` from the `metasploit-payloads/java` directory.

Previously, this was failing with:
<details>

```
10:19:54 -------------------------------------------------------
10:19:54  T E S T S
10:19:54 -------------------------------------------------------
10:19:55 Running javapayload.stage.MeterpreterTest
10:19:55 Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.113 sec
10:19:55 Running javapayload.stage.ShellTest
10:19:55 Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 sec
10:19:55 Running metasploit.PayloadTest
10:19:58 Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.66 sec
10:19:58 
10:19:58 Results :
10:19:58 
10:19:58 Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
10:19:58 
10:20:21 [[1;31mERROR[m] Failed to execute goal [32mcom.simpligility.maven.plugins:android-maven-plugin:4.4.3:dex[m [1m(default-dex)[m on project [36mMetasploit-AndroidPayload[m: [1;31m[m: MojoExecutionException: ANDROID-040-001: Could not execute: Command = /bin/sh -c cd '/metasploit-payloads/java/androidpayload/app' && '/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java' '-Xmx1024M' '-jar' '/usr/local/android-sdk/build-tools/23.0.0/lib/dx.jar' '--dex' '--output=/metasploit-payloads/java/androidpayload/app/target/classes.dex' '/metasploit-payloads/java/androidpayload/app/target/Metasploit-AndroidPayload_obfuscated.jar', Result = 1 -> [1m[Help 1][m
10:20:21 [[1;31mERROR[m] 
10:20:21 [[1;31mERROR[m] To see the full stack trace of the errors, re-run Maven with the [1m-e[m switch.
10:20:21 [[1;31mERROR[m] Re-run Maven using the [1m-X[m switch to enable full debug logging.
10:20:21 [[1;31mERROR[m] 
10:20:21 [[1;31mERROR[m] For more information about the errors and possible solutions, please read the following articles:
10:20:21 [[1;31mERROR[m] [1m[Help 1][m http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
10:20:21 [[1;31mERROR[m] 
10:20:21 [[1;31mERROR[m] After correcting the problems, you can resume the build with the command
10:20:21 [[1;31mERROR[m]   [1mmvn <args> -rf :Metasploit-AndroidPayload[m
10:20:21 Copying: ../java/output/data/meterpreter/meterpreter.jar -> ./data/meterpreter/meterpreter.jar
10:20:21 Copying: ../java/output/data/meterpreter/ext_server_stdapi.jar -> ./data/meterpreter/ext_server_stdapi.jar
10:20:21 rake aborted!
10:20:21 Errno::ENOENT: No such file or directory @ rb_check_realpath_internal - ../java/output/data/android
10:20:21 /metasploit-payloads/gem/Rakefile:85:in `block in <top (required)>'
10:20:21 /usr/share/rubygems-integration/all/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
10:20:21 Tasks: TOP => java_prep => java_copy
```

</details>

Running the failed command manually results in `bad class file magic (cafebabe) or version (0034.0000)`:
<details>

```bash
jenkins@37ea3c03cc50:/metasploit-payloads/java$ /bin/sh -c cd '/metasploit-payloads/java/androidpayload/app' && '/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java' '-Xmx1024M' '-jar' '/usr/local/android-sdk/build-tools/23.0.0/lib/dx.jar' '--dex' '--output=/metasploit-payloads/java/androidpayload/app/target/classes.dex' '/metasploit-payloads/java/androidpayload/app/target/Metasploit-AndroidPayload_obfuscated.jar'

UNEXPECTED TOP-LEVEL EXCEPTION:
java.lang.RuntimeException: Exception parsing classes
        at com.android.dx.command.dexer.Main.processClass(Main.java:752)
        at com.android.dx.command.dexer.Main.processFileBytes(Main.java:718)
        at com.android.dx.command.dexer.Main.access$1200(Main.java:85)
        at com.android.dx.command.dexer.Main$FileBytesConsumer.processFileBytes(Main.java:1645)
        at com.android.dx.cf.direct.ClassPathOpener.processArchive(ClassPathOpener.java:284)
        at com.android.dx.cf.direct.ClassPathOpener.processOne(ClassPathOpener.java:166)
        at com.android.dx.cf.direct.ClassPathOpener.process(ClassPathOpener.java:144)
        at com.android.dx.command.dexer.Main.processOne(Main.java:672)
        at com.android.dx.command.dexer.Main.processAllFiles(Main.java:574)
        at com.android.dx.command.dexer.Main.runMonoDex(Main.java:311)
        at com.android.dx.command.dexer.Main.run(Main.java:277)
        at com.android.dx.command.dexer.Main.main(Main.java:245)
        at com.android.dx.command.Main.main(Main.java:106)
Caused by: com.android.dx.cf.iface.ParseException: bad class file magic (cafebabe) or version (0034.0000)
        at com.android.dx.cf.direct.DirectClassFile.parse0(DirectClassFile.java:472)
        at com.android.dx.cf.direct.DirectClassFile.parse(DirectClassFile.java:406)
        at com.android.dx.cf.direct.DirectClassFile.parseToInterfacesIfNecessary(DirectClassFile.java:388)
        at com.android.dx.cf.direct.DirectClassFile.getMagic(DirectClassFile.java:251)
        at com.android.dx.command.dexer.Main.parseClass(Main.java:764)
        at com.android.dx.command.dexer.Main.access$1500(Main.java:85)
        at com.android.dx.command.dexer.Main$ClassParserTask.call(Main.java:1684)
        at com.android.dx.command.dexer.Main.processClass(Main.java:749)
        ... 12 more
1 error; aborting
```

</details>

## Before
<details>

```bash
jenkins@38e1e836a6a5:/metasploit-payloads/gem$ rake java_prep

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running javapayload.stage.ShellTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.093 sec
Running javapayload.stage.MeterpreterTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.03 sec
Running metasploit.PayloadTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.636 sec

Results :

Tests run: 7, Failures: 0, Errors: 0, Skipped: 0

[ERROR] Failed to execute goal com.simpligility.maven.plugins:android-maven-plugin:4.4.3:dex (default-dex) on project Metasploit-AndroidPayload: : MojoExecutionException: ANDROID-040-001: Could not execute: Command = /bin/sh -c cd '/metasploit-payloads/java/androidpayload/app' && '/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java' '-Xmx1024M' '-jar' '/usr/local/android-sdk/build-tools/23.0.0/lib/dx.jar' '--dex' '--output=/metasploit-payloads/java/androidpayload/app/target/classes.dex' '/metasploit-payloads/java/androidpayload/app/target/Metasploit-AndroidPayload_obfuscated.jar', Result = 1 -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :Metasploit-AndroidPayload
Copying: ../java/output/data/meterpreter/ext_server_stdapi.jar -> ./data/meterpreter/ext_server_stdapi.jar
Copying: ../java/output/data/meterpreter/meterpreter.jar -> ./data/meterpreter/meterpreter.jar
```

</details>

## After
<details>

```bash
jenkins@38e1e836a6a5:/metasploit-payloads/gem$ rake java_prep

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running javapayload.stage.ShellTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.096 sec
Running javapayload.stage.MeterpreterTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 sec
Running metasploit.PayloadTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.627 sec

Results :

Tests run: 7, Failures: 0, Errors: 0, Skipped: 0

Copying: ../java/output/data/meterpreter/ext_server_stdapi.jar -> ./data/meterpreter/ext_server_stdapi.jar
Copying: ../java/output/data/meterpreter/meterpreter.jar -> ./data/meterpreter/meterpreter.jar
```
</details>