### PR TITLE
Add the debug files to the copy commands for "make-windows"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,23 @@ install-windows:
 		@echo "Installing Windows payloads"
     ifneq ("$(wildcard c/meterpreter/output/*.x86.dll)","")
 			@cp c/meterpreter/output/*.x86.dll $(METERPDIR) 
+    else
+			@echo "Note: Windows 32-bit Release not built, skipping"
+    endif
+    ifneq ("$(wildcard c/meterpreter/output/*.x86.debug.dll)","")
 			@cp c/meterpreter/output/*.x86.debug.dll $(METERPDIR) 
     else
-			@echo "Note: Windows 32-bit not built, skipping"
+			@echo "Note: Windows 32-bit Debug not built, skipping"
     endif
     ifneq ("$(wildcard c/meterpreter/output/*.x64.dll)","")
 			@cp c/meterpreter/output/*.x64.dll $(METERPDIR) 
+    else
+			@echo "Note: Windows 64-bit Release not built, skipping"
+    endif
+    ifneq ("$(wildcard c/meterpreter/output/*.x64.debug.dll)","")
 			@cp c/meterpreter/output/*.x64.debug.dll $(METERPDIR) 
     else
-			@echo "Note: Windows 64-bit not built, skipping"
+			@echo "Note: Windows 64-bit Debug not built, skipping"
     endif
 
 install-java:

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,13 @@ install-windows:
 		@echo "Installing Windows payloads"
     ifneq ("$(wildcard c/meterpreter/output/*.x86.dll)","")
 			@cp c/meterpreter/output/*.x86.dll $(METERPDIR) 
+			@cp c/meterpreter/output/*.x86.debug.dll $(METERPDIR) 
     else
 			@echo "Note: Windows 32-bit not built, skipping"
     endif
     ifneq ("$(wildcard c/meterpreter/output/*.x64.dll)","")
 			@cp c/meterpreter/output/*.x64.dll $(METERPDIR) 
+			@cp c/meterpreter/output/*.x64.debug.dll $(METERPDIR) 
     else
 			@echo "Note: Windows 64-bit not built, skipping"
     endif


### PR DESCRIPTION
When using the `make install-windows` command last week, I found myself troubleshooting unexpected behavior because `make install-windows` failed to move the debug versions of the files over, and if they're not present, then (as expected) there's no warning that the old debug stuff is used.  This just adds the debug dlls to the list of files copied to the `data/meterpreter` directory of framework.

Testing:
- [ ] Build meterpreter
- [ ] Run make install-windows from the root directory
- [ ] verify the debug dlls were copied correctly to `metasploit-framework/data/meterpreter`