### PR TITLE
Tweak java meterpreter to resolve multiple ips per host

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
@@ -121,6 +121,7 @@ public interface TLVType {
     public static final int TLV_TYPE_CONNECT_RETRIES = TLVPacket.TLV_META_TYPE_UINT   | 1504;
 
     public static final int TLV_TYPE_SHUTDOWN_HOW = TLVPacket.TLV_META_TYPE_UINT | 1530;
+    public static final int TLV_TYPE_RESOLVE_HOST_ENTRY = TLVPacket.TLV_META_TYPE_GROUP | 1550;
 
     // Registry
     public static final int TLV_TYPE_HKEY       = TLVPacket.TLV_META_TYPE_QWORD  | 1000;

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_host.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_host.java
@@ -49,15 +49,17 @@ public class stdapi_net_resolve_host implements Command {
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         String host = request.getStringValue(TLVType.TLV_TYPE_HOST_NAME);
         int family = request.getIntValue(TLVType.TLV_TYPE_ADDR_TYPE);
+        int return_val = ERROR_FAILURE;
         List<InetAddress> inetAddresses = resolve_host(host, family);
         if (inetAddresses != null) {
             TLVPacket addrTLV = new TLVPacket();
+            return_val = ERROR_SUCCESS;
             for(int i = 0; i < inetAddresses.size(); i++){
                 addrTLV.addOverflow(TLVType.TLV_TYPE_IP, inetAddresses.get(i).getAddress());
                 addrTLV.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);
             }
             response.addOverflow(TLVType.TLV_TYPE_RESOLVE_HOST_ENTRY, addrTLV);
         }
-        return ERROR_SUCCESS;
+        return return_val;
     }
 }

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_host.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_host.java
@@ -10,16 +10,17 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import java.util.Vector;
+import java.util.List;
+import java.util.ArrayList;
 
 public class stdapi_net_resolve_host implements Command {
 
     private static final int AF_INET = 2;
     private static final int AF_INET6 = 23;
 
-    public static Vector<InetAddress> resolve_host(String host, int family) {
+    public static List<InetAddress> resolve_host(String host, int family) {
         InetAddress[] inetAddresses;
-        Vector<InetAddress> addressList = new Vector<InetAddress>();
+        List<InetAddress> addressList = new ArrayList<InetAddress>();
         try {
             inetAddresses = InetAddress.getAllByName(host);
         } catch (UnknownHostException e) {
@@ -48,7 +49,7 @@ public class stdapi_net_resolve_host implements Command {
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         String host = request.getStringValue(TLVType.TLV_TYPE_HOST_NAME);
         int family = request.getIntValue(TLVType.TLV_TYPE_ADDR_TYPE);
-        Vector<InetAddress> inetAddresses = resolve_host(host, family);
+        List<InetAddress> inetAddresses = resolve_host(host, family);
         if (inetAddresses != null) {
             TLVPacket addrTLV = new TLVPacket();
             for(int i = 0; i < inetAddresses.size(); i++){

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_host.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_host.java
@@ -10,13 +10,16 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import java.util.Vector;
+
 public class stdapi_net_resolve_host implements Command {
 
     private static final int AF_INET = 2;
     private static final int AF_INET6 = 23;
 
-    public static InetAddress resolve_host(String host, int family) {
+    public static Vector<InetAddress> resolve_host(String host, int family) {
         InetAddress[] inetAddresses;
+        Vector<InetAddress> addressList = new Vector<InetAddress>();
         try {
             inetAddresses = InetAddress.getAllByName(host);
         } catch (UnknownHostException e) {
@@ -25,26 +28,34 @@ public class stdapi_net_resolve_host implements Command {
         for (InetAddress address : inetAddresses) {
             if (family == AF_INET6) {
                 if (address instanceof Inet6Address) {
-                    return address;
+                    addressList.add(address);
                 }
             } else if (family == AF_INET) {
                 if (address instanceof Inet4Address) {
-                    return address;
+                    addressList.add(address);
                 }
             } else {
-                return address;
+                addressList.add(address);
             }
         }
-        return null;
+        if (addressList.isEmpty()) {
+            return null;
+        } else {
+            return addressList;
+        }
     }
 
     public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         String host = request.getStringValue(TLVType.TLV_TYPE_HOST_NAME);
         int family = request.getIntValue(TLVType.TLV_TYPE_ADDR_TYPE);
-        InetAddress inetAddress = resolve_host(host, family);
-        if (inetAddress != null) {
-            response.addOverflow(TLVType.TLV_TYPE_IP, inetAddress.getAddress());
-            response.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);
+        Vector<InetAddress> inetAddresses = resolve_host(host, family);
+        if (inetAddresses != null) {
+            TLVPacket addrTLV = new TLVPacket();
+            for(int i = 0; i < inetAddresses.size(); i++){
+                addrTLV.addOverflow(TLVType.TLV_TYPE_IP, inetAddresses.get(i).getAddress());
+                addrTLV.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);
+            }
+            response.addOverflow(TLVType.TLV_TYPE_RESOLVE_HOST_ENTRY, addrTLV);
         }
         return ERROR_SUCCESS;
     }

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_hosts.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_hosts.java
@@ -7,6 +7,7 @@ import com.metasploit.meterpreter.command.Command;
 
 import java.net.InetAddress;
 import java.util.List;
+import java.util.Vector;
 
 public class stdapi_net_resolve_hosts implements Command {
 
@@ -15,10 +16,15 @@ public class stdapi_net_resolve_hosts implements Command {
         int family = request.getIntValue(TLVType.TLV_TYPE_ADDR_TYPE);
         for (int i=0;i<hosts.size();i++) {
             String host = hosts.get(i);
-            InetAddress inetAddress = stdapi_net_resolve_host.resolve_host(host, family);
-            if (inetAddress != null) {
-                response.addOverflow(TLVType.TLV_TYPE_IP, inetAddress.getAddress());
-                response.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);
+            System.out.println(host);
+            Vector<InetAddress> inetAddresses = stdapi_net_resolve_host.resolve_host(host, family);
+            if (inetAddresses != null) {
+                TLVPacket addrTLV = new TLVPacket();
+                for(int j = 0; j < inetAddresses.size(); j++){
+                    addrTLV.addOverflow(TLVType.TLV_TYPE_IP, inetAddresses.get(j).getAddress());
+                    addrTLV.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);
+                }
+                response.addOverflow(TLVType.TLV_TYPE_RESOLVE_HOST_ENTRY, addrTLV);
             } else {
                 response.addOverflow(TLVType.TLV_TYPE_IP, new byte[0]);
                 response.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_hosts.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_resolve_hosts.java
@@ -7,7 +7,6 @@ import com.metasploit.meterpreter.command.Command;
 
 import java.net.InetAddress;
 import java.util.List;
-import java.util.Vector;
 
 public class stdapi_net_resolve_hosts implements Command {
 
@@ -16,17 +15,17 @@ public class stdapi_net_resolve_hosts implements Command {
         int family = request.getIntValue(TLVType.TLV_TYPE_ADDR_TYPE);
         for (int i=0;i<hosts.size();i++) {
             String host = hosts.get(i);
-            System.out.println(host);
-            Vector<InetAddress> inetAddresses = stdapi_net_resolve_host.resolve_host(host, family);
+            List<InetAddress> inetAddresses = stdapi_net_resolve_host.resolve_host(host, family);
+            TLVPacket addrTLV = new TLVPacket();
             if (inetAddresses != null) {
-                TLVPacket addrTLV = new TLVPacket();
                 for(int j = 0; j < inetAddresses.size(); j++){
                     addrTLV.addOverflow(TLVType.TLV_TYPE_IP, inetAddresses.get(j).getAddress());
                     addrTLV.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);
                 }
                 response.addOverflow(TLVType.TLV_TYPE_RESOLVE_HOST_ENTRY, addrTLV);
             } else {
-                response.addOverflow(TLVType.TLV_TYPE_IP, new byte[0]);
+                addrTLV.addOverflow(TLVType.TLV_TYPE_IP, new byte[0]);
+                response.addOverflow(TLVType.TLV_TYPE_RESOLVE_HOST_ENTRY, addrTLV);
                 response.addOverflow(TLVType.TLV_TYPE_ADDR_TYPE, family);
             }
         }


### PR DESCRIPTION
Follow on to https://github.com/rapid7/metasploit-payloads/pull/681
This PR updates the Java Meterpreter to support resolving multiple IPs per host in the `resolve_host` and `resolve_hosts` functions, rather than just the first IP. 

This must be tested in conjunction with the metasploit-framework branch https://github.com/rapid7/metasploit-framework/pull/18499 