### PR TITLE
Fix a SyntaxError in Python 2.5

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1538,8 +1538,8 @@ def stdapi_sys_process_get_info(request, response):
             response += tlv_pack(TLV_TYPE_PROCESS_NAME, module_name)
             response += tlv_pack(TLV_TYPE_PROCESS_PATH, module_filename)
             break
-    except OSError as error:
-        debug_print('[-] method stdapi_sys_process_get_info failed on: ' + str(error))
+    except OSError:
+        debug_print('[-] method stdapi_sys_process_get_info failed')
         return error_result_windows(), response
 
     return ERROR_SUCCESS, response


### PR DESCRIPTION
Found and fixed this error that's preventing the stdapi extension from loading in Python 2.5. It was introduced in commit c2b6d505e408449d8577b82c4da68368f0e85742. Not assigning the exception to a variable for logging fixes it and allows the extension to load.

# Testing
- [x] Load the Python Meterpreter in Python 2.5 and see the session establish
- [x] Run the the `post/test/meterpreter` test suite