### PR TITLE
Add at rest encryption to Meterpreter payloads

### DIFF
--- a/gem/Rakefile
+++ b/gem/Rakefile
@@ -46,13 +46,28 @@ platform_config = {
   }
 }
 
+def chacha20_encrypt(contents: '')
+  cipher = ::OpenSSL::Cipher.new('chacha20')
+  cipher.encrypt
+  cipher.iv = 'EncryptedPayload'
+  cipher.key = 'Rapid7MetasploitEncryptedPayload'
+
+  encrypted_contents = 'encrypted_payload_chacha20_v1'
+  encrypted_contents << cipher.update(contents)
+  encrypted_contents << cipher.final
+
+  encrypted_contents
+end
+
 def copy_files(cnf, meterpreter_dest)
   cnf[:sources].each do |f|
     cnf[:extensions].each do |ext|
       Dir.glob("#{f}/*.#{ext}").each do |bin|
         target = File.join(meterpreter_dest, File.basename(bin))
         print("Copying: #{bin} -> #{target}\n")
-        FileUtils.cp(bin, target)
+        contents = ::File.binread(::File.expand_path(bin))
+        encrypted_contents = chacha20_encrypt(contents: contents)
+        ::File.binwrite(::File.expand_path(target), encrypted_contents)
       end
     end
   end

--- a/gem/Rakefile
+++ b/gem/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/gem_tasks"
 require 'openssl'
+require 'metasploit-payloads/crypto'
 
 c_source = "../c/meterpreter/"
 java_source = "../java"
@@ -46,19 +47,6 @@ platform_config = {
   }
 }
 
-def chacha20_encrypt(contents: '')
-  cipher = ::OpenSSL::Cipher.new('chacha20')
-  cipher.encrypt
-  cipher.iv = 'EncryptedPayload'
-  cipher.key = 'Rapid7MetasploitEncryptedPayload'
-
-  encrypted_contents = 'encrypted_payload_chacha20_v1'
-  encrypted_contents << cipher.update(contents)
-  encrypted_contents << cipher.final
-
-  encrypted_contents
-end
-
 def copy_files(cnf, meterpreter_dest)
   cnf[:sources].each do |f|
     cnf[:extensions].each do |ext|
@@ -66,7 +54,7 @@ def copy_files(cnf, meterpreter_dest)
         target = File.join(meterpreter_dest, File.basename(bin))
         print("Copying: #{bin} -> #{target}\n")
         contents = ::File.binread(::File.expand_path(bin))
-        encrypted_contents = chacha20_encrypt(contents: contents)
+        encrypted_contents = ::MetasploitPayloads::Crypto.encrypt(plaintext: contents)
         ::File.binwrite(::File.expand_path(target), encrypted_contents)
       end
     end

--- a/gem/lib/metasploit-payloads.rb
+++ b/gem/lib/metasploit-payloads.rb
@@ -50,7 +50,7 @@ module MetasploitPayloads
         # self.path can return a path to the gem data, or user's local data.
         bundled_file = out_path.start_with?(data_directory)
         if bundled_file
-          file_hash_match = (::OpenSSL::Digest.new(hash_type, self.read(filename)).to_s == hash)
+          file_hash_match = (::OpenSSL::Digest.new(hash_type, ::File.binread(out_path)).to_s == hash)
           unless file_hash_match
             e = ::MetasploitPayloads::HashMismatchError.new(out_path)
             manifest_errors.append({ path: e.path, error: e })

--- a/gem/lib/metasploit-payloads/crypto.rb
+++ b/gem/lib/metasploit-payloads/crypto.rb
@@ -2,10 +2,10 @@ require 'openssl'
 
 module MetasploitPayloads
   module Crypto
-    CIPHER_NAME = 'chacha20'.freeze
-    IV = 'EncryptedPayload'.freeze # 16 bytes
-    KEY = 'Rapid7MetasploitEncryptedPayload'.freeze # 32 bytes
-    ENCRYPTED_PAYLOAD_HEADER = 'encrypted_payload_chacha20_v1'.freeze
+    CIPHER_NAME = 'chacha20'.b.freeze
+    IV = 'EncryptedPayload'.b.freeze # 16 bytes
+    KEY = 'Rapid7MetasploitEncryptedPayload'.b.freeze # 32 bytes
+    ENCRYPTED_PAYLOAD_HEADER = 'encrypted_payload_chacha20_v1'.ljust(64, '_').b.freeze
 
     def self.encrypt(plaintext: '')
       raise ::ArgumentError, 'Unable to encrypt plaintext: ' << plaintext, caller unless plaintext.to_s

--- a/gem/lib/metasploit-payloads/crypto.rb
+++ b/gem/lib/metasploit-payloads/crypto.rb
@@ -7,11 +7,11 @@ module MetasploitPayloads
         name: 'chacha20'.b,
         version: 1,
         iv: {
-          value: 'EncryptedPayload'.b, # 16 bytes
+          value: "\x52\x25\xd7\xab\x52\x8f\x3f\xf8\x94\x97\x08\x42\x33\xb9\xd3\xb6".b, # 16 bytes
           version: 1
         },
         key: {
-          value: 'Rapid7MetasploitEncryptedPayload'.b, # 32 bytes
+          value: "\x28\x39\x97\x4c\x95\x11\x9d\x42\x6c\x8b\xff\x43\x3e\x5d\x3c\x33\x1b\x95\xd3\xea\xeb\xc9\xae\x71\x0a\x36\xe7\x98\x3d\x9d\x09\x52".b, # 32 bytes
           version: 1
         }
       }

--- a/gem/lib/metasploit-payloads/crypto.rb
+++ b/gem/lib/metasploit-payloads/crypto.rb
@@ -1,0 +1,44 @@
+require 'openssl'
+
+module MetasploitPayloads
+  module Crypto
+    CIPHER_NAME = 'chacha20'.freeze
+    IV = 'EncryptedPayload'.freeze # 16 bytes
+    KEY = 'Rapid7MetasploitEncryptedPayload'.freeze # 32 bytes
+    ENCRYPTED_PAYLOAD_HEADER = 'encrypted_payload_chacha20_v1'.freeze
+
+    def self.encrypt(plaintext: '')
+      raise ::ArgumentError, 'Unable to encrypt plaintext: ' << plaintext, caller unless plaintext.to_s
+
+      cipher = ::OpenSSL::Cipher.new(CIPHER_NAME)
+
+      cipher.encrypt
+      cipher.iv = IV
+      cipher.key = KEY
+
+      output = ENCRYPTED_PAYLOAD_HEADER.dup
+      output << cipher.update(plaintext)
+      output << cipher.final
+
+      output
+    end
+
+    def self.decrypt(ciphertext: '')
+      raise ::ArgumentError, 'Unable to decrypt ciphertext: ' << ciphertext, caller unless ciphertext.to_s
+
+      cipher = ::OpenSSL::Cipher.new(CIPHER_NAME)
+
+      cipher.decrypt
+      cipher.iv = IV
+      cipher.key = KEY
+
+      # Remove encrypted header if present
+      ciphertext = ciphertext.sub(ENCRYPTED_PAYLOAD_HEADER, '')
+
+      output = cipher.update(ciphertext)
+      output << cipher.final
+
+      output
+    end
+  end
+end

--- a/gem/lib/metasploit-payloads/crypto.rb
+++ b/gem/lib/metasploit-payloads/crypto.rb
@@ -2,19 +2,41 @@ require 'openssl'
 
 module MetasploitPayloads
   module Crypto
-    CIPHER_NAME = 'chacha20'.b.freeze
-    IV = 'EncryptedPayload'.b.freeze # 16 bytes
-    KEY = 'Rapid7MetasploitEncryptedPayload'.b.freeze # 32 bytes
-    ENCRYPTED_PAYLOAD_HEADER = 'encrypted_payload_chacha20_v1'.ljust(64, '_').b.freeze
+    CIPHERS = {
+      chacha20: {
+        name: 'chacha20'.b,
+        version: 1,
+        iv: {
+          value: 'EncryptedPayload'.b, # 16 bytes
+          version: 1
+        },
+        key: {
+          value: 'Rapid7MetasploitEncryptedPayload'.b, # 32 bytes
+          version: 1
+        }
+      }
+    }.freeze
+    CURRENT_CIPHER = CIPHERS[:chacha20]
+    CIPHER_VERSION = CURRENT_CIPHER[:version]
+    KEY_VERSION = CURRENT_CIPHER[:key][:version]
+    IV_VERSION = CURRENT_CIPHER[:iv][:version]
+    # Binary String, unsigned char, unsigned char, unsigned char
+    ENCRYPTED_PAYLOAD_HEADER = ['msf', CIPHER_VERSION, IV_VERSION, KEY_VERSION].pack('A*CCC')
+
+    private_constant :CIPHERS
+    private_constant :CURRENT_CIPHER
+    private_constant :CIPHER_VERSION
+    private_constant :KEY_VERSION
+    private_constant :IV_VERSION
 
     def self.encrypt(plaintext: '')
       raise ::ArgumentError, 'Unable to encrypt plaintext: ' << plaintext, caller unless plaintext.to_s
 
-      cipher = ::OpenSSL::Cipher.new(CIPHER_NAME)
+      cipher = ::OpenSSL::Cipher.new(CURRENT_CIPHER[:name])
 
       cipher.encrypt
-      cipher.iv = IV
-      cipher.key = KEY
+      cipher.iv = CURRENT_CIPHER[:iv][:value]
+      cipher.key = CURRENT_CIPHER[:key][:value]
 
       output = ENCRYPTED_PAYLOAD_HEADER.dup
       output << cipher.update(plaintext)
@@ -26,11 +48,11 @@ module MetasploitPayloads
     def self.decrypt(ciphertext: '')
       raise ::ArgumentError, 'Unable to decrypt ciphertext: ' << ciphertext, caller unless ciphertext.to_s
 
-      cipher = ::OpenSSL::Cipher.new(CIPHER_NAME)
+      cipher = ::OpenSSL::Cipher.new(CURRENT_CIPHER[:name])
 
       cipher.decrypt
-      cipher.iv = IV
-      cipher.key = KEY
+      cipher.iv = CURRENT_CIPHER[:iv][:value]
+      cipher.key = CURRENT_CIPHER[:key][:value]
 
       # Remove encrypted header if present
       ciphertext = ciphertext.sub(ENCRYPTED_PAYLOAD_HEADER, '')

--- a/gem/spec/metasploit_payloads/crypto_spec.rb
+++ b/gem/spec/metasploit_payloads/crypto_spec.rb
@@ -3,7 +3,7 @@ require 'metasploit-payloads'
 
 RSpec.describe ::MetasploitPayloads::Crypto do
   describe '#encrypt' do
-    let(:encrypted_header) { "encrypted_payload_chacha20_v1".ljust(64, '_').b }
+    let(:encrypted_header) { ::MetasploitPayloads::Crypto::ENCRYPTED_PAYLOAD_HEADER }
     let(:plaintext) { "Hello World!".b }
     let(:ciphertext) { encrypted_header + "\\c\xB6N\x95\xE58\x8D\xDF\xBF4c".b }
 

--- a/gem/spec/metasploit_payloads/crypto_spec.rb
+++ b/gem/spec/metasploit_payloads/crypto_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ::MetasploitPayloads::Crypto do
   describe '#encrypt' do
     let(:encrypted_header) { ::MetasploitPayloads::Crypto::ENCRYPTED_PAYLOAD_HEADER }
     let(:plaintext) { "Hello World!".b }
-    let(:ciphertext) { encrypted_header + "\\c\xB6N\x95\xE58\x8D\xDF\xBF4c".b }
+    let(:ciphertext) { encrypted_header + "\x89:^r\xC1\xC9\xD9\xA1\xDC\xEB\xBFm".b }
 
     it 'can encrypt plaintext' do
       expect(described_class.encrypt(plaintext: plaintext)).to eq ciphertext

--- a/gem/spec/metasploit_payloads/crypto_spec.rb
+++ b/gem/spec/metasploit_payloads/crypto_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'metasploit-payloads'
+
+RSpec.describe ::MetasploitPayloads::Crypto do
+  describe '#encrypt' do
+    let(:encrypted_header) { "encrypted_payload_chacha20_v1".b }
+    let(:plaintext) { "Hello World!".b }
+    let(:ciphertext) { encrypted_header + "\\c\xB6N\x95\xE58\x8D\xDF\xBF4c".b }
+
+    it 'can encrypt plaintext' do
+      expect(described_class.encrypt(plaintext: plaintext)).to eq ciphertext
+    end
+
+    it 'can decrypt ciphertext' do
+      expect(described_class.decrypt(ciphertext: ciphertext)).to eq plaintext
+    end
+
+    it 'is idempotent' do
+      expect(described_class.decrypt(ciphertext: described_class.encrypt(plaintext: plaintext))).to eq plaintext
+    end
+  end
+end

--- a/gem/spec/metasploit_payloads/crypto_spec.rb
+++ b/gem/spec/metasploit_payloads/crypto_spec.rb
@@ -3,7 +3,7 @@ require 'metasploit-payloads'
 
 RSpec.describe ::MetasploitPayloads::Crypto do
   describe '#encrypt' do
-    let(:encrypted_header) { "encrypted_payload_chacha20_v1".b }
+    let(:encrypted_header) { "encrypted_payload_chacha20_v1".ljust(64, '_').b }
     let(:plaintext) { "Hello World!".b }
     let(:ciphertext) { encrypted_header + "\\c\xB6N\x95\xE58\x8D\xDF\xBF4c".b }
 

--- a/gem/spec/metasploit_payloads/metasploit_payloads_spec.rb
+++ b/gem/spec/metasploit_payloads/metasploit_payloads_spec.rb
@@ -226,8 +226,6 @@ RSpec.describe ::MetasploitPayloads do
         bundled_file_path = ::MetasploitPayloads.expand(::MetasploitPayloads.data_directory, sample_file[:name])
         error = ::MetasploitPayloads::HashMismatchError.new(bundled_file_path)
         allow(::MetasploitPayloads).to receive(:path).with(sample_file[:name]).and_return(bundled_file_path)
-        # Second call to self.read takes in the splat operator
-        allow(::MetasploitPayloads).to receive(:path).with([sample_file[:name]]).and_return(bundled_file_path)
         allow(::File).to receive(:binread).with(bundled_file_path).and_return('sample_mismatched_contents')
 
         expect(subject.manifest_errors).to include({ path: bundled_file_path, error: error })


### PR DESCRIPTION
This PR adds in the generation of encrypted payload files using ChaCha20.
The files are automatically encrypted when the Rake tasks are called.
Using `#read` allows for the usage of encrypted and plain-text payloads as before.

ChaCha20 was chosen based on the following benchmarks on my developer machine:

First run:
<details>

```ruby
~/Programming/benchmarks via 🐍 v3.11.5 via 💎 v3.0.5 
❯ ruby ./src.rb    
Warming up --------------------------------------
   plaintext binread     1.468k i/100ms
aes encrypted read (decrypting)
                       877.000  i/100ms
chacha20 encrypted read (decrypting)
                       785.000  i/100ms
rc4 encrypted read (decrypting)
                       459.000  i/100ms
Calculating -------------------------------------
   plaintext binread     14.506k (±10.1%) i/s -     71.932k in   5.009154s
aes encrypted read (decrypting)
                          8.835k (±12.0%) i/s -     43.850k in   5.034825s
chacha20 encrypted read (decrypting)
                          6.886k (±14.0%) i/s -     33.755k in   5.004575s
rc4 encrypted read (decrypting)
                          3.876k (±11.4%) i/s -     19.278k in   5.041633s

Comparison:
   plaintext binread:    14506.2 i/s
aes encrypted read (decrypting):     8835.0 i/s - 1.64x  slower
chacha20 encrypted read (decrypting):     6885.6 i/s - 2.11x  slower
rc4 encrypted read (decrypting):     3876.0 i/s - 3.74x  slower
```

</details>

Second run:
<details>

```ruby
~/Programming/benchmarks via 🐍 v3.11.5 via 💎 v3.0.5 took 28s 
❯ ruby ./src.rb
Warming up --------------------------------------
   plaintext binread     1.214k i/100ms
aes encrypted read (decrypting)
                       881.000  i/100ms
chacha20 encrypted read (decrypting)
                       801.000  i/100ms
rc4 encrypted read (decrypting)
                       395.000  i/100ms
Calculating -------------------------------------
   plaintext binread     12.861k (± 7.5%) i/s -     64.342k in   5.032598s
aes encrypted read (decrypting)
                          7.570k (±15.3%) i/s -     37.002k in   5.003907s
chacha20 encrypted read (decrypting)
                          7.901k (±12.6%) i/s -     39.249k in   5.051235s
rc4 encrypted read (decrypting)
                          3.951k (±11.1%) i/s -     19.750k in   5.063716s

Comparison:
   plaintext binread:    12861.5 i/s
chacha20 encrypted read (decrypting):     7900.5 i/s - 1.63x  slower
aes encrypted read (decrypting):     7569.5 i/s - 1.70x  slower
rc4 encrypted read (decrypting):     3951.0 i/s - 3.26x  slower
```

</details>