### PR TITLE
Reflective Loader Disable Compile Flag

### DIFF
--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -545,13 +545,13 @@ docker-ext-unhook-x64:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-unhook-x64
 
 docker-ext-winpmem:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-winpmem
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-winpmem
 
 docker-ext-winpmem-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-winpmem-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-winpmem-x86
 
 docker-ext-winpmem-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-winpmem-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-winpmem-x64
 
 docker-ext-kiwi:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-kiwi

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -554,13 +554,13 @@ docker-ext-winpmem-x64:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-winpmem-x64
 
 docker-ext-kiwi:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-kiwi
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-kiwi
 
 docker-ext-kiwi-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-kiwi-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-kiwi-x86
 
 docker-ext-kiwi-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-kiwi-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-kiwi-x64
 
 docker-ext-peinjector:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-peinjector

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -572,10 +572,10 @@ docker-ext-peinjector-x64:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-peinjector-x64
 
 docker-ext-bofloader:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-bofloader
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-bofloader
 
 docker-ext-bofloader-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-bofloader-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-bofloader-x86
 
 docker-ext-bofloader-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-bofloader-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-bofloader-x64

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -5,6 +5,10 @@ COMMON_GEN_X86=-DCMAKE_TOOLCHAIN_FILE=../toolsets/i686-w64-mingw32.cmake -DBUILD
 COMMON_GEN_X64=-DCMAKE_TOOLCHAIN_FILE=../toolsets/x86_64-w64-mingw32.cmake -DBUILD_ARCH=x64 ${COMMON_GEN}
 COMMON_BUILD=--config Release
 
+ifdef EXCLUDE_REFLECTIVE_LOADER
+COMMON_GEN += -DEXCLUDE_REFLECTIVE_LOADER=ON
+endif
+
 all: meterpreter
 
 clean: meterpreter-x64-clean meterpreter-x86-clean
@@ -406,13 +410,13 @@ docker-x86:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-x86
 
 docker-metsrv:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-metsrv
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-metsrv
 
 docker-metsrv-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-metsrv-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-metsrv-x86
 
 docker-metsrv-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-metsrv-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-metsrv-x64
 
 docker-ext-stdapi:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -491,13 +491,13 @@ docker-ext-stdapi-webcam-x64:
 	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-webcam-x64
 
 docker-ext-priv:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-priv
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-priv
 
 docker-ext-priv-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-priv-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-priv-x86
 
 docker-ext-priv-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-priv-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-priv-x64
 
 docker-ext-extapi:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-extapi

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -563,13 +563,13 @@ docker-ext-kiwi-x64:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-kiwi-x64
 
 docker-ext-peinjector:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-peinjector
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-peinjector
 
 docker-ext-peinjector-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-peinjector-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-peinjector-x86
 
 docker-ext-peinjector-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-peinjector-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-peinjector-x64
 
 docker-ext-bofloader:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-bofloader

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -509,13 +509,13 @@ docker-ext-extapi-x64:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-extapi-x64
 
 docker-ext-incognito:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-incognito
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-incognito
 
 docker-ext-incognito-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-incognito-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-incognito-x86
 
 docker-ext-incognito-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-incognito-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-incognito-x64
 
 docker-ext-espia:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-espia

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -527,13 +527,13 @@ docker-ext-espia-x64:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-espia-x64
 
 docker-ext-lanattacks:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-lanattacks
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-lanattacks
 
 docker-ext-lanattacks-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-lanattacks-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-lanattacks-x86
 
 docker-ext-lanattacks-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-lanattacks-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-lanattacks-x64
 
 docker-ext-unhook:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-unhook

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -518,13 +518,13 @@ docker-ext-incognito-x64:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-incognito-x64
 
 docker-ext-espia:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-espia
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-espia
 
 docker-ext-espia-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-espia-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-espia-x86
 
 docker-ext-espia-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-espia-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-espia-x64
 
 docker-ext-lanattacks:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-lanattacks

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -377,7 +377,7 @@ meterpreter-ext-bofloader: meterpreter-ext-bofloader-x86 meterpreter-ext-bofload
 meterpreter-ext-bofloader-x86: meterpreter-ext-bofloader-x86-gen meterpreter-ext-bofloader-x86-build
 
 meterpreter-ext-bofloader-x86-gen:
-	@cmake -S workspace -B workspace/build/mingw-x86-ext-bofloader -DBUILD_ALL=OFF -DBUILD_EXT_bofloader=ON $(COMMON_GEN_X86)
+	@cmake -S workspace -B workspace/build/mingw-x86-ext-bofloader -DBUILD_ALL=OFF -DBUILD_EXT_BOFLOADER=ON $(COMMON_GEN_X86)
 
 meterpreter-ext-bofloader-x86-build:
 	@cmake --build workspace/build/mingw-x86-ext-bofloader $(COMMON_BUILD)
@@ -385,7 +385,7 @@ meterpreter-ext-bofloader-x86-build:
 meterpreter-ext-bofloader-x64: meterpreter-ext-bofloader-x64-gen meterpreter-ext-bofloader-x64-build
 
 meterpreter-ext-bofloader-x64-gen:
-	@cmake -S workspace -B workspace/build/mingw-x64-ext-bofloader -DBUILD_ALL=OFF -DBUILD_EXT_bofloader=ON $(COMMON_GEN_X64)
+	@cmake -S workspace -B workspace/build/mingw-x64-ext-bofloader -DBUILD_ALL=OFF -DBUILD_EXT_BOFLOADER=ON $(COMMON_GEN_X64)
 
 meterpreter-ext-bofloader-x64-build:
 	@cmake --build workspace/build/mingw-x64-ext-bofloader $(COMMON_BUILD)

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -536,13 +536,13 @@ docker-ext-lanattacks-x64:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-lanattacks-x64
 
 docker-ext-unhook:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-unhook
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-unhook
 
 docker-ext-unhook-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-unhook-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-unhook-x86
 
 docker-ext-unhook-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-unhook-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-unhook-x64
 
 docker-ext-winpmem:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-winpmem

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -419,76 +419,76 @@ docker-metsrv-x64:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-metsrv-x64
 
 docker-ext-stdapi:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi
 
 docker-ext-stdapi-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-x86
 
 docker-ext-stdapi-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-x64
 
 docker-ext-stdapi-audio:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-audio
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-audio
 
 docker-ext-stdapi-audio-x86:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-audio-x86
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-audio-x86
 
 docker-ext-stdapi-audio-x64:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-audio-x64
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-audio-x64
 
 docker-ext-stdapi-fs:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-fs
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-fs
 
 docker-ext-stdapi-fs-x86:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-fs-x86
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-fs-x86
 
 docker-ext-stdapi-fs-x64:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-fs-x64
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-fs-x64
 
 docker-ext-stdapi-net:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-net
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-net
 
 docker-ext-stdapi-net-x86:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-net-x86
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-net-x86
 
 docker-ext-stdapi-net-x64:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-net-x64
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-net-x64
 
 docker-ext-stdapi-railgun:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-railgun
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-railgun
 
 docker-ext-stdapi-railgun-x86:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-railgun-x86
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-railgun-x86
 
 docker-ext-stdapi-railgun-x64:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-railgun-x64
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-railgun-x64
 
 docker-ext-stdapi-sys:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-sys
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-sys
 
 docker-ext-stdapi-sys-x86:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-sys-x86
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-sys-x86
 
 docker-ext-stdapi-sys-x64:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-sys-x64
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-sys-x64
 
 docker-ext-stdapi-ui:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-ui
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-ui
 
 docker-ext-stdapi-ui-x86:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-ui-x86
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-ui-x86
 
 docker-ext-stdapi-ui-x64:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-ui-x64
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-ui-x64
 
 docker-ext-stdapi-webcam:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-webcam
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-webcam
 
 docker-ext-stdapi-webcam-x86:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-webcam-x86
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-webcam-x86
 
 docker-ext-stdapi-webcam-x64:
-	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-webcam-x64
+	@docker run -u $(ID):$(ID) -it -v ${PWD}:/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-stdapi-webcam-x64
 
 docker-ext-priv:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-priv

--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -500,13 +500,13 @@ docker-ext-priv-x64:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-priv-x64
 
 docker-ext-extapi:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-extapi
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-extapi
 
 docker-ext-extapi-x86:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-extapi-x86
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-extapi-x86
 
 docker-ext-extapi-x64:
-	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-extapi-x64
+	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter -e EXCLUDE_REFLECTIVE_LOADER --rm $(DOCKER_CONTAINER) make meterpreter-ext-extapi-x64
 
 docker-ext-incognito:
 	@docker run -u $(ID):$(ID) -it -v "${PWD}":/meterpreter -w /meterpreter --rm $(DOCKER_CONTAINER) make meterpreter-ext-incognito

--- a/c/meterpreter/source/def/extension_no_rdi.def
+++ b/c/meterpreter/source/def/extension_no_rdi.def
@@ -1,0 +1,6 @@
+NAME extension.dll
+EXPORTS
+        InitServerExtension @2 NONAME PRIVATE
+        DeinitServerExtension @3 NONAME PRIVATE
+        StagelessInit @4 NONAME PRIVATE
+        CommandAdded @5 NONAME PRIVATE

--- a/c/meterpreter/source/extensions/bofloader/bofloader.c
+++ b/c/meterpreter/source/extensions/bofloader/bofloader.c
@@ -12,8 +12,13 @@
 
 // Required so that use of the API works.
 MetApi* met_api = NULL;
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 /*! @brief The enabled commands for this extension. */
 Command customCommands[] =

--- a/c/meterpreter/source/extensions/espia/espia.c
+++ b/c/meterpreter/source/extensions/espia/espia.c
@@ -10,8 +10,13 @@
 // Required so that use of the API works.
 MetApi* met_api = NULL;
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 Command customCommands[] =
 {

--- a/c/meterpreter/source/extensions/extapi/extapi.c
+++ b/c/meterpreter/source/extensions/extapi/extapi.c
@@ -9,8 +9,13 @@
 // Required so that use of the API works.
 MetApi* met_api = NULL;
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 #include "window.h"
 #include "service.h"

--- a/c/meterpreter/source/extensions/incognito/incognito.c
+++ b/c/meterpreter/source/extensions/incognito/incognito.c
@@ -14,8 +14,13 @@
 // Required so that use of the API works.
 MetApi* met_api = NULL;
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 DWORD request_incognito_list_tokens(Remote *remote, Packet *packet);
 DWORD request_incognito_impersonate_user(Remote *remote, Packet *packet);

--- a/c/meterpreter/source/extensions/kiwi/main.c
+++ b/c/meterpreter/source/extensions/kiwi/main.c
@@ -9,8 +9,13 @@
 // Required so that use of the API works.
 MetApi* met_api = NULL;
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 #include "main.h"
 

--- a/c/meterpreter/source/extensions/lanattacks/lanattacks.c
+++ b/c/meterpreter/source/extensions/lanattacks/lanattacks.c
@@ -8,8 +8,13 @@
 // Required so that use of the API works.
 MetApi* met_api = NULL;
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 #include <windows.h>
 #include "lanattacks.h"
 

--- a/c/meterpreter/source/extensions/peinjector/peinjector.c
+++ b/c/meterpreter/source/extensions/peinjector/peinjector.c
@@ -8,8 +8,13 @@
 // Required so that use of the API works.
 MetApi* met_api = NULL;
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 #include "peinjector_bridge.h"
 

--- a/c/meterpreter/source/extensions/powershell/powershell.c
+++ b/c/meterpreter/source/extensions/powershell/powershell.c
@@ -8,8 +8,13 @@
 // Required so that use of the API works.
 MetApi* met_api = NULL;
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 #include "powershell_bridge.h"
 #include "powershell_bindings.h"

--- a/c/meterpreter/source/extensions/priv/priv.c
+++ b/c/meterpreter/source/extensions/priv/priv.c
@@ -7,8 +7,13 @@
 // Required so that use of the API works.
 MetApi* met_api = NULL;
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 /*!
  * @brief `priv` extension dispatch table.

--- a/c/meterpreter/source/extensions/python/python_main.c
+++ b/c/meterpreter/source/extensions/python/python_main.c
@@ -8,9 +8,14 @@
 // Required so that use of the API works.
 MetApi* met_api = NULL;
 
+#ifndef NO_REFLECTIVE_LOADER
 #define REFLECTIVEDLLINJECTION_CUSTOM_DLLMAIN
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 #include "python_commands.h"
 #include "python_meterpreter_binding.h"

--- a/c/meterpreter/source/extensions/sniffer/sniffer.c
+++ b/c/meterpreter/source/extensions/sniffer/sniffer.c
@@ -35,8 +35,13 @@ Command customCommands[] =
 // include the Reflectiveloader() function, we end up linking back to the metsrv.dll's Init function
 // but this doesnt matter as we wont ever call DLL_METASPLOIT_ATTACH as that is only used by the
 // second stage reflective dll inject payload and not the metsrv itself when it loads extensions.
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 #define check_pssdk(); if(!hMgr && pktsdk_initialize()!=0){ met_api->packet.transmit_response(hErr, remote, response);return(hErr); }
 

--- a/c/meterpreter/source/extensions/stdapi/server/stdapi.c
+++ b/c/meterpreter/source/extensions/stdapi/server/stdapi.c
@@ -8,8 +8,13 @@
 // Required so that use of the API works.
 MetApi* met_api = NULL;
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 // NOTE: _CRT_SECURE_NO_WARNINGS has been added to Configuration->C/C++->Preprocessor->Preprocessor
 

--- a/c/meterpreter/source/extensions/unhook/unhook.c
+++ b/c/meterpreter/source/extensions/unhook/unhook.c
@@ -5,8 +5,13 @@
 #include "common.h"
 #include "common_metapi.h"
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 #include "unhook.h"
 #include "refresh.h"

--- a/c/meterpreter/source/extensions/winpmem/winpmem_meterpreter.cpp
+++ b/c/meterpreter/source/extensions/winpmem/winpmem_meterpreter.cpp
@@ -6,8 +6,13 @@ extern "C" {
 #include "common.h"
 #include "common_metapi.h"
 
+#ifndef NO_REFLECTIVE_LOADER
 #define RDIDLL_NOEXPORT
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 
 #ifndef min
 #define min(x,y) ((x)<(y)?(x):(y))

--- a/c/meterpreter/source/metsrv/metsrv.c
+++ b/c/meterpreter/source/metsrv/metsrv.c
@@ -8,9 +8,14 @@
 #define InitAppInstance() { if( hAppInstance == NULL ) hAppInstance = GetModuleHandle( NULL ); }
 
 
+#ifndef NO_REFLECTIVE_LOADER
 #define REFLECTIVEDLLINJECTION_CUSTOM_DLLMAIN
 #define RDIDLL_NOEXPORT
 #include "../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
+#else
+HINSTANCE hAppInstance = NULL;
+#include "../ReflectiveDLLInjection/dll/src/DirectSyscall.c"
+#endif
 #include "../ReflectiveDLLInjection/inject/src/GetProcAddressR.c"
 #include "../ReflectiveDLLInjection/inject/src/LoadLibraryR.c"
 

--- a/c/meterpreter/workspace/CMakeLists.txt
+++ b/c/meterpreter/workspace/CMakeLists.txt
@@ -286,6 +286,8 @@ if(BUILD_METSRV)
     set(MET_SERVERS metsrv)
 endif()
 
+option(EXCLUDE_REFLECTIVE_LOADER "Exclude the reflective loader from metsrv" OFF)
+
 set(MET_RDI_ASM ReflectiveDLLInjection)
 
 set(

--- a/c/meterpreter/workspace/CMakeLists.txt
+++ b/c/meterpreter/workspace/CMakeLists.txt
@@ -286,7 +286,13 @@ if(BUILD_METSRV)
     set(MET_SERVERS metsrv)
 endif()
 
-option(EXCLUDE_REFLECTIVE_LOADER "Exclude the reflective loader from metsrv" OFF)
+option(EXCLUDE_REFLECTIVE_LOADER "Exclude the reflective loader from metsrv and extensions" OFF)
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    set(EXTENSION_DEF_FILE ${MOD_DEF_DIR}/extension_no_rdi.def)
+else()
+    set(EXTENSION_DEF_FILE ${MOD_DEF_DIR}/extension.def)
+endif()
 
 set(MET_RDI_ASM ReflectiveDLLInjection)
 

--- a/c/meterpreter/workspace/ext_server_bofloader/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_bofloader/CMakeLists.txt
@@ -23,7 +23,7 @@ set(SRC_FILES
     ${SRC_DIR}/bofloader.c
     ${SRC_DIR}/COFFLoader/beacon_compatibility.c
     ${SRC_DIR}/COFFLoader/COFFLoader.c
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 
 foreach(srcfile SRC_FILES)
@@ -35,11 +35,15 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_espia/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_espia/CMakeLists.txt
@@ -19,17 +19,21 @@ include_directories(../../source/ReflectiveDLLInjection/common)
 set(SRC_DIR ../../source/extensions/espia)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.c
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS jpeg)
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_extapi/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_extapi/CMakeLists.txt
@@ -20,14 +20,14 @@ set(SRC_DIR ../../source/extensions/extapi)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.c
     ${SRC_DIR}/*.cpp
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -44,6 +44,10 @@ else()
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_incognito/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_incognito/CMakeLists.txt
@@ -20,17 +20,21 @@ include_directories(../../source/ReflectiveDLLInjection/common)
 set(SRC_DIR ../../source/extensions/incognito)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.c
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS advapi32 netapi32 mpr)
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_kiwi/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_kiwi/CMakeLists.txt
@@ -76,7 +76,7 @@ file(GLOB SRC_FILES
     ${SRC_DIR}/mimikatz/mimikatz/modules/sekurlsa/*.c
     ${SRC_DIR}/mimikatz/mimikatz/modules/sekurlsa/crypto/*.c
     ${SRC_DIR}/mimikatz/mimikatz/modules/sekurlsa/packages/*.c
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 
 # Ditch some old stuff that shouldn't even be here in the mimikatz repo!
@@ -85,8 +85,8 @@ list(REMOVE_ITEM SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${SRC_DIR}/mimikatz/mimik
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 if(IS_X86)
@@ -141,6 +141,10 @@ set(LINK_LIBS
 )
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_lanattacks/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_lanattacks/CMakeLists.txt
@@ -22,13 +22,13 @@ set(SRC_DIR ../../source/extensions/lanattacks)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.c
     ${SRC_DIR}/*.cpp
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -38,6 +38,10 @@ set(LINK_LIBS
 )
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 else()

--- a/c/meterpreter/workspace/ext_server_peinjector/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_peinjector/CMakeLists.txt
@@ -20,16 +20,20 @@ include_directories(../../source/ReflectiveDLLInjection/common)
 set(SRC_DIR ../../source/extensions/peinjector)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.c
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_powershell/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_powershell/CMakeLists.txt
@@ -17,15 +17,19 @@ set(SRC_DIR ../../source/extensions/powershell)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.c
     ${SRC_DIR}/*.cpp
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 
 set(LINK_LIBS psapi ws2_32)
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_priv/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_priv/CMakeLists.txt
@@ -60,19 +60,23 @@ set(SRC_DIR ../../source/extensions/priv)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.c
     ${SRC_DIR}/*.rc
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
     ../../source/extensions/kiwi/mimikatz/modules/rpc/kull_m_rpc_ms-rprn.c
     ../../source/extensions/kiwi/mimikatz/modules/rpc/kull_m_rpc_ms-efsr_c.c
 )
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS advapi32 psapi rpcrt4)
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_python/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_python/CMakeLists.txt
@@ -30,7 +30,7 @@ set(SRC_DIR ../../source/extensions/python)
 file(GLOB_RECURSE SRC_FILES
     ${SRC_DIR}/*.c
     ${SRC_DIR}/*.rc
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 
 if(IS_X64)
@@ -40,8 +40,8 @@ endif()
 
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 
 set(LIBRESSL_LIB_DIR ${WORKSPACE_ROOT_DIR}/../deps/libressl/output/${CMAKE_GENERATOR_TOOLSET}/${TARGET_ARCH})
 
@@ -56,6 +56,10 @@ set(LINK_LIBS
 )
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_sniffer/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_sniffer/CMakeLists.txt
@@ -25,12 +25,12 @@ endif()
 set(SRC_DIR ../../source/extensions/sniffer)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.c
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 
 set(PSSDK_LIB_DIR ${PSSDK_DIR}/PSSDK_VC${PSSDK_VER}_LIB/_Libs)
 if(IS_X64)
@@ -39,6 +39,10 @@ endif()
 
 set(LINK_LIBS ${PSSDK_LIB_DIR}/pssdk_vc${PSSDK_VER}_mt.lib ws2_32)
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_stdapi/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi/CMakeLists.txt
@@ -29,7 +29,7 @@ file(GLOB_RECURSE SRC_FILES
     ${SRC_DIR}/*.c
     ${SRC_DIR}/*.cpp
     ${SRC_DIR}/*.rc
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
     ../../source/tiny-regex-c/*.c
 )
 
@@ -39,8 +39,8 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_DEFINITIONS "STDAPI_NAMESPACE_AUDIO;STDAPI_NAMESPACE_FS;STDAPI_NAMESPACE_NET;STDAPI_NAMESPACE_RAILGUN;STDAPI_NAMESPACE_SYS;STDAPI_NAMESPACE_UI;STDAPI_NAMESPACE_WEBCAM")
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -61,6 +61,10 @@ if(MSVC)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 # Post processing (required for all Meterpreter DLLs)
 editbin(${PROJECT_NAME} ${BIN_SUBSYSTEM})
 copyoutput(${PROJECT_NAME} ${BIN_OUTPUT_DIR})

--- a/c/meterpreter/workspace/ext_server_stdapi_audio/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi_audio/CMakeLists.txt
@@ -33,7 +33,7 @@ file(GLOB_RECURSE SRC_FILES
     ${SRC_DIR}/server/general.c
     ${SRC_DIR}/server/stdapi.c
     ${SRC_DIR}/*.rc
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
     ../../source/tiny-regex-c/*.c
 )
 
@@ -43,8 +43,8 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_DEFINITIONS "STDAPI_NAMESPACE_AUDIO;")
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -65,6 +65,10 @@ if(MSVC)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 # Post processing (required for all Meterpreter DLLs)
 editbin(${PROJECT_NAME} ${BIN_SUBSYSTEM})
 copyoutput(${PROJECT_NAME} ${BIN_OUTPUT_DIR})

--- a/c/meterpreter/workspace/ext_server_stdapi_fs/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi_fs/CMakeLists.txt
@@ -33,7 +33,7 @@ file(GLOB_RECURSE SRC_FILES
     ${SRC_DIR}/server/general.c
     ${SRC_DIR}/server/stdapi.c
     ${SRC_DIR}/*.rc
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
     ../../source/tiny-regex-c/*.c
 )
 
@@ -43,8 +43,8 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_DEFINITIONS "STDAPI_NAMESPACE_FS;")
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -65,6 +65,10 @@ if(MSVC)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 # Post processing (required for all Meterpreter DLLs)
 editbin(${PROJECT_NAME} ${BIN_SUBSYSTEM})
 copyoutput(${PROJECT_NAME} ${BIN_OUTPUT_DIR})

--- a/c/meterpreter/workspace/ext_server_stdapi_net/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi_net/CMakeLists.txt
@@ -33,7 +33,7 @@ file(GLOB_RECURSE SRC_FILES
     ${SRC_DIR}/server/general.c
     ${SRC_DIR}/server/stdapi.c
     ${SRC_DIR}/*.rc
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
     ../../source/tiny-regex-c/*.c
 )
 
@@ -43,8 +43,8 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_DEFINITIONS "STDAPI_NAMESPACE_NET;")
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -65,6 +65,10 @@ if(MSVC)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 # Post processing (required for all Meterpreter DLLs)
 editbin(${PROJECT_NAME} ${BIN_SUBSYSTEM})
 copyoutput(${PROJECT_NAME} ${BIN_OUTPUT_DIR})

--- a/c/meterpreter/workspace/ext_server_stdapi_railgun/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi_railgun/CMakeLists.txt
@@ -33,7 +33,7 @@ file(GLOB_RECURSE SRC_FILES
     ${SRC_DIR}/server/general.c
     ${SRC_DIR}/server/stdapi.c
     ${SRC_DIR}/*.rc
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
     ../../source/tiny-regex-c/*.c
 )
 
@@ -43,8 +43,8 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_DEFINITIONS "STDAPI_NAMESPACE_RAILGUN;")
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -65,6 +65,10 @@ if(MSVC)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 # Post processing (required for all Meterpreter DLLs)
 editbin(${PROJECT_NAME} ${BIN_SUBSYSTEM})
 copyoutput(${PROJECT_NAME} ${BIN_OUTPUT_DIR})

--- a/c/meterpreter/workspace/ext_server_stdapi_sys/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi_sys/CMakeLists.txt
@@ -33,7 +33,7 @@ file(GLOB_RECURSE SRC_FILES
     ${SRC_DIR}/server/general.c
     ${SRC_DIR}/server/stdapi.c
     ${SRC_DIR}/*.rc
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
     ../../source/tiny-regex-c/*.c
 )
 
@@ -43,8 +43,8 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_DEFINITIONS "STDAPI_NAMESPACE_SYS;")
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -65,6 +65,10 @@ if(MSVC)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 # Post processing (required for all Meterpreter DLLs)
 editbin(${PROJECT_NAME} ${BIN_SUBSYSTEM})
 copyoutput(${PROJECT_NAME} ${BIN_OUTPUT_DIR})

--- a/c/meterpreter/workspace/ext_server_stdapi_ui/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi_ui/CMakeLists.txt
@@ -37,7 +37,7 @@ file(GLOB_RECURSE SRC_FILES
     ${SRC_DIR}/server/general.c
     ${SRC_DIR}/server/stdapi.c
     ${SRC_DIR}/*.rc
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
     ../../source/tiny-regex-c/*.c
 )
 
@@ -47,8 +47,8 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_DEFINITIONS "STDAPI_NAMESPACE_AUDIO;STDAPI_NAMESPACE_WEBCAM;STDAPI_NAMESPACE_SYS;STDAPI_NAMESPACE_UI;")
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -69,6 +69,10 @@ if(MSVC)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 # Post processing (required for all Meterpreter DLLs)
 editbin(${PROJECT_NAME} ${BIN_SUBSYSTEM})
 copyoutput(${PROJECT_NAME} ${BIN_OUTPUT_DIR})

--- a/c/meterpreter/workspace/ext_server_stdapi_webcam/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_stdapi_webcam/CMakeLists.txt
@@ -36,7 +36,7 @@ file(GLOB_RECURSE SRC_FILES
     ${SRC_DIR}/server/general.c
     ${SRC_DIR}/server/stdapi.c
     ${SRC_DIR}/*.rc
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
     ../../source/tiny-regex-c/*.c
 )
 
@@ -46,8 +46,8 @@ add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_DEFINITIONS "STDAPI_NAMESPACE_AUDIO;STDAPI_NAMESPACE_WEBCAM;STDAPI_NAMESPACE_SYS;")
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -68,6 +68,10 @@ if(MSVC)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 # Post processing (required for all Meterpreter DLLs)
 editbin(${PROJECT_NAME} ${BIN_SUBSYSTEM})
 copyoutput(${PROJECT_NAME} ${BIN_OUTPUT_DIR})

--- a/c/meterpreter/workspace/ext_server_unhook/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_unhook/CMakeLists.txt
@@ -18,16 +18,20 @@ include_directories(../../source/ReflectiveDLLInjection/common)
 set(SRC_DIR ../../source/extensions/unhook)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.c
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/ext_server_winpmem/CMakeLists.txt
+++ b/c/meterpreter/workspace/ext_server_winpmem/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(../../source/ReflectiveDLLInjection/common)
 set(SRC_DIR ../../source/extensions/winpmem)
 file(GLOB SRC_FILES
     ${SRC_DIR}/*.cpp
-    ${MOD_DEF_DIR}/extension.def
+    ${EXTENSION_DEF_FILE}
 )
 
 if(MSVC)
@@ -33,8 +33,8 @@ endif()
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 if(MSVC)
-    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/extension.def\"")
-    set_source_files_properties(${MOD_DEF_DIR}/extension.def PROPERTIES HEADER_FILE_ONLY TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${EXTENSION_DEF_FILE}\"")
+    set_source_files_properties(${EXTENSION_DEF_FILE} PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
 
 set(LINK_LIBS
@@ -44,6 +44,10 @@ set(LINK_LIBS
 )
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 if(MSVC)
     target_link_options(${PROJECT_NAME} PUBLIC "/ignore:4070")
 endif()

--- a/c/meterpreter/workspace/metsrv/CMakeLists.txt
+++ b/c/meterpreter/workspace/metsrv/CMakeLists.txt
@@ -19,10 +19,16 @@ include_directories(../../source/common)
 include_directories(../../source/ReflectiveDLLInjection/common)
 
 set(SRC_DIR ../../source/metsrv)
-file(GLOB SRC_FILES
-    ${SRC_DIR}/*.c
-    ${MOD_DEF_DIR}/metsrv.def
-)
+if(EXCLUDE_REFLECTIVE_LOADER)
+    file(GLOB SRC_FILES
+        ${SRC_DIR}/*.c
+    )
+else()
+    file(GLOB SRC_FILES
+        ${SRC_DIR}/*.c
+        ${MOD_DEF_DIR}/metsrv.def
+    )
+endif()
 add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${TARGET_ARCH})
 if(MSVC)
@@ -39,6 +45,10 @@ else()
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS} ${MET_RDI_ASM})
+
+if(EXCLUDE_REFLECTIVE_LOADER)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE NO_REFLECTIVE_LOADER)
+endif()
 
 # Post processing (required for all Meterpreter DLLs)
 editbin(${PROJECT_NAME} ${BIN_SUBSYSTEM})


### PR DESCRIPTION
This pull request introduces the ability to exclude the Reflective Loader from Meterpreter builds, providing an alternative build path that uses direct syscalls instead. It does this by adding a new `EXCLUDE_REFLECTIVE_LOADER` build option, updating the build system and Docker targets to support this flag, and modifying extension source files to conditionally include either the Reflective Loader or direct syscall code.

```
EXCLUDE_REFLECTIVE_LOADER=1 make docker

or

make docker
```