### PR TITLE
disable mingw useless exports

### DIFF
--- a/c/meterpreter/Makefile
+++ b/c/meterpreter/Makefile
@@ -1,6 +1,6 @@
 ID := $(shell id -u)
 DOCKER_CONTAINER=rapid7/msf-ubuntu-x64-meterpreter:latest
-COMMON_GEN=-Wno-dev -DUSE_STATIC_MSVC_RUNTIMES=ON
+COMMON_GEN=-Wno-dev -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--strip-all,--build-id=none,--no-insert-timestamp,--exclude-all-symbols" -DCMAKE_MODULE_LINKER_FLAGS="-Wl,--strip-all,--build-id=none,--no-insert-timestamp,--exclude-all-symbols" -DUSE_STATIC_MSVC_RUNTIMES=ON
 COMMON_GEN_X86=-DCMAKE_TOOLCHAIN_FILE=../toolsets/i686-w64-mingw32.cmake -DBUILD_ARCH=Win32 ${COMMON_GEN}
 COMMON_GEN_X64=-DCMAKE_TOOLCHAIN_FILE=../toolsets/x86_64-w64-mingw32.cmake -DBUILD_ARCH=x64 ${COMMON_GEN}
 COMMON_BUILD=--config Release

--- a/c/meterpreter/workspace/metsrv/CMakeLists.txt
+++ b/c/meterpreter/workspace/metsrv/CMakeLists.txt
@@ -34,6 +34,10 @@ set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}.${T
 if(MSVC)
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${MOD_DEF_DIR}/metsrv.def\"")
     set_source_files_properties(${MOD_DEF_DIR}/metsrv.def PROPERTIES HEADER_FILE_ONLY TRUE)
+else()
+    # Prevent MinGW from auto-exporting symbols.
+    # With metsrv.def present this yields a single explicit export; without it, zero exports.
+    target_link_options(${PROJECT_NAME} PRIVATE "-Wl,--exclude-all-symbols")
 endif()
 
 set(LINK_LIBS advapi32 winhttp wininet crypt32)


### PR DESCRIPTION
## Before
```
―――――――――――――――――――――――――――
1   0x00009290 0x6c849c90 GLOBAL FUNC 0    server.dll   Ordinal_1
0   0x00000600 0x6c841000 GLOBAL FUNC 0                 pre_c_init
1   0x00000610 0x6c841010 GLOBAL FUNC 0                 _CRT_INIT
2   0x00000800 0x6c841200 GLOBAL FUNC 0                 __DllMainCRTStartup
3   0x00000950 0x6c841350 GLOBAL FUNC 0                 DllMainCRTStartup
4   0x000009a0 0x6c8413a0 GLOBAL FUNC 0                 atexit
5   0x000009b0 0x6c8413b0 GLOBAL FUNC 0                 __gcc_register_frame
6   0x000009c0 0x6c8413c0 GLOBAL FUNC 0                 __gcc_deregister_frame
7   0x000009d0 0x6c8413d0 GLOBAL FUNC 0                 remote_request_core_console_write
8   0x000009e0 0x6c8413e0 GLOBAL FUNC 0                 remote_response_core_console_write
9   0x000009f0 0x6c8413f0 GLOBAL FUNC 0                 register_base_dispatch_routines
10  0x00000b40 0x6c841540 GLOBAL FUNC 0                 deregister_base_dispatch_routines
11  0x00000be0 0x6c8415e0 GLOBAL FUNC 0                 command_register_all
12  0x00000d00 0x6c841700 GLOBAL FUNC 0                 command_register
13  0x00000df0 0x6c8417f0 GLOBAL FUNC 0                 command_deregister_all
14  0x00000e90 0x6c841890 GLOBAL FUNC 0                 command_deregister
15  0x00000f10 0x6c841910 GLOBAL FUNC 0                 command_join_threads
16  0x00000f60 0x6c841960 GLOBAL FUNC 0                 command_locate_extension
17  0x00000f90 0x6c841990 GLOBAL FUNC 0                 command_is_inline
18  0x00000ff0 0x6c8419f0 GLOBAL FUNC 0                 command_validate_arguments
19  0x000010c0 0x6c841ac0 GLOBAL FUNC 0                 command_process_inline
20  0x00001230 0x6c841c30 GLOBAL FUNC 0                 command_handle
21  0x00001360 0x6c841d60 GLOBAL FUNC 0                 command_process_thread
22  0x00001450 0x6c841e50 GLOBAL FUNC 0                 get_migrate_context

```

## After
```
┌──(kali㉿kali)-[~/…/github/metasploit-payloads/c/meterpreter]
└─$ make docker-metsrv-x86
...
┌──(kali㉿kali)-[~/…/github/metasploit-payloads/c/meterpreter]
└─$ rabin2 -s output/metsrv.x86.dll | grep GLOBAL     
1   0x00009050 0x6ad09c50 GLOBAL FUNC 0    server.dll   Ordinal_1
                                                                                           
┌──(kali㉿kali)-[~/…/github/metasploit-payloads/c/meterpreter]
└─$ EXCLUDE_REFLECTIVE_LOADER=1 make docker-metsrv-x86
...
┌──(kali㉿kali)-[~/…/github/metasploit-payloads/c/meterpreter]
└─$ rabin2 -s output/metsrv.x86.dll | grep GLOBAL     
                                                                                           
┌──(kali㉿kali)-[~/…/github/metasploit-payloads/c/meterpreter]
└─$ 

```