### PR TITLE
Move the crypto code into the Python Meterpreter

### DIFF
--- a/python/meterpreter/tests/test_ext_server_stdapi.py
+++ b/python/meterpreter/tests/test_ext_server_stdapi.py
@@ -22,7 +22,7 @@ def create_meterpreter_context():
         # Read and patch out the Meterpreter socket connection logic side effect onwards
         source = file.read()
         source_without_socket_connection = source[
-            0 : source.index(b"# PATCH-SETUP-ENCRYPTION #")
+            0 : source.index(b"_try_to_fork = TRY_TO_FORK")
         ]
 
         context = {}


### PR DESCRIPTION
This ensures that the crypto functionality is present without needing to be patched in by framework. This should also ensure that line numbers are correct for uncaught stack traces that occur early in the init process because multiple lines are no longer being patched in.

Once this is in place, the Framework side of things can have [its code](https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/payload/python/meterpreter_loader.rb#L156-L191) removed because it'll all live here in the payloads directory.

# Testing
Test that a session can be initialized with each of the [supported Python versions:](https://github.com/rapid7/metasploit-framework/blob/f61a321dcd6ed6c635611d6d56912dd5aa81bf30/modules/payloads/stages/python/meterpreter.rb#L14)

- [x] ~Python 2.5~ (skip this, Python 2.5 is broken but it's not due to the changes here)
- [x] Python 2.6
- [x] Python 2.7
- [x] Python 3.1
- [x] Python 3.something newish