### PR TITLE
Tcp support php meterpreter

### DIFF
--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -1444,6 +1444,9 @@ function packet_add_tlv_local_addrinfo(&$pkt, $sock) {
         break;
     case 'stream':
         $local_name = stream_socket_get_name($sock, false);
+        if (!is_string($local_name)) {
+            return false;
+        }
         if (preg_match('/^\[([^\]]+)\]:(\d+)$/', $local_name, $matches)) {
             // IPv6 with brackets
             packet_add_tlv($pkt, create_tlv(TLV_TYPE_LOCAL_HOST, $matches[1]));
@@ -1521,6 +1524,60 @@ function channel_create_stdapi_net_udp_client($req, &$pkt) {
     #
 
     $id = register_channel($sock);
+    packet_add_tlv($pkt, create_tlv(TLV_TYPE_CHANNEL_ID, $id));
+    packet_add_tlv_local_addrinfo($pkt, $sock);
+    add_reader($sock);
+    return ERROR_SUCCESS;
+}
+}
+
+if (!function_exists('channel_create_stdapi_net_tcp_server')) {
+function channel_create_stdapi_net_tcp_server($req, &$pkt) {
+    my_print("creating tcp server");
+
+    $local_host_tlv = packet_get_tlv($req, TLV_TYPE_LOCAL_HOST);
+    $local_port_tlv = packet_get_tlv($req, TLV_TYPE_LOCAL_PORT);
+
+    $local_host = $local_host_tlv ? $local_host_tlv['value'] : '';
+    $local_port = $local_port_tlv ? $local_port_tlv['value'] : 0;
+    $sock = false;
+
+    if (empty($local_host)) {
+        $local_host = '0.0.0.0';
+    }
+
+    if (can_call_function('stream_socket_server')) {
+        if (strpos($local_host, ':') !== false) {
+            $address = "tcp://[{$local_host}]:{$local_port}";
+        } else {
+            $address = "tcp://{$local_host}:{$local_port}";
+        }
+
+        $sock = @stream_socket_server($address, $errno, $errstr, STREAM_SERVER_BIND | STREAM_SERVER_LISTEN);
+        if ($sock) {
+            stream_set_blocking($sock, 0);
+            register_stream($sock);
+        }
+    } elseif (can_call_function('socket_create')) {
+        $af = (strpos($local_host, ':') !== false) ? AF_INET6 : AF_INET;
+        $sock = @socket_create($af, SOCK_STREAM, SOL_TCP);
+        if ($sock) {
+            @socket_set_option($sock, SOL_SOCKET, SO_REUSEADDR, 1);
+            if (@socket_bind($sock, $local_host, $local_port) && @socket_listen($sock, 128)) {
+                @socket_set_nonblock($sock);
+                register_socket($sock);
+            } else {
+                @socket_close($sock);
+                $sock = false;
+            }
+        }
+    }
+
+    if (!$sock) {
+        return ERROR_CONNECTION_ERROR;
+    }
+
+    $id = register_channel($sock, null, null, 'tcp_server');
     packet_add_tlv($pkt, create_tlv(TLV_TYPE_CHANNEL_ID, $id));
     packet_add_tlv_local_addrinfo($pkt, $sock);
     add_reader($sock);

--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -1538,21 +1538,12 @@ function channel_create_stdapi_net_tcp_server($req, &$pkt) {
     $local_host_tlv = packet_get_tlv($req, TLV_TYPE_LOCAL_HOST);
     $local_port_tlv = packet_get_tlv($req, TLV_TYPE_LOCAL_PORT);
 
-    $local_host = $local_host_tlv ? $local_host_tlv['value'] : '';
+    $local_host = $local_host_tlv && $local_host_tlv['value'] ? $local_host_tlv['value'] : '0.0.0.0';
     $local_port = $local_port_tlv ? $local_port_tlv['value'] : 0;
     $sock = false;
 
-    if (empty($local_host)) {
-        $local_host = '0.0.0.0';
-    }
-
     if (can_call_function('stream_socket_server')) {
-        if (strpos($local_host, ':') !== false) {
-            $address = "tcp://[{$local_host}]:{$local_port}";
-        } else {
-            $address = "tcp://{$local_host}:{$local_port}";
-        }
-
+        $address = "tcp://{$local_host}:{$local_port}";
         $sock = @stream_socket_server($address, $errno, $errstr, STREAM_SERVER_BIND | STREAM_SERVER_LISTEN);
         if ($sock) {
             stream_set_blocking($sock, 0);

--- a/php/meterpreter/ext_server_stdapi.php
+++ b/php/meterpreter/ext_server_stdapi.php
@@ -1543,7 +1543,11 @@ function channel_create_stdapi_net_tcp_server($req, &$pkt) {
     $sock = false;
 
     if (can_call_function('stream_socket_server')) {
-        $address = "tcp://{$local_host}:{$local_port}";
+        if (strpos($local_host, ':') !== false) {
+            $address = "tcp://[{$local_host}]:{$local_port}";
+        } else {
+            $address = "tcp://{$local_host}:{$local_port}";
+        }
         $sock = @stream_socket_server($address, $errno, $errstr, STREAM_SERVER_BIND | STREAM_SERVER_LISTEN);
         if ($sock) {
             stream_set_blocking($sock, 0);


### PR DESCRIPTION
Fixes rapid7/metasploit-framework#20748.

## Summary

Adds TCP server channel support to PHP Meterpreter.


## Testing

Ran `post/test/socket_channels` against a PHP meterpreter session.

- TCP Client: pass
- TCP Server: pass
- UDP: 1 known failure 

## Verification

1. `make install-php`
2. Start `msfconsole`
3. Launch a `php/meterpreter/reverse_tcp` session
4. `loadpath test/modules`
5. Run `post/test/socket_channels` with that session
6. Confirm TCP client/server tests pass and session stays alive
