### PR TITLE
Add version detection for newer Windows

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
@@ -556,7 +556,7 @@ DWORD add_windows_os_version(Packet** packet)
 		{
 			if (v.dwMinorVersion == 0)
 			{
-				osName = "Windows 2000";
+				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 2000" : "Windows Server 2000";
 			}
 			else if (v.dwMinorVersion == 1)
 			{
@@ -571,26 +571,34 @@ DWORD add_windows_os_version(Packet** packet)
 		{
 			if (v.dwMinorVersion == 0)
 			{
-				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows Vista" : "Windows 2008";
+				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows Vista" : "Windows Server 2008";
 			}
 			else if (v.dwMinorVersion == 1)
 			{
-				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 7" : "Windows 2008 R2";
+				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 7" : "Windows Server 2008 R2";
 			}
 			else if (v.dwMinorVersion == 2)
 			{
-				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 8" : "Windows 2012";
+				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 8" : "Windows Server 2012";
 			}
 			else if (v.dwMinorVersion == 3)
 			{
-				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 8.1" : "Windows 2012 R2";
+				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 8.1" : "Windows Server 2012 R2";
 			}
 		}
 		else if (v.dwMajorVersion == 10)
 		{
 			if (v.dwMinorVersion == 0)
 			{
-				osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 10" : "Windows 2016+";
+				if (v.dwBuildNumber < 17763) {
+					osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 10" : "Windows Server 2016";
+				} else if (v.dwBuildNumber < 20348) {
+					osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 10" : "Windows Server 2019";
+				} else if (v.dwBuildNumber < 22000) {
+					osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 10" : "Windows Server 2022";
+				} else {
+					osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 11" : "Windows Server 2022";
+				}
 			}
 		}
 


### PR DESCRIPTION
Add version detection by checking the build number for Server 2019, Server 2022 and Windows 11. Server versions also now have the word "Server" in their OS string which more closely resembles the string shown in "System Information" app. The OS Name is typically "Microsoft Windows (?p<version>) (Server)? \d+ (?p<edition>)" if written as a regex. The exception is Windows .NET Server instead of Windows Server 2003 which I've never understood but remains the same. Build numbers were taken [from Metasploit](https://github.com/rapid7/metasploit-framework/blob/c5075ade2ae550a21450196a85b6a69c198175c5/lib/msf/core/windows_version.rb#L7.) to ensure consistency.

Testing:

- [ ] Obtain a Meterpreter session on a Server 2019, Server 2022 or Windows 11 system
- [ ] See the correct OS information in the output of `sysinfo` instead of "Windows 10" (in place of Windows 11) or "Windows 2016+" (in place of Windows Server 2019 or Windows Server 2022)
