### PR TITLE
metsrv/pool_party.c: Fix allocation size

### DIFF
--- a/c/meterpreter/source/metsrv/pool_party.c
+++ b/c/meterpreter/source/metsrv/pool_party.c
@@ -15,7 +15,7 @@ NtDll* GetOrInitNtDll() {
 			break;
 		}
 
-		pNtDll = (NtDll*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, sizeof(pNtDll));
+		pNtDll = (NtDll*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, sizeof(*pNtDll));
 		if(!pNtDll) {
 			break;
 		}


### PR DESCRIPTION
This is a classic bug where the size of a pointer is allocated, instead of the size of the underlying structure.