### PR TITLE
Adds support for resolving multiple host ips

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -487,7 +487,7 @@ function resolve_host($hostname, $family) {
         return NULL;
     }
 
-    $addresses = [];
+    $addresses = array();
 
     foreach ($dns as $record) {
         if ($record["type"] == "A") {
@@ -501,7 +501,7 @@ function resolve_host($hostname, $family) {
         array_push($addresses, $binary_address);
     }
 
-    return ['family' => $family, 'addresses' => $addresses];
+    return array('family' => $family, 'addresses' => $addresses);
 }
 }
 
@@ -1319,15 +1319,15 @@ function stdapi_net_config_get_arp_table($req, &$pkt) {
     if ($content === false) {
       return ERROR_FAILURE;
     }
-    $lines = explode(PHP_EOL, $content);             
+    $lines = explode(PHP_EOL, $content);
     array_shift($lines); // first line is the header of the array
-    foreach($lines as $line) { 
-      if ($line == '') continue; 
-      $v = preg_split('/\s+/', $line); 
-      $ip = $v[0]; 
-      $mac = $v[3]; 
-      $iface = $v[5]; 
-      my_print("arp line: $ip $mac $iface"); 
+    foreach($lines as $line) {
+      if ($line == '') continue;
+      $v = preg_split('/\s+/', $line);
+      $ip = $v[0];
+      $mac = $v[3];
+      $iface = $v[5];
+      my_print("arp line: $ip $mac $iface");
       $arp_tlv  = tlv_pack(create_tlv(TLV_TYPE_IP, inet_pton($ip)));
       $arp_tlv .= tlv_pack(create_tlv(TLV_TYPE_MAC_ADDRESS, pack("H*", str_replace(':', '', $mac))));
       $arp_tlv .= tlv_pack(create_tlv(TLV_TYPE_MAC_NAME, $iface));

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -582,7 +582,7 @@ TLV_TYPE_CONNECT_RETRIES       = TLV_META_TYPE_UINT    | 1504
 TLV_TYPE_SHUTDOWN_HOW          = TLV_META_TYPE_UINT    | 1530
 
 # Resolve hosts/host
-TLV_TYPE_RESOLVE_HOST_ENTRY = TLV_META_TYPE_GROUP   | 1550
+TLV_TYPE_RESOLVE_HOST_ENTRY    = TLV_META_TYPE_GROUP   | 1550
 
 ##
 # Railgun
@@ -1087,7 +1087,7 @@ def resolve_host(hostname, family):
         binary_address = inet_pton(family, addr['sockaddr'][0])
         addresses.append(binary_address)
 
-    return { 'family': family, 'address': addresses }
+    return { 'family': family, 'addresses': addresses }
 
 def tlv_pack_local_addrinfo(sock):
     local_host, local_port = sock.getsockname()[:2]
@@ -2683,8 +2683,8 @@ def stdapi_net_resolve_host(request, response):
 
     result = resolve_host(hostname, family)
 
-    host_tlv  = bytes()
-    for ip in result['address']:
+    host_tlv = bytes()
+    for ip in result['addresses']:
         host_tlv +=  tlv_pack(TLV_TYPE_IP, ip)
         host_tlv += tlv_pack(TLV_TYPE_ADDR_TYPE, family)
 
@@ -2708,9 +2708,9 @@ def stdapi_net_resolve_hosts(request, response):
         except socket.error:
             result = {'family':family, 'packed_address':''}
 
-        host_tlv  = bytes()
-        for ip in result['address']:
-            host_tlv +=  tlv_pack(TLV_TYPE_IP, ip)
+        host_tlv = bytes()
+        for ip in result['addresses']:
+            host_tlv += tlv_pack(TLV_TYPE_IP, ip)
             host_tlv += tlv_pack(TLV_TYPE_ADDR_TYPE, family)
 
         response += tlv_pack(TLV_TYPE_RESOLVE_HOST_ENTRY, host_tlv)

--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1087,7 +1087,7 @@ def resolve_host(hostname, family):
         binary_address = inet_pton(family, addr['sockaddr'][0])
         addresses.append(binary_address)
 
-    return [{ 'family': family, 'address': addresses }]
+    return { 'family': family, 'address': addresses }
 
 def tlv_pack_local_addrinfo(sock):
     local_host, local_port = sock.getsockname()[:2]
@@ -2683,12 +2683,10 @@ def stdapi_net_resolve_host(request, response):
 
     result = resolve_host(hostname, family)
 
-    for resolved_host in result:
-        host_tlv  = bytes()
-        for ip in resolved_host['address']:
-            host_tlv +=  tlv_pack(TLV_TYPE_IP, ip)
-            host_tlv += tlv_pack(TLV_TYPE_ADDR_TYPE, family)
-
+    host_tlv  = bytes()
+    for ip in result['address']:
+        host_tlv +=  tlv_pack(TLV_TYPE_IP, ip)
+        host_tlv += tlv_pack(TLV_TYPE_ADDR_TYPE, family)
 
     response += tlv_pack(TLV_TYPE_RESOLVE_HOST_ENTRY, host_tlv)
 
@@ -2709,11 +2707,11 @@ def stdapi_net_resolve_hosts(request, response):
             result = resolve_host(hostname, family)
         except socket.error:
             result = {'family':family, 'packed_address':''}
-        for resolved_host in result:
-            host_tlv  = bytes()
-            for ip in resolved_host['address']:
-                host_tlv +=  tlv_pack(TLV_TYPE_IP, ip)
-                host_tlv += tlv_pack(TLV_TYPE_ADDR_TYPE, family)
+
+        host_tlv  = bytes()
+        for ip in result['address']:
+            host_tlv +=  tlv_pack(TLV_TYPE_IP, ip)
+            host_tlv += tlv_pack(TLV_TYPE_ADDR_TYPE, family)
 
         response += tlv_pack(TLV_TYPE_RESOLVE_HOST_ENTRY, host_tlv)
     return ERROR_SUCCESS, response

--- a/python/meterpreter/tests/test_ext_server_stdapi.py
+++ b/python/meterpreter/tests/test_ext_server_stdapi.py
@@ -321,7 +321,7 @@ class ExtServerStdApiSystemConfigTest(ExtServerStdApiTest):
         self.assertRegex(sid, "S-1-5-.*")
 
 class ExtStdNetResolveTest(ExtServerStdApiTest):
-    def stdapi_net_resolve_hosts(self):
+    def test_stdapi_net_resolve_host(self):
         # Full request from msfconsole
         request = b'\x00\x00\x00\x0c\x00\x02\x00\x01\x00\x00\x04\x00\x00\x00\x00)\x00\x01\x00\x0264769531726942037539492283558475\x00\x00\x00\x00\x13\x00\x01\x05xrapid7.com\x00\x00\x00\x00\x0c\x00\x02\x05\xa4\x00\x00\x00\x02'
         response = bytes()
@@ -329,15 +329,18 @@ class ExtStdNetResolveTest(ExtServerStdApiTest):
             "stdapi_net_resolve_hosts", request, response
         )
 
-        print(response)
+        resolved_hosts = self.meterpreter_context["packet_get_tlv"](
+            result_tlvs, self.ext_server_stdapi["TLV_TYPE_RESOLVE_HOST_ENTRY"]
+        ).get("value")
 
-        # TODO: Assert
-        # user_name = self.meterpreter_context["packet_get_tlv"](
-        #     result_tlvs, self.ext_server_stdapi["TLV_TYPE_USER_NAME"]
-        # ).get("value")
-        #
-        #self.assert(response, bytes('......'))
+        resolved_hosts = self.meterpreter_context["packet_enum_tlvs"](
+            resolved_hosts, self.ext_server_stdapi["TLV_TYPE_IP"]
+        )
 
+        for host in resolved_hosts:
+            ip = socket.inet_ntop(socket.AF_INET, host['value'])
+            # Checks if IP is a valid IP address
+            self.assertTrue(isinstance(socket.inet_aton(ip), bytes))
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/meterpreter/tests/test_ext_server_stdapi.py
+++ b/python/meterpreter/tests/test_ext_server_stdapi.py
@@ -320,6 +320,24 @@ class ExtServerStdApiSystemConfigTest(ExtServerStdApiTest):
         ).get("value")
         self.assertRegex(sid, "S-1-5-.*")
 
+class ExtStdNetResolveTest(ExtServerStdApiTest):
+    def stdapi_net_resolve_hosts(self):
+        # Full request from msfconsole
+        request = b'\x00\x00\x00\x0c\x00\x02\x00\x01\x00\x00\x04\x00\x00\x00\x00)\x00\x01\x00\x0264769531726942037539492283558475\x00\x00\x00\x00\x13\x00\x01\x05xrapid7.com\x00\x00\x00\x00\x0c\x00\x02\x05\xa4\x00\x00\x00\x02'
+        response = bytes()
+        _result_code, result_tlvs = self.assertMethodErrorSuccess(
+            "stdapi_net_resolve_hosts", request, response
+        )
+
+        print(response)
+
+        # TODO: Assert
+        # user_name = self.meterpreter_context["packet_get_tlv"](
+        #     result_tlvs, self.ext_server_stdapi["TLV_TYPE_USER_NAME"]
+        # ).get("value")
+        #
+        #self.assert(response, bytes('......'))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/meterpreter/tests/test_ext_server_stdapi.py
+++ b/python/meterpreter/tests/test_ext_server_stdapi.py
@@ -327,7 +327,7 @@ class ExtStdNetResolveTest(ExtServerStdApiTest):
         request = bytes()
         request += self.meterpreter_context["tlv_pack"](
             self.meterpreter_context["TLV_TYPE_COMMAND_ID"],
-            1024
+            self.meterpreter_context['cmd_string_to_id']('stdapi_net_resolve_host')
         )
 
         request += self.meterpreter_context["tlv_pack"](
@@ -375,7 +375,7 @@ class ExtStdNetResolveTest(ExtServerStdApiTest):
         request = bytes()
         request += self.meterpreter_context["tlv_pack"](
             self.meterpreter_context["TLV_TYPE_COMMAND_ID"],
-            1025
+            self.meterpreter_context['cmd_string_to_id']('stdapi_net_resolve_hosts')
         )
 
         request += self.meterpreter_context["tlv_pack"](


### PR DESCRIPTION
This PR updates the Python and PHP Meterpreter to now support resolving multiple IPs. Previously `resolve_host` and `resolve_hosts` would only resolve a single IP per host. Now they will resolve each IP per host.

This is achieved by now having packing `TLV_TYPE_IP` and `TLV_TYPE_ADDR_TYPE` into a `TLV_META_TYPE_GROUP` TLV called `TLV_TYPE_RESOLVE_HOST_ENTRY`.

To ensure this is backwards compatible, we will be updating the Metasploit-Framework side of things to check for both the now TLV type as well as the old TLVs.

This is part of a larger effort to update all Meterpreter implementations:
Updating other Meterpreter implementations:
- Mettle: https://github.com/rapid7/mettle/pull/254
- Java: https://github.com/rapid7/metasploit-payloads/pull/683
- Windows C: https://github.com/rapid7/metasploit-payloads/pull/684

Metasploit Framework PR:
- https://github.com/rapid7/metasploit-framework/pull/18499