### PR TITLE
Handle Windows oddity in java's process launch library

### DIFF
--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_execute.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_execute.java
@@ -68,8 +68,12 @@ public class stdapi_sys_process_execute implements Command {
     // On Windows, Java quote-escapes _some_ arguments (like those with spaces), but doesn't deal correctly with some
     // edge cases; e.g. empty strings, strings that already have quotes.
     protected String escapeArg(String arg) {
-        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
-            if (arg == "") {
+        if (arg == null) {
+            return null;
+        }
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase().contains("windows")) {
+            if (arg.equals("")) {
                 return "\"\"";
             } else {
                 StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
One test case slipped through the cracks: Java on Windows. This fixes those test failures.

## Verification

- [ ] In MSF, check out the `new_cmd_exec` branch
- [ ] Build the java solution (run `make` when in a directory adjacent to MSF)
- [ ] Create a java payload (`java/meterpreter/reverse_tcp`), and run it on Windows
- [ ] Catch the shell in MSF - validate that it warns that 'ext_server_stdapi.jar is being used`
- [ ] `loadpath test/modules/`
- [ ] `use post/test/cmd_exec`
- [ ] `run` with the captured session
- [ ] Validate that all tests pass