### PR TITLE
Removes paths from metasploit-framework acceptance tests

### DIFF
--- a/.github/workflows/metasploit-framework-meterpreter_acceptance.yml
+++ b/.github/workflows/metasploit-framework-meterpreter_acceptance.yml
@@ -36,15 +36,6 @@ on:
   pull_request:
     branches:
       - '*'
-    paths:
-      - 'metsploit-framework.gemspec'
-      - 'Gemfile.lock'
-      - 'docker/**'
-      - 'java/**'
-      - 'php/**'
-      - 'powershell/**'
-      - 'python/**'
-      - '.github/**'
 #   Example of running as a cron, to weed out flaky tests
 #  schedule:
 #    - cron: '*/15 * * * *'


### PR DESCRIPTION
Removes `paths` from the metasploit-framework acceptance testing that are not required.

## Verification
- [ ] Code changes are sane
- [ ] CI passes