### PR TITLE
Fix a regression in the search behavior

### DIFF
--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_search.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_search.java
@@ -64,15 +64,16 @@ public class stdapi_fs_search implements Command {
 
     public static List findFiles(String path, String mask, boolean recurse, Integer startDate, Integer endDate) {
         try {
-            File pathfile = Loader.expand(path);
-            if (!pathfile.exists() || !pathfile.isDirectory()) {
-                pathfile = new File(path);
-                if (!pathfile.exists() || !pathfile.isDirectory()) {
+            File pathFile = Loader.expand(path);
+            if (!pathFile.exists() || !pathFile.isDirectory()) {
+                pathFile = new File(path);
+                if (!pathFile.exists() || !pathFile.isDirectory()) {
                     throw new IOException("Path not found: " + path);
                 }
             }
-            path = pathfile.getCanonicalPath();
-            String[] lst = new File(path).list();
+            path = pathFile.getCanonicalPath();
+            pathFile = new File(path);
+            String[] lst = pathFile.list();
             List glob = new ArrayList();
             if (lst == null) {
                 return glob;
@@ -81,7 +82,7 @@ public class stdapi_fs_search implements Command {
                 if (lst[i] == null) {
                     continue;
                 }
-                File file = new File(lst[i]);
+                File file = new File(pathFile, lst[i]);
                 if (recurse && file.isDirectory()
                         // don't follow links to avoid infinite recursion
                         && file.getCanonicalPath().equals(file.getAbsolutePath())) {


### PR DESCRIPTION
I added a regression in the search behavior in #718. The issue is that because to fix the original problem, I switched from `File.listFiles` to `File.list` so the null values could be filtered out. I then failed to account for the target not being the current working directory when I created the new path object after filtering for NULL values. This new change ensures that when the `File` object is created, it's in relation to the `File` object from which the `File.list` was generated, thus fixing the regression in the search behavior.

## Testing

- [ ] Build and get a session using the new changes
- [ ] Load the test modules by running `loadpath test/modules` in msfconsole (this assumes that the working directory is the repository root)
- [ ] Run the `post/test/search` module and see everything passes