### PR TITLE
[PHP] Treat UDP Channels as Sockets Instead of Streams

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -1507,14 +1507,10 @@ function channel_create_stdapi_net_udp_client($req, &$pkt) {
 
     $peer_host_tlv = packet_get_tlv($req, TLV_TYPE_PEER_HOST);
     $peer_port_tlv = packet_get_tlv($req, TLV_TYPE_PEER_PORT);
+    $local_host_tlv = packet_get_tlv($req, TLV_TYPE_LOCAL_HOST);
+    $local_port_tlv = packet_get_tlv($req, TLV_TYPE_LOCAL_PORT);
 
-    # We can't actually do anything with local_host and local_port because PHP
-    # doesn't let us specify these values in any of the exposed socket API
-    # functions.
-    #$local_host_tlv = packet_get_tlv($req, TLV_TYPE_LOCAL_HOST);
-    #$local_port_tlv = packet_get_tlv($req, TLV_TYPE_LOCAL_PORT);
-
-    $sock = connect($peer_host_tlv['value'], $peer_port_tlv['value'], 'udp');
+    $sock = connect($peer_host_tlv['value'], $peer_port_tlv['value'], 'udp', $local_host_tlv['value'], $local_port_tlv['value']);
     my_print("UDP channel on {$sock}");
 
     if (!$sock) {


### PR DESCRIPTION
Should fix the tests that are intermittenly (though often at least in the case of PHP 5.3.29 on Windows). There were multiple underlying issues that were causing discrepancies in behviors.

1. The localhost / localport wasn't being used for sockets so the socket wasn't  being bound to the address requested by Metasploit. This is still the case for TCP because those sockets are treated as streams and I'm not sure streams can be bound. This should likely be addressed in another ticket but the current tests don't cover this edge case so I'll leave it be.
2. UDP sockets were being treated as streams instead of sockets due to the ordering in `connect`. This seemed to be the core of the issue that was preventing the channel from receiving data.
3. The `socket_sendto` call was wrong. The [per the PHP docs](https://www.php.net/manual/en/function.socket-sendto.php), `$host` argument was being treated as the `flags` argument.

Related to https://github.com/rapid7/metasploit-framework/pull/20729