### PR TITLE
Removed GetThreadId and replaced with optional CLIENTID argument

### DIFF
--- a/c/meterpreter/source/metsrv/remote_thread.c
+++ b/c/meterpreter/source/metsrv/remote_thread.c
@@ -80,7 +80,7 @@ HANDLE create_remote_thread(HANDLE hProcess, SIZE_T sStackSize, LPVOID pvStartAd
 
 			if (ntResult == 0 && pdwThreadId)
 			{
-				*pdwThreadId = (DWORD) ClientId.UniqueThread;
+				*pdwThreadId = PtrToUint(ClientId.UniqueThread);
 			}
 		}
 		else

--- a/c/meterpreter/source/metsrv/remote_thread.c
+++ b/c/meterpreter/source/metsrv/remote_thread.c
@@ -39,7 +39,8 @@ HANDLE create_remote_thread(HANDLE hProcess, SIZE_T sStackSize, LPVOID pvStartAd
 	BOOL bCreateSuspended;
 	DWORD dwThreadId;
 	HANDLE hThread;
-	
+	CLIENTID ClientId;
+
 	if (pdwThreadId == NULL)
 	{
 		pdwThreadId = &dwThreadId;
@@ -74,12 +75,12 @@ HANDLE create_remote_thread(HANDLE hProcess, SIZE_T sStackSize, LPVOID pvStartAd
 		{
 			dprintf("[REMOTETHREAD] Attempting thread creation with RtlCreateUserThread");
 			bCreateSuspended = (dwCreateFlags & CREATE_SUSPENDED) == CREATE_SUSPENDED;
-			ntResult = pRtlCreateUserThread(hProcess, NULL, bCreateSuspended, 0, 0, 0, (PTHREAD_START_ROUTINE)pvStartAddress, pvStartParam, &hThread, NULL);
+			ntResult = pRtlCreateUserThread(hProcess, NULL, bCreateSuspended, 0, 0, 0, (PTHREAD_START_ROUTINE)pvStartAddress, pvStartParam, &hThread, &ClientId);
 			SetLastError(ntResult);
 
 			if (ntResult == 0 && pdwThreadId)
 			{
-				*pdwThreadId = GetThreadId(hThread);
+				*pdwThreadId = (DWORD) ClientId.UniqueThread;
 			}
 		}
 		else


### PR DESCRIPTION
As reported in the pull request https://github.com/rapid7/metasploit-payloads/pull/712/ GetThreadId api, used in create_remote_thread function is available only from Windows Vista or Windows Server 2003.
The API function is available in platform sdk, but it doesn't reflect Windows XP SP3.

GetThreadId needs an HANDLE to retrieve the UniqueThread value, and the same information is available calling RtlCreateUserThread with the optional argument CLIENTID.

