### PR TITLE
Fix Java Meterpreter Symlink Handling on Windows

### DIFF
--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/CommandManager.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/CommandManager.java
@@ -40,6 +40,12 @@ public class CommandManager {
             Class.forName("java.util.ServiceLoader");
             apiVersion = ExtensionLoader.V1_6;
 
+            Class.forName("java.util.Objects");
+            apiVersion = ExtensionLoader.V1_7;
+
+            Class.forName("java.util.Optional");
+            apiVersion = ExtensionLoader.V1_8;
+
             Class.forName("java.util.Optional").getMethod("stream");
             apiVersion = ExtensionLoader.V1_9;
 

--- a/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/ExtensionLoader.java
+++ b/java/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/ExtensionLoader.java
@@ -13,6 +13,8 @@ public interface ExtensionLoader {
     public static final int V1_4 = 14;
     public static final int V1_5 = 15;
     public static final int V1_6 = 16;
+    public static final int V1_7 = 17;
+    public static final int V1_8 = 18;
     public static final int V1_9 = 19;
     public static final int V1_15 = 25;
 

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/FsUtils.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/FsUtils.java
@@ -1,0 +1,55 @@
+package com.metasploit.meterpreter.stdapi;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+public class FsUtils {
+    public static boolean isSymlink(File file) throws IOException {
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase().contains("windows") && isWindowsSymlink(file)) {
+            return true;
+        }
+
+        File canon;
+        if (file.getParent() == null) {
+            canon = file;
+        } else {
+            File canonDir = file.getParentFile().getCanonicalFile();
+            canon = new File(canonDir, file.getName());
+        }
+
+        return !canon.getCanonicalFile().equals(canon.getAbsoluteFile());
+    }
+
+    private static boolean isWindowsSymlink(File file) {
+        // this uses reflection to access the java.nio.file classes necessary that are available on Java 7+
+        try {
+            // first check using isSymbolicLink
+            Class<?> filesClass = Class.forName("java.nio.file.Files");
+            Class<?> pathClass = Class.forName("java.nio.file.Path");
+
+            Method isSymbolicLinkMethod = filesClass.getMethod("isSymbolicLink", pathClass);
+            Method toPathMethod = File.class.getMethod("toPath");
+
+            Object path = toPathMethod.invoke(file);
+            if ((Boolean)isSymbolicLinkMethod.invoke(null, path)) {
+                return true;
+            }
+
+            // next check if the target is a junction because isSymbolicLink doesn't handle that
+            Class<?> linkOptionClass = Class.forName("java.nio.file.LinkOption");
+            Object linkOptionArray = java.lang.reflect.Array.newInstance(linkOptionClass, 0);
+            Method toRealPath = pathClass.getMethod("toRealPath", linkOptionArray.getClass());
+            Object realPath = toRealPath.invoke(path, linkOptionArray);
+
+            // toRealPath resolves junctions so the result will be different
+            Method equalsMethod = pathClass.getMethod("equals", Object.class);
+            if (!(Boolean)equalsMethod.invoke(path, realPath)) {
+                return true;
+            }
+        } catch (ReflectiveOperationException e) {
+        }
+        return false;
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
@@ -42,7 +42,7 @@ public class Loader implements ExtensionLoader {
     public void load(CommandManager mgr) throws Exception {
         mgr.registerCommand(CommandId.CORE_CHANNEL_OPEN, stdapi_channel_open.class, V1_2, V1_15);
         mgr.registerCommand(CommandId.STDAPI_FS_CHDIR, stdapi_fs_chdir.class);
-        mgr.registerCommand(CommandId.STDAPI_FS_DELETE_DIR, stdapi_fs_delete_dir.class);
+        mgr.registerCommand(CommandId.STDAPI_FS_DELETE_DIR, stdapi_fs_delete_dir.class, V1_2, V1_7);
         mgr.registerCommand(CommandId.STDAPI_FS_DELETE_FILE, stdapi_fs_delete_file.class);
         mgr.registerCommand(CommandId.STDAPI_FS_FILE_EXPAND_PATH, stdapi_fs_file_expand_path.class, V1_2, V1_5); // %COMSPEC% only
         mgr.registerCommand(CommandId.STDAPI_FS_FILE_MOVE, stdapi_fs_file_move.class);

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_delete_dir_V1_7.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_delete_dir_V1_7.java
@@ -7,7 +7,11 @@ import java.nio.file.Files;
 public class stdapi_fs_delete_dir_V1_7 extends stdapi_fs_delete_dir {
     @Override
     protected boolean deleteSymlink(File file) throws IOException {
-        Files.delete(file.toPath());
-        return true;
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase().contains("windows")) {
+            Files.delete(file.toPath());
+            return true;
+        }
+        return file.delete();
     }
 }

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_delete_dir_V1_7.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_delete_dir_V1_7.java
@@ -1,0 +1,13 @@
+package com.metasploit.meterpreter.stdapi;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class stdapi_fs_delete_dir_V1_7 extends stdapi_fs_delete_dir {
+    @Override
+    protected boolean deleteSymlink(File file) throws IOException {
+        Files.delete(file.toPath());
+        return true;
+    }
+}

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_stat.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_stat.java
@@ -24,10 +24,10 @@ public class stdapi_fs_stat implements Command {
             }
         }
         File file = new File(path);
-        if (!file.exists()) {
+        if (!exists(file)) {
             file = Loader.expand(path);
         }
-        if (!file.exists()) {
+        if (!exists(file)) {
             throw new IOException("File/directory does not exist: " + path);
         }
         response.add(TLVType.TLV_TYPE_STAT_BUF, stat(file));
@@ -74,6 +74,10 @@ public class stdapi_fs_stat implements Command {
      */
     protected boolean canExecute(File file) {
         return false;
+    }
+
+    private boolean exists(File file) throws IOException {
+        return file.exists() || FsUtils.isSymlink(file);
     }
 
     /**

--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_execute.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_process_execute.java
@@ -147,7 +147,7 @@ public class stdapi_sys_process_execute implements Command {
     }
 
     protected Process execute(String cmdstr) throws IOException {
-        Process proc = Runtime.getRuntime().exec(cmdstr);
+        Process proc = Runtime.getRuntime().exec(cmdstr, null, Loader.getCWD());
         return proc;
     }
 }

--- a/java/version-compatibility-check/java14/pom.xml
+++ b/java/version-compatibility-check/java14/pom.xml
@@ -27,7 +27,7 @@
 							<target>
 								<mkdir dir="${project.basedir}/target/generated-sources/copy/" />
 								<copy todir="${project.basedir}/target/generated-sources/copy">
-									<fileset dir="${project.basedir}/../java15/target/generated-sources/copy" includes="**/*.java" excludes="**/*_V1_5.java"/>
+									<fileset dir="${project.basedir}/../java15/target/generated-sources/copy" includes="**/*.java" excludes="**/*_V1_5.java" />
 								</copy>
 							</target>
 						</configuration>

--- a/java/version-compatibility-check/java15/pom.xml
+++ b/java/version-compatibility-check/java15/pom.xml
@@ -27,7 +27,7 @@
 							<target>
 								<mkdir dir="${project.basedir}/target/generated-sources/copy/" />
 								<copy todir="${project.basedir}/target/generated-sources/copy">
-									<fileset dir="${project.basedir}/../java16/target/generated-sources/copy" includes="**/*.java" excludes="**/*_V1_6.java"/>
+									<fileset dir="${project.basedir}/../java16/target/generated-sources/copy" includes="**/*.java" excludes="**/*_V1_6.java" />
 								</copy>
 							</target>
 						</configuration>

--- a/java/version-compatibility-check/java16/pom.xml
+++ b/java/version-compatibility-check/java16/pom.xml
@@ -28,10 +28,21 @@
 								<mkdir dir="${project.basedir}/target/generated-sources/copy/" />
 								<copy todir="${project.basedir}/target/generated-sources/copy">
 									<fileset dir="${project.basedir}/../../javapayload/src/main/java" includes="**/*.java" excludes="rmi/**" />
-									<fileset dir="${project.basedir}/../../meterpreter/meterpreter/src/main/java" includes="**/*.java"/>
-									<fileset dir="${project.basedir}/../../meterpreter/shared/src/main/java" includes="**/*.java"/>
-									<!-- Webcam_audio_record_V1_4 depends on Sun proprietary API -->
-									<fileset dir="${project.basedir}/../../meterpreter/meterpreter/target/extension-src" includes="**/*.java" excludes="**/stdapi_webcam_audio_record_V1_4.java" />
+									<fileset dir="${project.basedir}/../../meterpreter/meterpreter/src/main/java" includes="**/*.java" />
+									<fileset dir="${project.basedir}/../../meterpreter/shared/src/main/java" includes="**/*.java" />
+									<fileset dir="${project.basedir}/../../meterpreter/meterpreter/target/extension-src" includes="**/*.java">
+										<!-- stdapi_webcam_audio_record_V1_4 depends on Sun proprietary API -->
+										<exclude name="**/stdapi_webcam_audio_record_V1_4.java" />
+										<scriptselector language="javascript">
+											if (!(new RegExp('_V[0-9]_[0-9]+\.java')).test(filename)) {
+												self.setSelected(true);
+											} else if ((new RegExp('_V1_[0-6]\.java')).test(filename)) {
+												self.setSelected(true);
+											} else {
+												self.setSelected(false);
+											}
+										</scriptselector>
+									</fileset>
 								</copy>
 							</target>
 						</configuration>


### PR DESCRIPTION
This fixes issues in how the Java Meterpreter handles links and junctions when running on Windows. This issue arose when [these](https://github.com/rapid7/metasploit-framework/actions/runs/11632225478/job/32395656705) tests failed due to the new addition of tests in rapid7/metasploit-framework#19554.

Along the way the following additional changes were made:
* An issue with process execution was fixed whereby the subprocess did not have its working directory properly set.
* `pom.xml` compatibility checks for Java 6 were updated to use javascript to select versioned files, so all files lacking a version and marked for version 1-6 are included. This means new versioned files can be added in the future without troubleshooting and updating this `pom.xml`.
* Added version detection for Java 7 and 8.

For testing:

* [ ] Grab the changes from PR 19554.
* [ ] Start a Java Meterpreter session on a Windows host, make sure Java is version 8 or newer. Older versions will still fail and there's not much that can be done about that. Java 8 was [released in 2014](https://en.wikipedia.org/wiki/Java_version_history#Java_SE_8).
* [ ] Run the tests and see them all work