### PR TITLE
Java: Send the channel address info back to Metasploit

### DIFF
--- a/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_channel_open.java
+++ b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_channel_open.java
@@ -80,6 +80,8 @@ public class stdapi_channel_open implements Command {
         }
         Channel channel = new DatagramSocketChannel(meterpreter, ds);
         response.add(TLVType.TLV_TYPE_CHANNEL_ID, channel.getID());
+        response.add(TLVType.TLV_TYPE_LOCAL_HOST, ds.getLocalAddress().getHostAddress());
+        response.add(TLVType.TLV_TYPE_LOCAL_PORT, ds.getLocalPort());
         return ERROR_SUCCESS;
     }
 
@@ -89,13 +91,14 @@ public class stdapi_channel_open implements Command {
         ServerSocket ss = getSocket(localHost, localPort);
         Channel channel = new ServerSocketChannel(meterpreter, ss);
         response.add(TLVType.TLV_TYPE_CHANNEL_ID, channel.getID());
+        response.add(TLVType.TLV_TYPE_LOCAL_HOST, ss.getInetAddress().getHostAddress());
+        response.add(TLVType.TLV_TYPE_LOCAL_PORT, ss.getLocalPort());
         return ERROR_SUCCESS;
     }
 
     protected ServerSocket getSocket(String localHost, int localPort) throws UnknownHostException, IOException {
         return new ServerSocket(localPort, 50, InetAddress.getByName(localHost));
     }
-
 
     private int executeTcpClient(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
         String peerHost = request.getStringValue(TLVType.TLV_TYPE_PEER_HOST);
@@ -124,6 +127,8 @@ public class stdapi_channel_open implements Command {
         Channel channel = new SocketChannel(meterpreter, socket);
         channel.startInteract();
         response.add(TLVType.TLV_TYPE_CHANNEL_ID, channel.getID());
+        response.add(TLVType.TLV_TYPE_LOCAL_HOST, socket.getLocalAddress().getHostAddress());
+        response.add(TLVType.TLV_TYPE_LOCAL_PORT, socket.getLocalPort());
         return ERROR_SUCCESS;
     }
 }


### PR DESCRIPTION
The Java Meterpreter has inconsistent behavior in how the socket channels are handled in that it does not send the local address and local port information back to Metasploit. This becomes an issue when Metasploit requests that the OS environment on which the Java Meterpreter is running allocate the port by specifying port 0. When bound to port 0 in any of the three configurations (UDP, TCP client and TCP server), the port should be fetched from the socket and sent back to Metasploit. Metasploit can then use this information for socket communications. At least the Python, Windows and Mettle Meterpreter implementations do this already. I'll test PHP shortly and get a PR to fix it as well if it has the same issue.

## Testing

The easiest way to test this is to use the module from rapid7/metasploit-framework#20689

- [x] Get a Java Meterpreter session
- [x] Run the `post/test/socket_channels` test suite
- [x] See all three "Allows binding to port 0" tests pass
- [x] Know that `[-] FAILED: [UDP] Has the correct peer information` is a separate issue requiring a different fix, ignore it for now

## Demo

```
msf payload(java/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: smcintyre
meterpreter > sysinfo
Computer        : fedora-vm
OS              : Linux 6.17.6-200.fc42.x86_64 (amd64)
Architecture    : x64
System Language : en_US
Meterpreter     : java/linux
meterpreter > run post/test/socket_channels
[*] Running against session 1
[*] Session type is meterpreter and platform is linux
[*] Running TCP client channel tests...
[+] [TCP-Client] Allows binding to port 0
[+] [TCP-Client] Has the correct peer information
[+] [TCP-Client] Receives data from the peer
[+] [TCP-Client] Sends data to the peer
[+] [TCP-Client] Propagates close events to the peer
[+] [TCP-Client] Propagates close events from the peer
[*] Running TCP server channel tests...
[+] [TCP-Server] Allows binding to port 0
[+] [TCP-Server] Accepts a connection
[+] [TCP-Server] Has the correct peer information
[+] [TCP-Server] Receives data from the peer
[+] [TCP-Server] Sends data to the peer
[+] [TCP-Server] Propagates close events to the server
[+] [TCP-Server] Propagates close events to the peer
[+] [TCP-Server] Propagates close events from the peer
[*] Running UDP channel tests...
[+] [UDP] Allows binding to port 0
[-] FAILED: [UDP] Has the correct peer information
[+] [UDP] Receives data from the peer
[+] [UDP] Sends data to the peer
[-] Passed: 17; Failed: 1; Skipped: 0
meterpreter >
```