### PR TITLE
Fix incorrect `Py_XDECREF/Py_DECREF` call on stolen reference after `PyList_SetItem` failure

### DIFF
--- a/c/meterpreter/source/extensions/python/Modules/_localemodule.c
+++ b/c/meterpreter/source/extensions/python/Modules/_localemodule.c
@@ -75,7 +75,6 @@ copy_grouping(char* s)
         if (!val)
             break;
         if (PyList_SetItem(result, i, val)) {
-            Py_DECREF(val);
             val = NULL;
             break;
         }

--- a/c/meterpreter/source/extensions/python/Modules/selectmodule.c
+++ b/c/meterpreter/source/extensions/python/Modules/selectmodule.c
@@ -591,7 +591,6 @@ poll_poll(pollObject *self, PyObject *args)
             }
             PyTuple_SET_ITEM(value, 1, num);
             if ((PyList_SetItem(result_list, j, value)) == -1) {
-                Py_DECREF(value);
                 goto error;
             }
             i++;


### PR DESCRIPTION
Close #799 