### PR TITLE
Use macos 12 runner for python tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-11
+          - macos-12
           - windows-2019
           - ubuntu-20.04
         runtime_version:


### PR DESCRIPTION
The macos-11 runner is no longer available, and as a result the jobs hang indefinitely.
Updating to macos-12 will fix this issue.