### PR TITLE
Correctly encrypt Java & Android files in Rake task

### DIFF
--- a/gem/Rakefile
+++ b/gem/Rakefile
@@ -21,13 +21,32 @@ platform_config = {
       "dll"
     ]
   },
-  :java => {
+  :java_meterpreter => {
     :sources => [
       "../java/output/data/meterpreter"
     ],
     :extensions => [
       "jar"
     ],
+  },
+  :java_output => {
+    :sources => [
+      "../java/output/data/java"
+    ],
+    :extensions => [
+      "class"
+    ]
+  },
+  :android => {
+    :sources => [
+      "../java/output/data/android"
+    ],
+    :extensions => [
+      "jar",
+      "dex",
+      "xml",
+      "arsc"
+    ]
   },
   :php => {
     :sources => [
@@ -83,10 +102,9 @@ task :win_copy do
 end
 
 task :java_copy do
-  copy_files(platform_config[:java], meterpreter_dest)
-  FileUtils.remove_entry_secure('./java', :force => true)
-  FileUtils.cp_r('../java/output/data/android', dest)
-  FileUtils.cp_r('../java/output/data/java', dest)
+  copy_files(platform_config[:java_meterpreter], meterpreter_dest)
+  copy_files(platform_config[:java_output], dest)
+  copy_files(platform_config[:android], dest)
 end
 
 task :php_copy do

--- a/gem/Rakefile
+++ b/gem/Rakefile
@@ -8,6 +8,8 @@ php_source = "../php/meterpreter/"
 python_source = "../python/meterpreter/"
 dest = "./data"
 meterpreter_dest = "./data/meterpreter"
+android_dest = "./data/android"
+java_dest = "./data/java"
 manifest_file = './manifest'
 manifest_uuid_file = './manifest.uuid'
 manifest_hash_type = 'SHA3-256'
@@ -69,12 +71,16 @@ platform_config = {
 def copy_files(cnf, meterpreter_dest)
   cnf[:sources].each do |f|
     cnf[:extensions].each do |ext|
-      Dir.glob("#{f}/*.#{ext}").each do |bin|
-        target = File.join(meterpreter_dest, File.basename(bin))
+      Dir.glob("#{f}/**/*.#{ext}").each do |bin|
+        f_path = ::Pathname.new(f)
+        bin_path = ::Pathname.new(bin)
+        target = File.join(meterpreter_dest, bin_path.relative_path_from(f_path))
         print("Copying: #{bin} -> #{target}\n")
-        contents = ::File.binread(::File.expand_path(bin))
+        contents = ::File.binread(bin_path)
         encrypted_contents = ::MetasploitPayloads::Crypto.encrypt(plaintext: contents)
-        ::File.binwrite(::File.expand_path(target), encrypted_contents)
+        output = ::Pathname.new(::File.expand_path(target))
+        ::FileUtils.mkdir_p(output.dirname) unless output.dirname.exist?
+        ::File.binwrite(output, encrypted_contents)
       end
     end
   end
@@ -83,6 +89,8 @@ end
 task :create_dir do
   Dir.mkdir(dest) unless Dir.exist?(dest)
   Dir.mkdir(meterpreter_dest) unless Dir.exist?(meterpreter_dest)
+  Dir.mkdir(java_dest) unless Dir.exist?(java_dest)
+  Dir.mkdir(android_dest) unless Dir.exist?(android_dest)
 end
 
 task :win_compile do
@@ -103,8 +111,8 @@ end
 
 task :java_copy do
   copy_files(platform_config[:java_meterpreter], meterpreter_dest)
-  copy_files(platform_config[:java_output], dest)
-  copy_files(platform_config[:android], dest)
+  copy_files(platform_config[:java_output], java_dest)
+  copy_files(platform_config[:android], android_dest)
 end
 
 task :php_copy do


### PR DESCRIPTION
This PR fixes an issue where I didn't correctly encrypt all of the Java & Android files as they had their own file copy logic.

I used `::Dir.glob('**/*').each {|f| p = ::Pathname.new(f); x = ::File.binread(p) if p.file?; puts "#{f} : " + x[0..5] if p.file?; }` to show the header for each payload file in the gem built by Jenkins.
Output:
<details>

```ruby
android/apk/AndroidManifest.xml : msf
android/apk/classes.dex : msf
android/apk/resources.arsc : msf
android/meterpreter.dex : msf
android/meterpreter.jar : msf
android/metstage.jar : msf
android/shell.jar : msf
java/com/metasploit/meterpreter/JarFileClassLoader.class : msf
java/javapayload/stage/Meterpreter.class : msf
java/javapayload/stage/Shell.class : msf
java/javapayload/stage/Stage.class : msf
java/javapayload/stage/StreamForwarder.class : msf
java/metasploit/AESEncryption.class : msf
java/metasploit/JMXPayload.class : msf
java/metasploit/JMXPayloadMBean.class : msf
java/metasploit/Payload.class : msf
java/metasploit/PayloadServlet.class : msf
java/metasploit/PayloadTrustManager.class : msf
java/metasploit/RMILoader.class : msf
java/metasploit/RMIPayload.class : msf
meterpreter/dump_sam.x64.debug.dll : msf
meterpreter/dump_sam.x64.dll : msf
meterpreter/dump_sam.x86.debug.dll : msf
meterpreter/dump_sam.x86.dll : msf
meterpreter/elevator.x64.debug.dll : msf
meterpreter/elevator.x64.dll : msf
meterpreter/elevator.x86.debug.dll : msf
meterpreter/elevator.x86.dll : msf
meterpreter/ext_server_bofloader.x64.debug.dll : msf
meterpreter/ext_server_bofloader.x64.dll : msf
meterpreter/ext_server_bofloader.x86.debug.dll : msf
meterpreter/ext_server_bofloader.x86.dll : msf
meterpreter/ext_server_espia.x64.debug.dll : msf
meterpreter/ext_server_espia.x64.dll : msf
meterpreter/ext_server_espia.x86.debug.dll : msf
meterpreter/ext_server_espia.x86.dll : msf
meterpreter/ext_server_extapi.x64.debug.dll : msf
meterpreter/ext_server_extapi.x64.dll : msf
meterpreter/ext_server_extapi.x86.debug.dll : msf
meterpreter/ext_server_extapi.x86.dll : msf
meterpreter/ext_server_incognito.x64.debug.dll : msf
meterpreter/ext_server_incognito.x64.dll : msf
meterpreter/ext_server_incognito.x86.debug.dll : msf
meterpreter/ext_server_incognito.x86.dll : msf
meterpreter/ext_server_kiwi.x64.debug.dll : msf
meterpreter/ext_server_kiwi.x64.dll : msf
meterpreter/ext_server_kiwi.x86.debug.dll : msf
meterpreter/ext_server_kiwi.x86.dll : msf
meterpreter/ext_server_lanattacks.x64.debug.dll : msf
meterpreter/ext_server_lanattacks.x64.dll : msf
meterpreter/ext_server_lanattacks.x86.debug.dll : msf
meterpreter/ext_server_lanattacks.x86.dll : msf
meterpreter/ext_server_peinjector.x64.debug.dll : msf
meterpreter/ext_server_peinjector.x64.dll : msf
meterpreter/ext_server_peinjector.x86.debug.dll : msf
meterpreter/ext_server_peinjector.x86.dll : msf
meterpreter/ext_server_powershell.x64.debug.dll : msf
meterpreter/ext_server_powershell.x64.dll : msf
meterpreter/ext_server_powershell.x86.debug.dll : msf
meterpreter/ext_server_powershell.x86.dll : msf
meterpreter/ext_server_priv.x64.debug.dll : msf
meterpreter/ext_server_priv.x64.dll : msf
meterpreter/ext_server_priv.x86.debug.dll : msf
meterpreter/ext_server_priv.x86.dll : msf
meterpreter/ext_server_python.x64.debug.dll : msf
meterpreter/ext_server_python.x64.dll : msf
meterpreter/ext_server_python.x86.debug.dll : msf
meterpreter/ext_server_python.x86.dll : msf
meterpreter/ext_server_sniffer.x64.dll : msf
meterpreter/ext_server_sniffer.x86.dll : msf
meterpreter/ext_server_stdapi.jar : msf
meterpreter/ext_server_stdapi.php : msf
meterpreter/ext_server_stdapi.py : msf
meterpreter/ext_server_stdapi.x64.debug.dll : msf
meterpreter/ext_server_stdapi.x64.dll : msf
meterpreter/ext_server_stdapi.x86.debug.dll : msf
meterpreter/ext_server_stdapi.x86.dll : msf
meterpreter/ext_server_unhook.x64.debug.dll : msf
meterpreter/ext_server_unhook.x64.dll : msf
meterpreter/ext_server_unhook.x86.debug.dll : msf
meterpreter/ext_server_unhook.x86.dll : msf
meterpreter/ext_server_winpmem.x64.debug.dll : msf
meterpreter/ext_server_winpmem.x64.dll : msf
meterpreter/ext_server_winpmem.x86.debug.dll : msf
meterpreter/ext_server_winpmem.x86.dll : msf
meterpreter/meterpreter.jar : msf
meterpreter/meterpreter.php : msf
meterpreter/meterpreter.py : msf
meterpreter/metsrv.x64.debug.dll : msf
meterpreter/metsrv.x64.dll : msf
meterpreter/metsrv.x86.debug.dll : msf
meterpreter/metsrv.x86.dll : msf
meterpreter/screenshot.x64.debug.dll : msf
meterpreter/screenshot.x64.dll : msf
meterpreter/screenshot.x86.debug.dll : msf
meterpreter/screenshot.x86.dll : msf
meterpreter/tests/test_ext_server_stdapi.py : msf
```

</details>
