### PR TITLE
Add more granular support and server 2025 support for versioning

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
@@ -647,38 +647,17 @@ DWORD add_windows_os_version(Packet** packet)
 					}
 				}
 				else {
-					if (v.dwBuildNumber < 16299) {
+					if (v.dwBuildNumber < 17763) {
 						osName = "Windows Server 2016";
 					}
-					else if (v.dwBuildNumber < 17134) {
-						osName = "Windows Server 1709";
-					}
-					else if (v.dwBuildNumber < 17763) {
-						osName = "Windows Server 1803";
-					}
 					else if (v.dwBuildNumber < 18362) {
-						osName = "Windows Server 2019/1809";
-					}
-					else if (v.dwBuildNumber < 18363) {
-						osName = "Windows Server 1903";
-					}
-					else if (v.dwBuildNumber < 19041) {
-						osName = "Windows Server 1909";
-					}
-					else if (v.dwBuildNumber < 19042) {
-						osName = "Windows Server 2004";
-					}
-					else if (v.dwBuildNumber < 20348) {
-						osName = "Windows Server 20H2";
-					}
-					else if (v.dwBuildNumber < 25398) {
-						osName = "Windows Server 21H2";
+						osName = "Windows Server 2019";
 					}
 					else if (v.dwBuildNumber < 26100) {
-						osName = "Windows Server 23H2";
+						osName = "Windows Server 2022";
 					}
 					else {
-						osName = "Windows Server 2025";
+						osName = "Windows Server 2025+";
 					}
 				}
 			}

--- a/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
@@ -595,52 +595,55 @@ DWORD add_windows_os_version(Packet** packet)
 						osName = "Windows 10";
 					}
 					else if (v.dwBuildNumber < 14393) {
-						osName = "Windows 10_1511";
+						osName = "Windows 10 1511";
 					}
 					else if (v.dwBuildNumber < 15063) {
-						osName = "Windows 10_1607";
+						osName = "Windows 10 1607";
 					}
 					else if (v.dwBuildNumber < 16299) {
-						osName = "Windows 10_1703";
+						osName = "Windows 10 1703";
 					}
 					else if (v.dwBuildNumber < 17134) {
-						osName = "Windows 10_1709";
+						osName = "Windows 10 1709";
 					}
 					else if (v.dwBuildNumber < 17763) {
-						osName = "Windows 10_1803";
+						osName = "Windows 10 1803";
 					}
 					else if (v.dwBuildNumber < 18362) {
-						osName = "Windows 10_1809";
+						osName = "Windows 10 1809";
 					}
 					else if (v.dwBuildNumber < 18363) {
-						osName = "Windows 10_1903";
+						osName = "Windows 10 1903";
 					}
 					else if (v.dwBuildNumber < 19041) {
-						osName = "Windows 10_1909";
+						osName = "Windows 10 1909";
 					}
 					else if (v.dwBuildNumber < 19042) {
-						osName = "Windows 10_2004";
+						osName = "Windows 10 2004";
 					}
 					else if (v.dwBuildNumber < 19043) {
-						osName = "Windows 10_20H2";
+						osName = "Windows 10 20H2";
 					}
 					else if (v.dwBuildNumber < 19044) {
-						osName = "Windows 10_21H2";
+						osName = "Windows 10 21H1";
 					}
 					else if (v.dwBuildNumber < 19045) {
-						osName = "Windows 10_22H2";
+						osName = "Windows 10 21H2";
 					}
 					else if (v.dwBuildNumber < 22000) {
-						osName = "Windows 10_22H2+";
+						osName = "Windows 10 22H2+";
 					}
 					else if (v.dwBuildNumber < 22621) {
-						osName = "Windows 11_21H2";
+						osName = "Windows 11 21H2";
 					}
 					else if (v.dwBuildNumber < 22631) {
-						osName = "Windows 11_22H2";
+						osName = "Windows 11 22H2";
+					}
+					else if (v.dwBuildNumber < 26100) {
+						osName = "Windows 11 23H2";
 					}
 					else {
-						osName = "Windows 11_22H2+";
+						osName = "Windows 11 24H2+";
 					}
 				}
 				else {

--- a/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
@@ -590,14 +590,93 @@ DWORD add_windows_os_version(Packet** packet)
 		{
 			if (v.dwMinorVersion == 0)
 			{
-				if (v.dwBuildNumber < 17763) {
-					osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 10" : "Windows Server 2016";
-				} else if (v.dwBuildNumber < 20348) {
-					osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 10" : "Windows Server 2019";
-				} else if (v.dwBuildNumber < 22000) {
-					osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 10" : "Windows Server 2022";
-				} else {
-					osName = v.wProductType == VER_NT_WORKSTATION ? "Windows 11" : "Windows Server 2022";
+				if (v.wProductType == VER_NT_WORKSTATION) {
+					if (v.dwBuildNumber < 10586) {
+						osName = "Windows 10";
+					}
+					else if (v.dwBuildNumber < 14393) {
+						osName = "Windows 10_1511";
+					}
+					else if (v.dwBuildNumber < 15063) {
+						osName = "Windows 10_1607";
+					}
+					else if (v.dwBuildNumber < 16299) {
+						osName = "Windows 10_1703";
+					}
+					else if (v.dwBuildNumber < 17134) {
+						osName = "Windows 10_1709";
+					}
+					else if (v.dwBuildNumber < 17763) {
+						osName = "Windows 10_1803";
+					}
+					else if (v.dwBuildNumber < 18362) {
+						osName = "Windows 10_1809";
+					}
+					else if (v.dwBuildNumber < 18363) {
+						osName = "Windows 10_1903";
+					}
+					else if (v.dwBuildNumber < 19041) {
+						osName = "Windows 10_1909";
+					}
+					else if (v.dwBuildNumber < 19042) {
+						osName = "Windows 10_2004";
+					}
+					else if (v.dwBuildNumber < 19043) {
+						osName = "Windows 10_20H2";
+					}
+					else if (v.dwBuildNumber < 19044) {
+						osName = "Windows 10_21H2";
+					}
+					else if (v.dwBuildNumber < 19045) {
+						osName = "Windows 10_22H2";
+					}
+					else if (v.dwBuildNumber < 22000) {
+						osName = "Windows 10_22H2+";
+					}
+					else if (v.dwBuildNumber < 22621) {
+						osName = "Windows 11_21H2";
+					}
+					else if (v.dwBuildNumber < 22631) {
+						osName = "Windows 11_22H2";
+					}
+					else {
+						osName = "Windows 11_22H2+";
+					}
+				}
+				else {
+					if (v.dwBuildNumber < 16299) {
+						osName = "Windows Server 2016";
+					}
+					else if (v.dwBuildNumber < 17134) {
+						osName = "Windows Server 1709";
+					}
+					else if (v.dwBuildNumber < 17763) {
+						osName = "Windows Server 1803";
+					}
+					else if (v.dwBuildNumber < 18362) {
+						osName = "Windows Server 1809";
+					}
+					else if (v.dwBuildNumber < 18363) {
+						osName = "Windows Server 1903";
+					}
+					else if (v.dwBuildNumber < 19041) {
+						osName = "Windows Server 1909";
+					}
+					else if (v.dwBuildNumber < 19042) {
+						osName = "Windows Server 2004";
+					}
+					else if (v.dwBuildNumber < 20348) {
+						osName = "Windows Server 20H2";
+					}
+					else if (v.dwBuildNumber < 25398) {
+						osName = "Windows Server 21H2";
+					}
+					else if (v.dwBuildNumber < 26100) {
+						osName = "Windows Server 23H2";
+					}
+					else {
+						osName = "Windows Server 2025";
+					}
 				}
 			}
 		}

--- a/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/config/config.c
@@ -657,7 +657,7 @@ DWORD add_windows_os_version(Packet** packet)
 						osName = "Windows Server 1803";
 					}
 					else if (v.dwBuildNumber < 18362) {
-						osName = "Windows Server 1809";
+						osName = "Windows Server 2019/1809";
 					}
 					else if (v.dwBuildNumber < 18363) {
 						osName = "Windows Server 1903";


### PR DESCRIPTION
After checking out the latest build info stuff, it looks like Server 2025 is a bit of a combo breaker in loose parity on build numbers to workstation build numbers.
Rather than keep the original broad Windows 10 vs Windows 11 categories, I went ahead and split the Workstation/Servers and did the builds independently.  I also added the subversion where appropriate.  This results in code I can only apologize for, but it does provide a clear path forward and more granular results.
I'm hoping this does not break anything, as modules should be using the versioning we added recently.
Since Windows Server naming convention is..... imaginative, it might confuse someone when they're given `Windows Server 2004`.  I almost changed this to be `Windows 2016_2004`, but that could also be confusing, as I think Server 1909 technically is a variant of 2016, that's not how it was marketed.
Anyway- I wanted to add Server 2025 support and figured Id throw this out as a conversation piece, too.

```
msf6 payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : WIN2025__B7EC
OS              : Windows Server 2025 (10.0 Build 26100).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows

```

```
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : WIN10_1511_8379
OS              : Windows 10_1511 (10.0 Build 10586).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows

```