### PR TITLE
Add placeholder dockerfile for obfuscation

### DIFF
--- a/docker/Dockerfile.obfuscation
+++ b/docker/Dockerfile.obfuscation
@@ -1,0 +1,3 @@
+# To build the dev environment.
+#  docker build -t rapid7/msf-ubuntu-x64-meterpreter-obfuscation -f ./Dockerfile.obfuscation .
+FROM ubuntu:24.04


### PR DESCRIPTION
Add a placeholder dockerfile which can be used for obfuscation; with the plan to have it pushed up to: https://hub.docker.com/r/rapid7/msf-ubuntu-x64-meterpreter-obfuscation