### PR TITLE
Ensure manifest files are available in gem

### DIFF
--- a/gem/metasploit-payloads.gemspec
+++ b/gem/metasploit-payloads.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files`.split("\n")
   spec.files        += Dir['data/**/*']
+  spec.files        += Dir['manifest', 'manifest.uuid']
   spec.executables   = []
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-payloads/pull/675

## Before

The manifest and manifest.uuid file are missing from the gem

## After

The manifest and manifest.uuid file is now present in the gem

```
$ ls -la | grep manifest
-rw-r--r--@   1 user  staff     11556 29 Sep 11:30 manifest
-rw-r--r--@   1 user  staff        64 29 Sep 11:30 manifest.uuid
```