### PR TITLE
Adds support for nested directories

### DIFF
--- a/c/meterpreter/source/extensions/stdapi/server/fs/fs_local.h
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/fs_local.h
@@ -49,7 +49,7 @@ int fs_ls(const char *directory, fs_ls_cb_t cb, void *arg);
 
 int fs_getwd(char **directory);
 
-int fs_mkdir(const char *directory);
+int fs_mkdir(char *directory);
 
 int fs_move(const char *oldpath, const char *newpath);
 

--- a/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
@@ -367,11 +367,13 @@ int fs_mkdir(char *directory)
 			dir_w = met_api->string.utf8_to_wchar(base_dir);
 			if (dir_w == NULL) {
 				rc = GetLastError();
+				free(dir_w);
 				goto out;
 			}
 
 			if (CreateDirectoryW(dir_w, NULL) == 0) {
 				rc = GetLastError();
+				free(dir_w);
 				goto out;
 			}
 

--- a/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
@@ -358,7 +358,10 @@ int fs_mkdir(char *directory)
 
 	while (dir != NULL)
 	{
-		fs_stat(base_dir, &s);
+		if (fs_stat(base_dir, &s) != ERROR_SUCCESS)
+		{
+			goto out;
+		}
 
 		if (!(s.st_mode & _S_IFDIR)) {
 			dir_w = met_api->string.utf8_to_wchar(base_dir);
@@ -371,17 +374,22 @@ int fs_mkdir(char *directory)
 				rc = GetLastError();
 				goto out;
 			}
+
+			dir_w = NULL;
 		}
 
 		dir = strtok(NULL, "\\");
-		sprintf(base_dir, "%s%s\\", base_dir, dir);
+		if (dir != NULL){
+			sprintf(base_dir, "%s%s\\", base_dir, dir);
+		}
+
 		memset(&s, 0, sizeof(struct meterp_stat));
+		free(dir_w);
 	}
 
 
 out:
 	free(dir_w);
-	free(dir);
 	return rc;
 }
 

--- a/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
@@ -376,8 +376,6 @@ int fs_mkdir(char *directory)
 				free(dir_w);
 				goto out;
 			}
-
-			dir_w = NULL;
 		}
 
 		dir = strtok(NULL, "\\");

--- a/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
@@ -354,7 +354,7 @@ int fs_mkdir(char *directory)
 
 	char* dir = strtok(directory, "\\");
 
-	sprintf(base_dir, "%s\\", dir);
+	sprintf_s(base_dir, 255, "%s\\", dir);
 
 	while (dir != NULL)
 	{
@@ -380,7 +380,7 @@ int fs_mkdir(char *directory)
 
 		dir = strtok(NULL, "\\");
 		if (dir != NULL){
-			sprintf(base_dir, "%s%s\\", base_dir, dir);
+			sprintf_s(base_dir, 255, "%s%s\\", base_dir, dir);
 		}
 
 		memset(&s, 0, sizeof(struct meterp_stat));

--- a/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
@@ -369,6 +369,7 @@ int fs_mkdir(char *directory)
 
 			if (CreateDirectoryW(dir_w, NULL) == 0) {
 				rc = GetLastError();
+				goto out;
 			}
 		}
 

--- a/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
@@ -389,7 +389,6 @@ int fs_mkdir(char *directory)
 
 
 out:
-	free(dir_w);
 	return rc;
 }
 

--- a/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
@@ -353,10 +353,20 @@ int fs_mkdir(char *directory)
 	size_t directory_length;
 	char* base_dir;
 	char* dir;
-	
+		
+	if(directory == NULL){
+		return ERROR_INVALID_PARAMETER;
+	}
+
 	// Add 2 because of NULL character and additional backslash
 	directory_length = lstrlenA(directory)+2;
 	base_dir = (char *)HeapAlloc(GetProcessHeap(), 0, directory_length);
+	
+	if(base_dir == NULL){
+		rc = GetLastError();
+		return rc;
+	}
+
 	dir = strtok(directory, "\\");
 
 	sprintf_s(base_dir, directory_length, "%s\\", dir);

--- a/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
+++ b/c/meterpreter/source/extensions/stdapi/server/fs/fs_win.c
@@ -353,14 +353,22 @@ int fs_mkdir(char *directory)
 	size_t directory_length;
 	char* base_dir;
 	char* dir;
+	HANDLE process_heap = NULL;
 		
 	if(directory == NULL){
 		return ERROR_INVALID_PARAMETER;
 	}
 
+	process_heap =  GetProcessHeap();
+
+	if(process_heap == NULL){
+		rc = GetLastError();
+		return rc;
+	}
+
 	// Add 2 because of NULL character and additional backslash
 	directory_length = lstrlenA(directory)+2;
-	base_dir = (char *)HeapAlloc(GetProcessHeap(), 0, directory_length);
+	base_dir = (char *)HeapAlloc(process_heap, 0, directory_length);
 	
 	if(base_dir == NULL){
 		rc = GetLastError();
@@ -399,7 +407,7 @@ int fs_mkdir(char *directory)
 
 
 out:
-	HeapFree(GetProcessHeap(),0, base_dir);
+	HeapFree(process_heap,0, base_dir);
 	return rc;
 }
 


### PR DESCRIPTION
Fixes [mkdir inconsistency](https://github.com/rapid7/metasploit-framework/issues/20697). This address the inconsistency between mkdir among Meterpreter and other types of sessions. 
