### PR TITLE
Don't log to an invalid file

### DIFF
--- a/c/meterpreter/source/logging/logging.c
+++ b/c/meterpreter/source/logging/logging.c
@@ -5,13 +5,18 @@ HANDLE lock = NULL;
 HANDLE hFile = NULL;
 
 HANDLE init_logging(wchar_t* filePath) {
-	hFile = CreateFileW(filePath,                // name of the write
+	HANDLE result;
+	result = CreateFileW(filePath,                // name of the write
 		GENERIC_WRITE,          // open for writing
 		FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,    // do share (7)
 		NULL,                   // default security
 		OPEN_ALWAYS,             // create new file or open existing file
 		FILE_ATTRIBUTE_NORMAL,  // normal file
 		NULL);                  // no attr. template
+
+	if (result != INVALID_HANDLE_VALUE) {
+		hFile = result;
+	}
 	lock = CreateMutex(NULL, FALSE, NULL);
 
 	if (hFile == NULL) {


### PR DESCRIPTION
This fixes a bug in the debug logging behaviour in C Meterp on Windows. When `MeterpreterDebugBuild` was set to `true`, but no `MeterpreterDebugLogging` value was set, the call to `init_logging` would fail. A bug existed in the handling of this. The `log_to_file`  method expected the global value `hFile` to be `NULL` when there was no logging; however [CreateFileW](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew#return-value) returns `INVALID_HANDLE_VALUE`. As a result, all future calls to `dprintf` tried to write to an invalid file handle.

This was creating issues when `GetLastError()` was called after `dprintf` - the last error value was polluted. One way of reproducing this is to run the `execute_dotnet_assembly` module (misdiagnosed in #746).

- Run with no debugging stuff should suceed.
- Run with `MeterpreterDebugBuild=true` will fail (`the handle is invalid`).
- Run with `MeterpreterDebugBuild=true` and also `MeterpreterDebugLogging` set to a valid value should succeed.

This resolves the issue by correctly setting `hFile`.

There's probably more work to be done to make sure that any GetLastError is called before any `dprintf`, since theoretically it is possible for that to change `GetLastError` (e.g. failed file write).