### PR TITLE
Socks5h and socks5 support for python/meterpreter

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -60,13 +60,18 @@ jobs:
           DOCKER_IMAGE: ${{ matrix.docker_image }}
         run: |
           cd python/meterpreter
-          docker run --rm -w $(pwd) -v $(pwd):$(pwd) ${DOCKER_IMAGE} /bin/sh -c 'ls -lah; pip install mock; python -m unittest discover -v ./tests'
+          docker run --rm -w $(pwd) -v $(pwd):$(pwd) ${DOCKER_IMAGE} /bin/sh -c 'ls -lah; pip install mock requests; python -m unittest discover -v ./tests'
 
       - name: Set up Python on host
         if: ${{ !matrix.docker_image }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.runtime_version }}
+          
+      - name: Install dependencies on host
+        if: ${{ !matrix.docker_image }}
+        run: |
+          pip install mock requests
 
       - name: Run tests on host
         if: ${{ !matrix.docker_image }}

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1082,7 +1082,7 @@ class HttpTransport(Transport):
                     if len(packet) != (pkt_length + PACKET_HEADER_SIZE):
                         packet = None
         except requests.RequestException as e:
-            debug_traceback(f"[-] Failure to receive packet from {self.url}: {e}")
+            debug_traceback("[-] Failure to receive packet from " + str(self.url) + ": " + str(e))
 
         if not packet:
             self.communication_last = time.time()

--- a/python/meterpreter/meterpreter.py
+++ b/python/meterpreter/meterpreter.py
@@ -1082,6 +1082,7 @@ class HttpTransport(Transport):
                     if len(packet) != (pkt_length + PACKET_HEADER_SIZE):
                         packet = None
         except requests.RequestException as e:
+            debug_traceback(f"[-] Failure to receive packet from {self.url}: {e}")
 
         if not packet:
             self.communication_last = time.time()


### PR DESCRIPTION
Added requests library to properly use socks5 and socks5h for proxy also supports previous HTTP proxy
proxy format 
socks5://ipadrress:port
socks5h://ipadrress:port ( added this to use DNS through proxy )
http://ipadrress:port
https://ipadrress:port
same thing goes for HttpProxyUser and Pass both HTTP and SOCKS uses same format 

