### PR TITLE
[PHP] Fix UDP sockets for PHP v8

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -1434,8 +1434,8 @@ function channel_create_stdapi_fs_file($req, &$pkt) {
 
 if (!function_exists('packet_add_tlv_local_addrinfo')) {
 function packet_add_tlv_local_addrinfo(&$pkt, $sock) {
-    switch (get_resource_type($sock)) {
-    case 'Socket':
+    switch (get_rtype($sock)) {
+    case 'socket':
         $local_host = '';
         $local_port = 0;
         socket_getsockname($sock, $local_host, $local_port);
@@ -1511,7 +1511,6 @@ function channel_create_stdapi_net_udp_client($req, &$pkt) {
     $local_port_tlv = packet_get_tlv($req, TLV_TYPE_LOCAL_PORT);
 
     $sock = connect($peer_host_tlv['value'], $peer_port_tlv['value'], 'udp', $local_host_tlv['value'], $local_port_tlv['value']);
-    my_print("UDP channel on {$sock}");
 
     if (!$sock) {
         return ERROR_CONNECTION_ERROR;


### PR DESCRIPTION
So in my last PR #786 I fixed UDP channels for PHP 5.3.29 by prioritizing using sockets instead of streams. This then broke things on PHP v8 where sockets are not resources and thus treating them in the same way was causing a whole bunch of issues. This resolves those issues so the socket tests that are intended to pass do pass with both PHP v8.4 on Linux and PHP v5.3 on Winows.

At this point in time, this is a "successful" pass of the socket channel tests:

```
msf post(test/socket_channels) > run
[*] Running against session -1
[*] Session type is meterpreter and platform is windows
[*] Running TCP client channel tests...
[+] [TCP-Client] Allows binding to port 0
[+] [TCP-Client] Has the correct peer information
[+] [TCP-Client] Receives data from the peer
[+] [TCP-Client] Sends data to the peer
[+] [TCP-Client] Propagates close events to the peer
[+] [TCP-Client] Propagates close events from the peer
[*] Running TCP server channel tests...
[-] [[TCP-Server] Allows binding to port 0] FAILED: [TCP-Server] Allows binding to port 0
[-] [[TCP-Server] Allows binding to port 0] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1
[-] [[TCP-Server] Accepts a connection] FAILED: [TCP-Server] Accepts a connection
[-] [[TCP-Server] Accepts a connection] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1
[-] [[TCP-Server] Has the correct peer information] FAILED: [TCP-Server] Has the correct peer information
[-] [[TCP-Server] Has the correct peer information] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1
[-] [[TCP-Server] Receives data from the peer] FAILED: [TCP-Server] Receives data from the peer
[-] [[TCP-Server] Receives data from the peer] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1
[-] [[TCP-Server] Sends data to the peer] FAILED: [TCP-Server] Sends data to the peer
[-] [[TCP-Server] Sends data to the peer] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1
[-] [[TCP-Server] Propagates close events to the server] FAILED: [TCP-Server] Propagates close events to the server
[-] [[TCP-Server] Propagates close events to the server] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1
[-] [[TCP-Server] Propagates close events to the peer] FAILED: [TCP-Server] Propagates close events to the peer
[-] [[TCP-Server] Propagates close events to the peer] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1
[-] [[TCP-Server] Propagates close events from the peer] FAILED: [TCP-Server] Propagates close events from the peer
[-] [[TCP-Server] Propagates close events from the peer] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1
[*] Running UDP channel tests...
[+] [UDP] Allows binding to port 0
[-] FAILED: [UDP] Has the correct peer information
[+] [UDP] Receives data from the peer
[+] [UDP] Sends data to the peer
[-] Passed: 9; Failed: 9; Skipped: 0
[*] Post module execution completed
msf post(test/socket_channels) 
```

Server channels fail because there's no TCP server channel support (see rapid7/metasploit-framework#20748) and the UDP peer address is a rex socket issue.