### PR TITLE
GetThreadId/OpenThreadToken not available in kernel32 in Windows XP sp2/sp3 with MingW

### DIFF
--- a/c/meterpreter/source/metsrv/remote_thread.c
+++ b/c/meterpreter/source/metsrv/remote_thread.c
@@ -14,13 +14,6 @@ static PRtlCreateUserThread pRtlCreateUserThread = NULL;
 /*! @brief Indication of whether an attempt to locate the pRtlCreateUserThread pointer has been made. */
 static BOOL pRtlCreateUserThreadAttempted = FALSE;
 
-/*! @brief Function pointer type for the GetThreadId function in kernel32.dll not available in Windows XP SP3 */
-typedef DWORD (WINAPI * PGetThreadId)(HANDLE);
-/*! @brief Reference to the loaded GetThreadId function pointer. */
-static PGetThreadId pGetThreadId = NULL;
-/*! @brief Indication of whether an attempt to locate the pRtlCreateUserThread pointer has been made. */
-static BOOL pGetThreadIdAttempted = FALSE;
-
 /*!
  * @brief Helper function for creating a remote thread in a privileged process.
  * @param hProcess Handle to the target process.
@@ -86,23 +79,7 @@ HANDLE create_remote_thread(HANDLE hProcess, SIZE_T sStackSize, LPVOID pvStartAd
 
 			if (ntResult == 0 && pdwThreadId)
 			{
-				if (!pGetThreadIdAttempted)
-				{
-					if (pGetThreadId == NULL)
-					{
-						pGetThreadId = (PGetThreadId)GetProcAddress(GetModuleHandleA("kernel32"), "GetThreadId");
-						if (pGetThreadId)
-						{
-							dprintf("[REMOTHREAD] GetThreadId found at %p", pGetThreadId);
-						}
-					}
-					pGetThreadIdAttempted = TRUE;
-				}
-
-				if (pGetThreadId != NULL)
-					*pdwThreadId = pGetThreadId(hThread);
-				else
-					*pdwThreadId = 0;
+				*pdwThreadId = GetThreadId(hThread);
 			}
 		}
 		else

--- a/c/meterpreter/source/metsrv/remote_thread.c
+++ b/c/meterpreter/source/metsrv/remote_thread.c
@@ -14,6 +14,13 @@ static PRtlCreateUserThread pRtlCreateUserThread = NULL;
 /*! @brief Indication of whether an attempt to locate the pRtlCreateUserThread pointer has been made. */
 static BOOL pRtlCreateUserThreadAttempted = FALSE;
 
+/*! @brief Function pointer type for the GetThreadId function in kernel32.dll not available in Windows XP SP3 */
+typedef DWORD (WINAPI * PGetThreadId)(HANDLE);
+/*! @brief Reference to the loaded GetThreadId function pointer. */
+static PGetThreadId pGetThreadId = NULL;
+/*! @brief Indication of whether an attempt to locate the pRtlCreateUserThread pointer has been made. */
+static BOOL pGetThreadIdAttempted = FALSE;
+
 /*!
  * @brief Helper function for creating a remote thread in a privileged process.
  * @param hProcess Handle to the target process.
@@ -79,7 +86,23 @@ HANDLE create_remote_thread(HANDLE hProcess, SIZE_T sStackSize, LPVOID pvStartAd
 
 			if (ntResult == 0 && pdwThreadId)
 			{
-				*pdwThreadId = GetThreadId(hThread);
+				if (!pGetThreadIdAttempted)
+				{
+					if (pGetThreadId == NULL)
+					{
+						pGetThreadId = (PGetThreadId)GetProcAddress(GetModuleHandleA("kernel32"), "GetThreadId");
+						if (pGetThreadId)
+						{
+							dprintf("[REMOTHREAD] GetThreadId found at %p", pGetThreadId);
+						}
+					}
+					pGetThreadIdAttempted = TRUE;
+				}
+
+				if (pGetThreadId != NULL)
+					*pdwThreadId = pGetThreadId(hThread);
+				else
+					*pdwThreadId = 0;
 			}
 		}
 		else

--- a/c/meterpreter/source/metsrv/remote_thread.c
+++ b/c/meterpreter/source/metsrv/remote_thread.c
@@ -18,7 +18,7 @@ static BOOL pRtlCreateUserThreadAttempted = FALSE;
 typedef DWORD (WINAPI * PGetThreadId)(HANDLE);
 /*! @brief Reference to the loaded GetThreadId function pointer. */
 static PGetThreadId pGetThreadId = NULL;
-/*! @brief Indication of whether an attempt to locate the pGetThreadId pointer has been made. */
+/*! @brief Indication of whether an attempt to locate the pRtlCreateUserThread pointer has been made. */
 static BOOL pGetThreadIdAttempted = FALSE;
 
 /*!
@@ -93,7 +93,7 @@ HANDLE create_remote_thread(HANDLE hProcess, SIZE_T sStackSize, LPVOID pvStartAd
 						pGetThreadId = (PGetThreadId)GetProcAddress(GetModuleHandleA("kernel32"), "GetThreadId");
 						if (pGetThreadId)
 						{
-							dprintf("[REMOTETHREAD] GetThreadId found at %p", pGetThreadId);
+							dprintf("[REMOTHREAD] GetThreadId found at %p", pGetThreadId);
 						}
 					}
 					pGetThreadIdAttempted = TRUE;

--- a/c/meterpreter/source/metsrv/remote_thread.c
+++ b/c/meterpreter/source/metsrv/remote_thread.c
@@ -18,7 +18,7 @@ static BOOL pRtlCreateUserThreadAttempted = FALSE;
 typedef DWORD (WINAPI * PGetThreadId)(HANDLE);
 /*! @brief Reference to the loaded GetThreadId function pointer. */
 static PGetThreadId pGetThreadId = NULL;
-/*! @brief Indication of whether an attempt to locate the pRtlCreateUserThread pointer has been made. */
+/*! @brief Indication of whether an attempt to locate the pGetThreadId pointer has been made. */
 static BOOL pGetThreadIdAttempted = FALSE;
 
 /*!
@@ -93,7 +93,7 @@ HANDLE create_remote_thread(HANDLE hProcess, SIZE_T sStackSize, LPVOID pvStartAd
 						pGetThreadId = (PGetThreadId)GetProcAddress(GetModuleHandleA("kernel32"), "GetThreadId");
 						if (pGetThreadId)
 						{
-							dprintf("[REMOTHREAD] GetThreadId found at %p", pGetThreadId);
+							dprintf("[REMOTETHREAD] GetThreadId found at %p", pGetThreadId);
 						}
 					}
 					pGetThreadIdAttempted = TRUE;

--- a/c/meterpreter/workspace/ext_server_incognito/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_incognito/CMakeLists.txt
@@ -29,7 +29,7 @@ if(MSVC)
     set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
-set(LINK_LIBS netapi32 mpr)
+set(LINK_LIBS advapi32 netapi32 mpr)
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")

--- a/c/meterpreter/workspace/ext_server_priv/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_priv/CMakeLists.txt
@@ -71,7 +71,7 @@ if(MSVC)
     set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
-set(LINK_LIBS psapi rpcrt4)
+set(LINK_LIBS advapi32 psapi rpcrt4)
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")

--- a/c/meterpreter/workspace/ext_server_stdapi/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi/CMakeLists.txt
@@ -43,6 +43,7 @@ if(MSVC)
 endif()
 
 set(LINK_LIBS
+    advapi32
     jpeg
     mpr
     netapi32

--- a/c/meterpreter/workspace/metsrv/CMakeLists.txt
+++ b/c/meterpreter/workspace/metsrv/CMakeLists.txt
@@ -30,7 +30,7 @@ if(MSVC)
     set_source_files_properties(${MOD_DEF_DIR}/metsrv.def PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
-set(LINK_LIBS winhttp wininet crypt32)
+set(LINK_LIBS advapi32 winhttp wininet crypt32)
 
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")


### PR DESCRIPTION
This patch fixes two issues on Windows XP:

1. GetThreadId not available on Windows XP sp2/sp3 (according to MSDN, it's present only from NT 5.2)
2. OpenThreadToken is present in ADVAPI32.dll as API, but the same API is available in kernel32 in mingw-x86, which doesn't reflect the exported symbol of kernel32 on XP.
