### PR TITLE
Fix incorrect Memory Search variable name

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/process/memory.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/process/memory.c
@@ -625,7 +625,7 @@ DWORD request_sys_process_memory_search(Remote* remote, Packet* packet)
 
 						current_buffer_offset += (match_result + match_length);
 					}
-				} while (result != -1);
+				} while (match_result != -1);
 			}
 
 			memory_region_offset += bytes_to_read;


### PR DESCRIPTION
This PR fixes a small mistake introduced by my previous commit, where a variable was being shadowed, but not all occurrences were fixed resulting in a hanging process.

## After
I rebuilt the solution, and ran:
```bash
cp ~/Desktop/Programming/metasploit-payloads/c/meterpreter/output/* /z/meterpreter/ && ~/Desktop/met.exe
```
where `z` is a shared folder pointing to my installation of Metasploit Framework on my host machine, and `met.exe` is a staged Windows payload.

Exploit output:
```ruby
msf6 post(windows/gather/openssh_password_search) > time run pid=6460

[*] Running module against - DESKTOP-NO8VQQB\win10 @ DESKTOP-NO8VQQB (192.168.112.129). This might take a few seconds...
[*] Memory Matches for OpenSSH
==========================

 Match Address       Match Length  Match Buffer                                                                                    Memory Region Start  Memory Region Size
 -------------       ------------  ------------                                                                                    -------------------  ------------------
 0x0000000A00060EE0  127           "publickey,password......3.......myverysecretpassword.9..................#.........#..........  0x0000000A00000000   0x0000000000090000
                                   ...........#.......client-session."

[+] Loot stored to: /Users/sjanusz/.msf4/loot/20240108101436_default_192.168.112.129_openssh.buffer_381191.bin
[*] Post module execution completed
[+] Command "run pid\\=6460" completed in 0.27960299979895353 seconds
```