### PR TITLE
Handle discrepancy of process launching on Windows between different versions of Java

### DIFF
--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_execute.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_execute.java
@@ -67,70 +67,83 @@ public class stdapi_sys_process_execute implements Command {
 
     // On Windows, Java quote-escapes _some_ arguments (like those with spaces), but doesn't deal correctly with some
     // edge cases; e.g. empty strings, strings that already have quotes.
-    protected String escapeArg(String arg) {
+    protected String escapeArgWindows(String arg) {
         if (arg == null) {
             return null;
         }
-        String osName = System.getProperty("os.name");
-        if (osName != null && osName.toLowerCase().contains("windows")) {
-            if (arg.equals("")) {
-                return "\"\"";
-            } else {
-                StringBuilder sb = new StringBuilder();
-                int numBackslashes = 0;
-                boolean needsQuoting = false;
-                for (int i = 0; i < arg.length(); i++) {
-                    char c = arg.charAt(i);
-                    switch (c) {
-                        case '"': {
-                            for (int nb = 0; nb < numBackslashes; nb++) {
-                                sb.append('\\');
-                            }
-                            numBackslashes = 0;
-                            sb.append('\\');
-                            break;
-                        }
-                        case '\\': {
-                            numBackslashes++;
-                            break;
-                        }
-                        case ' ':
-                        case '\t':
-                        case (char)11:
-                        {
-                            needsQuoting = true;
-                            numBackslashes = 0;
-                            break;
-                        }
-                        default: {
-                            numBackslashes = 0;
-                            break;
-                        }
-                    }
-                    sb.append(c);
-                }
-                if (needsQuoting) {
-                    for (int nb = 0; nb < numBackslashes; nb++) {
-                        sb.append('\\');
-                    }
-                    return "\"" + sb.toString() + "\"";
-                }
-                return sb.toString();
-            }
-        } else {
-            return arg;
+       if (arg.equals("")) {
+           return "\"\"";
+       } else {
+           StringBuilder sb = new StringBuilder();
+           int numBackslashes = 0;
+           boolean needsQuoting = false;
+           for (int i = 0; i < arg.length(); i++) {
+               char c = arg.charAt(i);
+               switch (c) {
+                   case '"': {
+                       for (int nb = 0; nb < numBackslashes; nb++) {
+                           sb.append('\\');
+                       }
+                       numBackslashes = 0;
+                       sb.append('\\');
+                       break;
+                   }
+                   case '\\': {
+                       numBackslashes++;
+                       break;
+                   }
+                   case ' ':
+                   case '\t':
+                   case (char)11:
+                   {
+                       needsQuoting = true;
+                       numBackslashes = 0;
+                       break;
+                   }
+                   default: {
+                       numBackslashes = 0;
+                       break;
+                   }
+               }
+               sb.append(c);
+           }
+           if (needsQuoting) {
+               for (int nb = 0; nb < numBackslashes; nb++) {
+                   sb.append('\\');
+               }
+               return "\"" + sb.toString() + "\"";
+           }
+           return sb.toString();
         }
     }
 
-    protected Process execute(String cmd, ArrayList<String> args) throws IOException {
-        ArrayList<String> cmdAndArgs = new ArrayList<String>();
-        cmdAndArgs.add(cmd);
-        for (String arg : args) {
-            cmdAndArgs.add(escapeArg(arg));
+    protected Process executeWindows(String cmd, ArrayList<String> args) throws IOException {
+        StringBuilder cmdString = new StringBuilder();
+        cmdString.append(cmd);
+        if (args.size() > 0) {
+            for (String arg : args) {
+                cmdString.append(" ");
+                cmdString.append(escapeArgWindows(arg));
+            }
         }
-        ProcessBuilder builder = new ProcessBuilder(cmdAndArgs);
-        builder.directory(Loader.getCWD());
-        return builder.start();
+
+        return execute(cmdString.toString());
+    }
+
+    protected Process execute(String cmd, ArrayList<String> args) throws IOException {
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase().contains("windows")) {
+            return executeWindows(cmd, args);
+        } else {
+            ArrayList<String> cmdAndArgs = new ArrayList<String>();
+            cmdAndArgs.add(cmd);
+            for (String arg : args) {
+                cmdAndArgs.add(arg);
+            }
+            ProcessBuilder builder = new ProcessBuilder(cmdAndArgs);
+            builder.directory(Loader.getCWD());
+            return builder.start();
+        }
     }
 
     protected Process execute(String cmdstr) throws IOException {


### PR DESCRIPTION
This fixes a test failure when running acceptance tests with Java 8 on Windows.

![image](https://github.com/user-attachments/assets/42e5c180-c5b3-4a91-a024-cd54f9bd7ad0)

At some point in the past, it seems that OpenJDK decided to change the behaviour of `ProcessBuilder` on Windows, to partially-but-not-entirely start doing some argv-like escaping when converting to a Windows command line. 

Seems like it's just better for us to avoid letting Java do any smarts, and just create a command line string that is passed straight to the `CreateProcess` API, which we know has been consistent since the dawn of time.

## Verification

On both older (Java 8? 11?) and newer (tested on Java 16):

- [ ] In MSF, check out the new_cmd_exec branch
- [ ] Build the java solution (run make when in a directory adjacent to MSF)
- [ ] Create a java payload (`java/meterpreter/reverse_tcp`), and run it on Windows
- [ ] Catch the shell in MSF - validate that it warns that `ext_server_stdapi.jar is being used`
- [ ] `loadpath test/modules/`
- [ ] `use post/test/cmd_exec`
- [ ] `run` with the captured session
- [ ] Validate that all tests pass