### PR TITLE
Don't listen on IPv6 when 0.0.0.0 srvhost is requested

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/CommandManager.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/CommandManager.java
@@ -30,25 +30,47 @@ public class CommandManager {
         try {
             Class.forName("java.lang.StrictMath");
             apiVersion = ExtensionLoader.V1_3;
+
             Class.forName("java.lang.CharSequence");
             apiVersion = ExtensionLoader.V1_4;
+
             Class.forName("java.net.Proxy");
             apiVersion = ExtensionLoader.V1_5;
+
             Class.forName("java.util.ServiceLoader");
             apiVersion = ExtensionLoader.V1_6;
+
+            Class.forName("java.util.Optional").getMethod("stream");
+            apiVersion = ExtensionLoader.V1_9;
+
+            Class<?> protocolFamilyCls = Class.forName("java.net.ProtocolFamily");
+            Class.forName("java.nio.channels.ServerSocketChannel").getMethod("open", protocolFamilyCls);
+            apiVersion = ExtensionLoader.V1_15;
         } catch (Throwable ignored) {
         }
-        String javaversion = System.getProperty("java.version");
-        if (javaversion != null && javaversion.length() > 2) {
-            int vmVersion = javaversion.charAt(2) - '2' + ExtensionLoader.V1_2;
-            if (vmVersion >= ExtensionLoader.V1_2 && vmVersion < apiVersion) {
-                apiVersion = vmVersion;
-            }
+        int vmVersion = getVersion();
+        if (vmVersion >= ExtensionLoader.V1_2 && vmVersion < apiVersion) {
+            apiVersion = vmVersion;
         }
         this.javaVersion = apiVersion;
 
         // load core commands
         new com.metasploit.meterpreter.core.Loader().load(this);
+    }
+
+    private static int getVersion() {
+        String version = System.getProperty("java.version");
+        // Java version string changed at Java 9 from 1.x.y to just x.y
+        if (version.startsWith("1.")) {
+            version = version.substring(2, 3);
+        } else {
+            int dot = version.indexOf(".");
+            if (dot != -1) {
+                version = version.substring(0, dot);
+            }
+        }
+
+        return Integer.parseInt(version) + ExtensionLoader.V1_base;
     }
 
     /**
@@ -95,7 +117,7 @@ public class CommandManager {
         }
 
         if (version != ExtensionLoader.V1_2) {
-            commandClass = commandClass.getClassLoader().loadClass(commandClass.getName() + "_V1_" + (version - 10));
+            commandClass = commandClass.getClassLoader().loadClass(commandClass.getName() + "_V1_" + (version - ExtensionLoader.V1_base));
         }
 
         Command cmd = (Command) commandClass.newInstance();

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/ExtensionLoader.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/ExtensionLoader.java
@@ -7,12 +7,14 @@ package com.metasploit.meterpreter;
  */
 public interface ExtensionLoader {
 
+    public static final int V1_base = 10;
     public static final int V1_2 = 12;
     public static final int V1_3 = 13;
     public static final int V1_4 = 14;
     public static final int V1_5 = 15;
     public static final int V1_6 = 16;
     public static final int V1_9 = 19;
+    public static final int V1_15 = 25;
 
     /**
      * Load this extension.

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
@@ -40,7 +40,7 @@ public class Loader implements ExtensionLoader {
     }
 
     public void load(CommandManager mgr) throws Exception {
-        mgr.registerCommand(CommandId.CORE_CHANNEL_OPEN, stdapi_channel_open.class);
+        mgr.registerCommand(CommandId.CORE_CHANNEL_OPEN, stdapi_channel_open.class, V1_2, V1_15);
         mgr.registerCommand(CommandId.STDAPI_FS_CHDIR, stdapi_fs_chdir.class);
         mgr.registerCommand(CommandId.STDAPI_FS_DELETE_DIR, stdapi_fs_delete_dir.class);
         mgr.registerCommand(CommandId.STDAPI_FS_DELETE_FILE, stdapi_fs_delete_file.class);

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_channel_open.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_channel_open.java
@@ -1,20 +1,22 @@
 package com.metasploit.meterpreter.stdapi;
 
-import java.net.ConnectException;
-import java.net.DatagramSocket;
-import java.net.InetAddress;
-import java.net.ServerSocket;
-import java.net.Socket;
-
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.UnknownHostException;
 
 import com.metasploit.meterpreter.Channel;
 import com.metasploit.meterpreter.DatagramSocketChannel;
+import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.ServerSocketChannel;
 import com.metasploit.meterpreter.SocketChannel;
-import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.TLVPacket;
 import com.metasploit.meterpreter.TLVType;
 import com.metasploit.meterpreter.command.Command;
@@ -81,18 +83,46 @@ public class stdapi_channel_open implements Command {
         return ERROR_SUCCESS;
     }
 
-    private int executeTcpServer(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+    private int executeTcpServer(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws UnknownHostException, IOException {
         String localHost = request.getStringValue(TLVType.TLV_TYPE_LOCAL_HOST);
         int localPort = request.getIntValue(TLVType.TLV_TYPE_LOCAL_PORT);
-        ServerSocket ss;
-        if (localHost.equals("0.0.0.0")) {
-            ss = new ServerSocket(localPort);
-        } else {
-            ss = new ServerSocket(localPort, 50, InetAddress.getByName(localHost));
-        }
+        ServerSocket ss = getSocket(localHost, localPort);
         Channel channel = new ServerSocketChannel(meterpreter, ss);
         response.add(TLVType.TLV_TYPE_CHANNEL_ID, channel.getID());
         return ERROR_SUCCESS;
+    }
+
+    private ServerSocket getSocket(String localHost, int localPort) throws UnknownHostException, IOException {
+        try {
+            if (localHost.equals("0.0.0.0")) {
+                return getIPv4Socket_java7plus(localHost, localPort);
+            }
+        } catch (UnknownHostException e) {
+            throw e;
+        }
+         catch (Exception e) {
+            // Fall back to old behaviour: will listen on IPv4 and IPv6
+        }
+        return new ServerSocket(localPort, 50, InetAddress.getByName(localHost));
+    }
+
+    // Constructing a ServerSocket directly for 0.0.0.0 will listen on both IPv4 and IPv6, which, if the operator has explicitly requested 0.0.0.0,
+    // may not be desirable. Java 7 and later support explicitly specifying IPv4 using ServerSocketChannel.open(StandardProtocolFamily.INET).
+    // To keep backwards-compatibility, we use reflection to call the newer version.
+    private ServerSocket getIPv4Socket_java7plus(String localHost, int localPort) throws Exception {
+        Class standardProtocolFamilyCls = Class.forName("java.net.StandardProtocolFamily");
+        Class protocolFamilyCls = Class.forName("java.net.ProtocolFamily");
+        java.lang.reflect.Method getValueMethod = standardProtocolFamilyCls.getMethod("valueOf", String.class);
+        Object inet = getValueMethod.invoke(null, "INET");
+        Class sscClazz = java.nio.channels.ServerSocketChannel.class;
+        java.lang.reflect.Method method = sscClazz.getMethod("open", protocolFamilyCls);
+        java.nio.channels.ServerSocketChannel server = (java.nio.channels.ServerSocketChannel)method.invoke(null, inet);
+        InetAddress addr = InetAddress.getByName(localHost);
+        InetSocketAddress sockAddr = new InetSocketAddress(addr, localPort);
+        java.lang.reflect.Method bindMethod = sscClazz.getMethod("bind", java.net.SocketAddress.class);
+        bindMethod.invoke(server, sockAddr);
+        ServerSocket ss = server.socket();
+        return ss;
     }
 
     private int executeTcpClient(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_channel_open_V1_15.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_channel_open_V1_15.java
@@ -13,7 +13,7 @@ import java.net.ServerSocket;
 import java.net.UnknownHostException;
 
 public class stdapi_channel_open_V1_15 extends stdapi_channel_open {
-        
+
     // Constructing a ServerSocket directly for 0.0.0.0 will listen on both IPv4 and IPv6, which, if the operator has explicitly requested 0.0.0.0,
     // may not be desirable. Java 15 and later support explicitly specifying IPv4 using ServerSocketChannel.open(StandardProtocolFamily.INET).
     // To keep backwards-compatibility, we use reflection to call the newer version.

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_channel_open_V1_15.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_channel_open_V1_15.java
@@ -1,0 +1,46 @@
+package com.metasploit.meterpreter.stdapi;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.ConnectException;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.UnknownHostException;
+
+public class stdapi_channel_open_V1_15 extends stdapi_channel_open {
+        
+    // Constructing a ServerSocket directly for 0.0.0.0 will listen on both IPv4 and IPv6, which, if the operator has explicitly requested 0.0.0.0,
+    // may not be desirable. Java 15 and later support explicitly specifying IPv4 using ServerSocketChannel.open(StandardProtocolFamily.INET).
+    // To keep backwards-compatibility, we use reflection to call the newer version.
+    protected ServerSocket getSocket(String localHost, int localPort) throws UnknownHostException, IOException {
+        if (localHost.equals("0.0.0.0")) {
+            try {
+                Class<?> standardProtocolFamilyCls = Class.forName("java.net.StandardProtocolFamily");
+                Class<?> protocolFamilyCls = Class.forName("java.net.ProtocolFamily");
+                java.lang.reflect.Method getValueMethod = standardProtocolFamilyCls.getMethod("valueOf", String.class);
+                Object inet = getValueMethod.invoke(null, "INET");
+                Class<?> sscClazz = java.nio.channels.ServerSocketChannel.class;
+                java.lang.reflect.Method method = sscClazz.getMethod("open", protocolFamilyCls);
+                java.nio.channels.ServerSocketChannel server = (java.nio.channels.ServerSocketChannel)method.invoke(null, inet);
+                InetAddress addr = InetAddress.getByName(localHost);
+                InetSocketAddress sockAddr = new InetSocketAddress(addr, localPort);
+                java.lang.reflect.Method bindMethod = sscClazz.getMethod("bind", java.net.SocketAddress.class);
+                bindMethod.invoke(server, sockAddr);
+                ServerSocket ss = server.socket();
+                return ss;
+            }
+            // If reflection failed for some reason, fall back to the original implementation
+            catch (IllegalAccessException e) {}
+            catch (ClassNotFoundException e) {}
+            catch (NoSuchMethodException e) {}
+            catch (InvocationTargetException e) {}
+        }
+        return super.getSocket(localHost, localPort);
+
+    }
+}


### PR DESCRIPTION
This brings Java meterp in line with other meterps when binding to `0.0.0.0`. Previously, when trying to listen on all IPv4 interfaces, Java meterp would _also_ listen on all IPv6 interfaces. Java's `ServerSocketChannel` class introduced this in Java 15: [see here](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/channels/ServerSocketChannel.html#open(java.net.ProtocolFamily)). Because of back-compat requirements, we can't just call it; otherwise trying to load it in older JVMs will fail. So we use reflection to try to call it, and fall back to the existing behaviour if it fails.

The PR also fixes an issue with the Java version detection, which we leverage to select the right version of the TCP server listening. Previously, the version detection was always capped at Java 6. This would have only affected the `getpid` command, which required Java 9, thus would have never used the "new" version of the code.

## Verification

When performing verification, setting up a reverse port forward will not work (since the interface is ignored for that). Instead, use a capture module such as `auxiliary/server/capture/telnet`, set the `srvhost` to `0.0.0.0`, and use `netstat` to verify.

- [x] Verify that Java > 15 listens on IPv4 only, and the listener works as expected.
- [x] Verify that Java between v6 and 15 inclusive still works as expected (albeit listening on all IPv4 and IPv6 interfaces).
- [x] Verify that the `getpid` command works on pre-Java-9 and Java >= 9