### PR TITLE
32-to-64-bit remote thread creation on Windows 10

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/sys/process/thread.c
+++ b/c/meterpreter/source/extensions/stdapi/server/sys/process/thread.c
@@ -116,7 +116,7 @@ DWORD request_sys_process_thread_create(Remote *remote, Packet *packet)
 			dprintf("[THREAD CREATE] Failed to create remote thread");
 			dwResult = GetLastError();
 
-			if (dwResult == ERROR_ACCESS_DENIED
+			if ((dwResult == ERROR_ACCESS_DENIED || dwResult == ERROR_INVALID_HANDLE)
 				&& dwMeterpreterArch == PROCESS_ARCH_X86
 				&& LocalIsWow64Process(GetCurrentProcess())
 				&& !LocalIsWow64Process(hProcess))


### PR DESCRIPTION
On older versions of Windows (tested on Server 2008), calling `CreateRemoteThread` from an x86 to an x64 failed with `ERROR_ACCESS_DENIED`. On newer versions (tested on Windows 10 22H2), it fails with `ERROR_INVALID_HANDLE`. This breaks the fallback behaviour of `request_sys_process_thread_create`, which attempts to detect this situation and use Magic™️ to do the WoW64 transition.

This PR fixes that behaviour by detecting either of these failure statuses.

To verify, on Windows 10:

- [ ] Use [this](https://github.com/rapid7/metasploit-framework/pull/20098) branch of metasploit-framework (or find another module that does a create thread into an arbitrary process - this PR is just what I've been working with, and where I encountered the issue)
- [ ] Obtain an x86 shell
- [ ] Inject (or spawn-and-inject) into an x64 process
- [ ] Verify that it succeeds (fails without this fix)